### PR TITLE
feat: implement scheduled broadcast system (#89)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+
 import { BadgesModule } from './badges/badges.module';
 import { InternetSpeedModule } from './internet-speed/internet-speed.module';
 import { LibraryService } from './library/library.service';
@@ -8,17 +9,19 @@ import { LibraryModule } from './library/library-module.module';
 import { BusinessesModule } from './businesses/businesses.module';
 import { PollsModule } from './polls/polls.module';
 import { LeaveModule } from './leave/leave.module';
-
 import { InternalNotesModule } from './internal-notes/internal-notes.module';
 import { SystemStatsModule } from './system-stats/system-stats.module';
-
 import { ServiceVendorVisitModule } from './service-vendor-visit/service-vendor-visit.module';
-
 import { BackupsModule } from './backups/backups.module';
 import { EnvironmentMonitorModule } from './environment-monitor/environment-monitor.module';
+import { BroadcastModule } from './broadcast/broadcast.module';
+
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
+
     BadgesModule,
     InternetSpeedModule,
     LibraryModule,
@@ -30,6 +33,7 @@ import { EnvironmentMonitorModule } from './environment-monitor/environment-moni
     ServiceVendorVisitModule,
     BackupsModule,
     EnvironmentMonitorModule,
+    BroadcastModule,
   ],
   controllers: [AppController],
   providers: [AppService, LibraryService],

--- a/backend/src/broadcast/broadcast.controller.ts
+++ b/backend/src/broadcast/broadcast.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Post, Body, Get, Param, Patch } from '@nestjs/common';
+import { BroadcastService } from './broadcast.service';
+import { CreateBroadcastDto } from './dto/create-broadcast.dto';
+import { UpdateBroadcastDto } from './dto/update-broadcast.dto';
+
+@Controller('broadcasts')
+export class BroadcastController {
+  constructor(private readonly broadcastService: BroadcastService) {}
+
+  @Post()
+  create(@Body() dto: CreateBroadcastDto) {
+    return this.broadcastService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.broadcastService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.broadcastService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateBroadcastDto) {
+    return this.broadcastService.update(id, dto);
+  }
+}

--- a/backend/src/broadcast/broadcast.module.ts
+++ b/backend/src/broadcast/broadcast.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Broadcast } from './entities/broadcast.entity';
+import { BroadcastService } from './broadcast.service';
+import { BroadcastController } from './broadcast.controller';
+
+import { BroadcastSchedulerService } from './scheduler/broadcast-scheduler.service';
+
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Broadcast])],
+  controllers: [BroadcastController],
+  providers: [BroadcastService, BroadcastSchedulerService],
+  exports: [BroadcastService],
+})
+export class BroadcastModule {}

--- a/backend/src/broadcast/broadcast.service.ts
+++ b/backend/src/broadcast/broadcast.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Broadcast } from './entities/broadcast.entity';
+import { CreateBroadcastDto } from './dto/create-broadcast.dto';
+import { UpdateBroadcastDto } from './dto/update-broadcast.dto';
+import { LessThanOrEqual } from 'typeorm';
+
+
+@Injectable()
+export class BroadcastService {
+  constructor(
+    @InjectRepository(Broadcast)
+    private readonly broadcastRepository: Repository<Broadcast>,
+  ) {}
+
+  async create(dto: CreateBroadcastDto): Promise<Broadcast> {
+    const broadcast = this.broadcastRepository.create(dto);
+    return this.broadcastRepository.save(broadcast);
+  }
+
+  async findAll(): Promise<Broadcast[]> {
+    return this.broadcastRepository.find({
+      order: { scheduledAt: 'ASC' },
+    });
+  }
+
+  async findOne(id: string): Promise<Broadcast> {
+    const broadcast = await this.broadcastRepository.findOne({ where: { id } });
+    if (!broadcast) throw new NotFoundException(`Broadcast ${id} not found`);
+    return broadcast;
+  }
+
+  async update(id: string, dto: UpdateBroadcastDto): Promise<Broadcast> {
+    const broadcast = await this.findOne(id);
+    Object.assign(broadcast, dto);
+    return this.broadcastRepository.save(broadcast);
+  }
+
+  async findPendingBroadcasts(currentTime: Date): Promise<Broadcast[]> {
+  return this.broadcastRepository.find({
+    where: {
+      isPublished: false,
+      scheduledAt: LessThanOrEqual(currentTime),
+    },
+  });
+}
+
+async save(broadcast: Broadcast): Promise<Broadcast> {
+  return this.broadcastRepository.save(broadcast);
+}
+}
+
+

--- a/backend/src/broadcast/dto/create-broadcast.dto.ts
+++ b/backend/src/broadcast/dto/create-broadcast.dto.ts
@@ -1,0 +1,16 @@
+import { IsString, IsNotEmpty, IsDateString, MaxLength } from 'class-validator';
+
+export class CreateBroadcastDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  title: string;
+
+  @IsString()
+  @IsNotEmpty()
+  message: string;
+
+  @IsDateString()
+  @IsNotEmpty()
+  scheduledAt: string; // ISO 8601 format
+}

--- a/backend/src/broadcast/dto/update-broadcast.dto.ts
+++ b/backend/src/broadcast/dto/update-broadcast.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateBroadcastDto } from './create-broadcast.dto';
+
+export class UpdateBroadcastDto extends PartialType(CreateBroadcastDto) {}

--- a/backend/src/broadcast/entities/broadcast.entity.ts
+++ b/backend/src/broadcast/entities/broadcast.entity.ts
@@ -1,0 +1,25 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('broadcasts')
+export class Broadcast {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ length: 255 })
+  title: string;
+
+  @Column({ type: 'text' })
+  message: string;
+
+  @Column({ type: 'timestamp with time zone' })
+  scheduledAt: Date;
+
+  @Column({ default: false })
+  isPublished: boolean;
+
+  @CreateDateColumn({ type: 'timestamp with time zone' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp with time zone' })
+  updatedAt: Date;
+}

--- a/backend/src/broadcast/scheduler/broadcast-scheduler.service.ts
+++ b/backend/src/broadcast/scheduler/broadcast-scheduler.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { BroadcastService } from '../broadcast.service';
+
+@Injectable()
+export class BroadcastSchedulerService {
+  private readonly logger = new Logger(BroadcastSchedulerService.name);
+
+  constructor(private readonly broadcastService: BroadcastService) {}
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async handleScheduledBroadcasts() {
+    this.logger.log('Checking for scheduled broadcasts...');
+
+    const now = new Date();
+    const pendingBroadcasts = await this.broadcastService.findPendingBroadcasts(now);
+
+    for (const broadcast of pendingBroadcasts) {
+      this.logger.log(`Publishing broadcast "${broadcast.title}" scheduled at ${broadcast.scheduledAt.toISOString()}`);
+
+      broadcast.isPublished = true;
+      await this.broadcastService.save(broadcast);
+
+      // Optional: Trigger additional logic like email or logging
+    }
+  }
+}


### PR DESCRIPTION
### ✅ What’s in This PR?
Implements the scheduled broadcast feature to allow admins to queue announcements at future dates.

### 📦 Features
- [x] Broadcast entity with fields: `title`, `message`, `scheduledAt`, `isPublished`
- [x] Admin endpoints for create, update, list, and single view
- [x] Scheduler service using `@Cron()` to auto-publish
- [x] Registered BroadcastModule and global ScheduleModule

### 📅 Scheduled Cron Strategy
Runs every minute to check for:
- `isPublished = false`
- `scheduledAt <= now()`

Marks broadcast as published once due.

### 🔒 Notes
- Completely decoupled from the notifications or announcements module.
- Upgradeable to BullMQ if needed.

Closes #89
