### PR TITLE
feat: Implement survey module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { MonitoringModule } from './monitoring/monitoring.module';
 import { SettingsModule } from './settings/settings.module';
 import { ParkingModule } from './parking/parking.module';
+import { SurveysModule } from './surveys/surveys.module';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { ParkingModule } from './parking/parking.module';
     MonitoringModule,
     SettingsModule,
     ParkingModule,
+    SurveysModule,
   ],
   controllers: [AppController],
   providers: [AppService, LibraryService],

--- a/backend/src/surveys/README.md
+++ b/backend/src/surveys/README.md
@@ -1,0 +1,109 @@
+# Surveys Module
+
+The Surveys module allows the creation and management of surveys within the ManageHub platform. Admins can create surveys with different types of questions, and users can respond to them. All data is stored independently from the user module.
+
+## Features
+
+- Create, read, update, and delete surveys
+- Create questions with different types (text, single choice, multiple choice, rating)
+- Submit responses to surveys
+- Get survey responses for analysis
+
+## API Endpoints
+
+### Surveys
+
+- `POST /surveys` - Create a new survey
+- `GET /surveys` - Get all surveys
+- `GET /surveys?active=true` - Get only active surveys
+- `GET /surveys/:id` - Get a specific survey by ID
+- `PATCH /surveys/:id` - Update a survey
+- `DELETE /surveys/:id` - Delete a survey
+- `POST /surveys/responses` - Submit responses to a survey
+- `GET /surveys/:id/responses` - Get all responses for a survey
+
+## Usage Examples
+
+### Creating a Survey
+
+```json
+POST /surveys
+{
+  "title": "Office Satisfaction Survey",
+  "description": "Please help us improve your workplace experience",
+  "createdBy": "admin-123",
+  "questions": [
+    {
+      "text": "How satisfied are you with the office environment?",
+      "type": "rating",
+      "isRequired": true
+    },
+    {
+      "text": "What could be improved?",
+      "type": "text",
+      "isRequired": false
+    },
+    {
+      "text": "Which amenities do you use most often?",
+      "type": "multiple_choice",
+      "options": ["Kitchen", "Meeting Rooms", "Quiet Spaces", "Recreation Area"],
+      "isRequired": true
+    }
+  ]
+}
+```
+
+### Submitting Responses
+
+```json
+POST /surveys/responses
+{
+  "surveyId": "survey-uuid",
+  "respondentId": "user-123",
+  "responses": [
+    {
+      "questionId": "question-1-uuid",
+      "value": 4
+    },
+    {
+      "questionId": "question-2-uuid",
+      "value": "The temperature control could be improved"
+    },
+    {
+      "questionId": "question-3-uuid",
+      "value": ["Kitchen", "Meeting Rooms"]
+    }
+  ]
+}
+```
+
+### Getting Survey Responses
+
+```
+GET /surveys/survey-uuid/responses
+```
+
+Response:
+```json
+{
+  "surveyId": "survey-uuid",
+  "title": "Office Satisfaction Survey",
+  "description": "Please help us improve your workplace experience",
+  "questions": [
+    {
+      "questionId": "question-1-uuid",
+      "questionText": "How satisfied are you with the office environment?",
+      "questionType": "rating",
+      "responses": [
+        {
+          "responseId": "response-1-uuid",
+          "respondentId": "user-123",
+          "value": 4,
+          "createdAt": "2025-08-21T10:30:15.000Z"
+        }
+      ]
+    },
+    // More questions and responses...
+  ]
+}
+```

--- a/backend/src/surveys/dto/response.dto.ts
+++ b/backend/src/surveys/dto/response.dto.ts
@@ -1,0 +1,23 @@
+import { IsString, IsUUID, IsNotEmpty, IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateResponseItemDto {
+  @IsUUID()
+  questionId: string;
+
+  @IsNotEmpty()
+  value: any;
+}
+
+export class CreateSurveyResponseDto {
+  @IsUUID()
+  surveyId: string;
+
+  @IsString()
+  respondentId: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateResponseItemDto)
+  responses: CreateResponseItemDto[];
+}

--- a/backend/src/surveys/dto/survey.dto.ts
+++ b/backend/src/surveys/dto/survey.dto.ts
@@ -1,0 +1,59 @@
+import { IsString, IsOptional, IsBoolean, IsArray, ValidateNested, IsEnum, IsNumber, IsUUID } from 'class-validator';
+import { Type } from 'class-transformer';
+import { QuestionType } from '../entities/question.entity';
+
+export class CreateQuestionDto {
+  @IsString()
+  text: string;
+
+  @IsEnum(QuestionType)
+  type: QuestionType;
+
+  @IsArray()
+  @IsOptional()
+  options?: string[];
+
+  @IsBoolean()
+  @IsOptional()
+  isRequired?: boolean;
+
+  @IsNumber()
+  @IsOptional()
+  order?: number;
+}
+
+export class CreateSurveyDto {
+  @IsString()
+  title: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsString()
+  createdBy: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateQuestionDto)
+  questions: CreateQuestionDto[];
+}
+
+export class UpdateSurveyDto {
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}
+
+export class GetSurveyResponsesDto {
+  @IsUUID()
+  surveyId: string;
+}

--- a/backend/src/surveys/entities/question.entity.ts
+++ b/backend/src/surveys/entities/question.entity.ts
@@ -1,0 +1,45 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, OneToMany, JoinColumn } from 'typeorm';
+import { Survey } from './survey.entity';
+
+export enum QuestionType {
+  TEXT = 'text',
+  SINGLE_CHOICE = 'single_choice',
+  MULTIPLE_CHOICE = 'multiple_choice',
+  RATING = 'rating',
+}
+
+@Entity()
+export class Question {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  text: string;
+
+  @Column({
+    type: 'varchar',
+    enum: QuestionType,
+    default: QuestionType.TEXT,
+  })
+  type: QuestionType;
+
+  @Column('simple-json', { nullable: true })
+  options: string[];
+
+  @Column({ default: false })
+  isRequired: boolean;
+
+  @Column({ default: 0 })
+  order: number;
+
+  @ManyToOne(() => Survey, (survey) => survey.questions, { onDelete: 'CASCADE' })
+  @JoinColumn()
+  survey: Survey;
+
+  @Column()
+  surveyId: string;
+
+  // Forward reference to responses instead of importing Response entity
+  @OneToMany('Response', 'question')
+  responses: any[];
+}

--- a/backend/src/surveys/entities/response.entity.ts
+++ b/backend/src/surveys/entities/response.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn, CreateDateColumn } from 'typeorm';
+import { Question } from './question.entity';
+
+@Entity()
+export class Response {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('simple-json')
+  value: any;
+
+  @Column()
+  respondentId: string;
+
+  @ManyToOne(() => Question, (question) => question.responses, { onDelete: 'CASCADE' })
+  @JoinColumn()
+  question: Question;
+
+  @Column()
+  questionId: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/surveys/entities/survey.entity.ts
+++ b/backend/src/surveys/entities/survey.entity.ts
@@ -1,0 +1,32 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, OneToMany } from 'typeorm';
+import { Question } from './question.entity';
+
+@Entity()
+export class Survey {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @OneToMany(() => Question, (question) => question.survey, {
+    cascade: true,
+    eager: true,
+  })
+  questions: Question[];
+
+  @Column()
+  createdBy: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/surveys/surveys.controller.spec.ts
+++ b/backend/src/surveys/surveys.controller.spec.ts
@@ -1,0 +1,140 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SurveysController } from './surveys.controller';
+import { SurveysService } from './surveys.service';
+import { CreateSurveyDto } from './dto/survey.dto';
+import { QuestionType } from './entities/question.entity';
+import { CreateSurveyResponseDto } from './dto/response.dto';
+
+describe('SurveysController', () => {
+  let controller: SurveysController;
+  let service: SurveysService;
+
+  const mockSurveysService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    submitResponses: jest.fn(),
+    getSurveyResponses: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SurveysController],
+      providers: [
+        {
+          provide: SurveysService,
+          useValue: mockSurveysService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<SurveysController>(SurveysController);
+    service = module.get<SurveysService>(SurveysService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new survey', async () => {
+      const createSurveyDto: CreateSurveyDto = {
+        title: 'Test Survey',
+        description: 'A test survey',
+        createdBy: 'admin',
+        questions: [
+          {
+            text: 'Question 1',
+            type: QuestionType.TEXT,
+            isRequired: true,
+          },
+          {
+            text: 'Question 2',
+            type: QuestionType.SINGLE_CHOICE,
+            options: ['Option 1', 'Option 2'],
+            isRequired: false,
+          },
+        ],
+      };
+
+      const expectedResult = {
+        id: 'survey-uuid',
+        ...createSurveyDto,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      jest.spyOn(service, 'create').mockResolvedValue(expectedResult as any);
+
+      const result = await controller.create(createSurveyDto);
+      expect(result).toEqual(expectedResult);
+      expect(service.create).toHaveBeenCalledWith(createSurveyDto);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of surveys', async () => {
+      const expectedResult = [
+        {
+          id: 'survey-uuid-1',
+          title: 'Survey 1',
+          isActive: true,
+        },
+        {
+          id: 'survey-uuid-2',
+          title: 'Survey 2',
+          isActive: false,
+        },
+      ];
+
+      jest.spyOn(service, 'findAll').mockResolvedValue(expectedResult as any);
+
+      const result = await controller.findAll();
+      expect(result).toEqual(expectedResult);
+      expect(service.findAll).toHaveBeenCalled();
+    });
+
+    it('should return only active surveys when active=true', async () => {
+      const expectedResult = [
+        {
+          id: 'survey-uuid-1',
+          title: 'Survey 1',
+          isActive: true,
+        },
+      ];
+
+      jest.spyOn(service, 'findAll').mockResolvedValue(expectedResult as any);
+
+      const result = await controller.findAll('true');
+      expect(result).toEqual(expectedResult);
+      expect(service.findAll).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('submitResponses', () => {
+    it('should submit responses for a survey', async () => {
+      const createResponseDto: CreateSurveyResponseDto = {
+        surveyId: 'survey-uuid',
+        respondentId: 'user-123',
+        responses: [
+          {
+            questionId: 'question-1',
+            value: 'Answer to question 1',
+          },
+          {
+            questionId: 'question-2',
+            value: 'Option 1',
+          },
+        ],
+      };
+
+      jest.spyOn(service, 'submitResponses').mockResolvedValue(undefined);
+
+      await controller.submitResponses(createResponseDto);
+      expect(service.submitResponses).toHaveBeenCalledWith(createResponseDto);
+    });
+  });
+});

--- a/backend/src/surveys/surveys.controller.ts
+++ b/backend/src/surveys/surveys.controller.ts
@@ -1,0 +1,49 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, ParseUUIDPipe } from '@nestjs/common';
+import { SurveysService } from './surveys.service';
+import { CreateSurveyDto, UpdateSurveyDto } from './dto/survey.dto';
+import { CreateSurveyResponseDto } from './dto/response.dto';
+import { Survey } from './entities/survey.entity';
+
+@Controller('surveys')
+export class SurveysController {
+  constructor(private readonly surveysService: SurveysService) {}
+
+  @Post()
+  create(@Body() createSurveyDto: CreateSurveyDto): Promise<Survey> {
+    return this.surveysService.create(createSurveyDto);
+  }
+
+  @Get()
+  findAll(@Query('active') active?: string): Promise<Survey[]> {
+    const activeOnly = active === 'true';
+    return this.surveysService.findAll(activeOnly);
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Survey> {
+    return this.surveysService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateSurveyDto: UpdateSurveyDto,
+  ): Promise<Survey> {
+    return this.surveysService.update(id, updateSurveyDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    return this.surveysService.remove(id);
+  }
+
+  @Post('responses')
+  submitResponses(@Body() createResponseDto: CreateSurveyResponseDto): Promise<void> {
+    return this.surveysService.submitResponses(createResponseDto);
+  }
+
+  @Get(':id/responses')
+  getSurveyResponses(@Param('id', ParseUUIDPipe) id: string): Promise<any> {
+    return this.surveysService.getSurveyResponses(id);
+  }
+}

--- a/backend/src/surveys/surveys.module.ts
+++ b/backend/src/surveys/surveys.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SurveysController } from './surveys.controller';
+import { SurveysService } from './surveys.service';
+import { Survey } from './entities/survey.entity';
+import { Question } from './entities/question.entity';
+import { Response } from './entities/response.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Survey,
+      Question,
+      Response,
+    ])
+  ],
+  controllers: [SurveysController],
+  providers: [SurveysService],
+  exports: [SurveysService],
+})
+export class SurveysModule {}

--- a/backend/src/surveys/surveys.service.spec.ts
+++ b/backend/src/surveys/surveys.service.spec.ts
@@ -1,0 +1,217 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { SurveysService } from './surveys.service';
+import { Survey } from './entities/survey.entity';
+import { Question, QuestionType } from './entities/question.entity';
+import { Response } from './entities/response.entity';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+
+type MockRepository<T = any> = Partial<Record<keyof Repository<T>, jest.Mock>>;
+
+const createMockRepository = <T = any>(): MockRepository<T> => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+});
+
+describe('SurveysService', () => {
+  let service: SurveysService;
+  let surveyRepository: MockRepository<Survey>;
+  let questionRepository: MockRepository<Question>;
+  let responseRepository: MockRepository<Response>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SurveysService,
+        {
+          provide: getRepositoryToken(Survey),
+          useValue: createMockRepository(),
+        },
+        {
+          provide: getRepositoryToken(Question),
+          useValue: createMockRepository(),
+        },
+        {
+          provide: getRepositoryToken(Response),
+          useValue: createMockRepository(),
+        },
+      ],
+    }).compile();
+
+    service = module.get<SurveysService>(SurveysService);
+    surveyRepository = module.get<MockRepository<Survey>>(getRepositoryToken(Survey));
+    questionRepository = module.get<MockRepository<Question>>(getRepositoryToken(Question));
+    responseRepository = module.get<MockRepository<Response>>(getRepositoryToken(Response));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a survey with questions', async () => {
+      const createSurveyDto = {
+        title: 'Test Survey',
+        description: 'A test survey',
+        createdBy: 'admin',
+        questions: [
+          {
+            text: 'Question 1',
+            type: QuestionType.TEXT,
+            isRequired: true,
+          },
+        ],
+      };
+
+      const savedSurvey = {
+        id: 'survey-uuid',
+        ...createSurveyDto,
+        questions: [],
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const savedQuestions = [
+        {
+          id: 'question-uuid',
+          text: 'Question 1',
+          type: QuestionType.TEXT,
+          isRequired: true,
+          order: 0,
+          surveyId: 'survey-uuid',
+          survey: savedSurvey,
+        },
+      ];
+
+      const surveyWithQuestions = {
+        ...savedSurvey,
+        questions: savedQuestions,
+      };
+
+      surveyRepository.create.mockReturnValue(savedSurvey);
+      surveyRepository.save.mockResolvedValue(savedSurvey);
+      questionRepository.create.mockReturnValue(savedQuestions[0]);
+      questionRepository.save.mockResolvedValue(savedQuestions);
+      surveyRepository.findOne.mockResolvedValue(surveyWithQuestions);
+
+      const result = await service.create(createSurveyDto);
+
+      expect(surveyRepository.create).toHaveBeenCalled();
+      expect(surveyRepository.save).toHaveBeenCalled();
+      expect(questionRepository.create).toHaveBeenCalled();
+      expect(questionRepository.save).toHaveBeenCalled();
+      expect(surveyRepository.findOne).toHaveBeenCalled();
+      expect(result).toEqual(surveyWithQuestions);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a survey by id', async () => {
+      const surveyId = 'survey-uuid';
+      const expectedSurvey = {
+        id: surveyId,
+        title: 'Test Survey',
+        questions: [
+          { id: 'q1', text: 'Question 1', order: 1 },
+          { id: 'q2', text: 'Question 2', order: 0 },
+        ],
+      };
+
+      surveyRepository.findOne.mockResolvedValue(expectedSurvey);
+
+      const result = await service.findOne(surveyId);
+
+      expect(surveyRepository.findOne).toHaveBeenCalledWith({
+        where: { id: surveyId },
+        relations: ['questions'],
+      });
+      expect(result).toEqual({
+        ...expectedSurvey,
+        questions: [
+          { id: 'q2', text: 'Question 2', order: 0 },
+          { id: 'q1', text: 'Question 1', order: 1 },
+        ],
+      });
+    });
+
+    it('should throw NotFoundException when survey not found', async () => {
+      const surveyId = 'non-existent-id';
+      surveyRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne(surveyId)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('submitResponses', () => {
+    it('should submit responses for a survey', async () => {
+      const createResponseDto = {
+        surveyId: 'survey-uuid',
+        respondentId: 'user-123',
+        responses: [
+          {
+            questionId: 'question-1',
+            value: 'Answer to question 1',
+          },
+        ],
+      };
+
+      const survey = {
+        id: 'survey-uuid',
+        title: 'Test Survey',
+        isActive: true,
+        questions: [
+          {
+            id: 'question-1',
+            text: 'Question 1',
+            isRequired: true,
+          },
+        ],
+      };
+
+      surveyRepository.findOne.mockResolvedValue(survey);
+      responseRepository.create.mockReturnValue({
+        questionId: 'question-1',
+        value: 'Answer to question 1',
+        respondentId: 'user-123',
+        question: survey.questions[0],
+      });
+      responseRepository.save.mockResolvedValue([]);
+
+      await service.submitResponses(createResponseDto);
+
+      expect(surveyRepository.findOne).toHaveBeenCalled();
+      expect(responseRepository.create).toHaveBeenCalled();
+      expect(responseRepository.save).toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when required question is not answered', async () => {
+      const createResponseDto = {
+        surveyId: 'survey-uuid',
+        respondentId: 'user-123',
+        responses: [],
+      };
+
+      const survey = {
+        id: 'survey-uuid',
+        title: 'Test Survey',
+        isActive: true,
+        questions: [
+          {
+            id: 'question-1',
+            text: 'Question 1',
+            isRequired: true,
+          },
+        ],
+      };
+
+      surveyRepository.findOne.mockResolvedValue(survey);
+
+      await expect(service.submitResponses(createResponseDto)).rejects.toThrow(BadRequestException);
+    });
+  });
+});

--- a/backend/src/surveys/surveys.service.ts
+++ b/backend/src/surveys/surveys.service.ts
@@ -1,0 +1,174 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Survey } from './entities/survey.entity';
+import { Question } from './entities/question.entity';
+import { Response } from './entities/response.entity';
+import { CreateSurveyDto, UpdateSurveyDto } from './dto/survey.dto';
+import { CreateSurveyResponseDto } from './dto/response.dto';
+
+@Injectable()
+export class SurveysService {
+  constructor(
+    @InjectRepository(Survey)
+    private surveysRepository: Repository<Survey>,
+    @InjectRepository(Question)
+    private questionsRepository: Repository<Question>,
+    @InjectRepository(Response)
+    private responsesRepository: Repository<Response>,
+  ) {}
+
+  async create(createSurveyDto: CreateSurveyDto): Promise<Survey> {
+    const { questions, ...surveyData } = createSurveyDto;
+    
+    // Create survey without questions first
+    const survey = this.surveysRepository.create(surveyData);
+    const savedSurvey = await this.surveysRepository.save(survey);
+    
+    // Create questions with reference to survey
+    if (questions && questions.length > 0) {
+      const questionEntities = questions.map((q, index) => {
+        const question = this.questionsRepository.create({
+          ...q,
+          order: q.order ?? index,
+          survey: savedSurvey,
+          surveyId: savedSurvey.id,
+        });
+        return question;
+      });
+      
+      await this.questionsRepository.save(questionEntities);
+      
+      // Reload survey with questions
+      return this.findOne(savedSurvey.id);
+    }
+    
+    return savedSurvey;
+  }
+
+  async findAll(activeOnly: boolean = false): Promise<Survey[]> {
+    if (activeOnly) {
+      return this.surveysRepository.find({
+        where: { isActive: true },
+        order: { createdAt: 'DESC' },
+      });
+    }
+    return this.surveysRepository.find({
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findOne(id: string): Promise<Survey> {
+    const survey = await this.surveysRepository.findOne({
+      where: { id },
+      relations: ['questions'],
+    });
+    
+    if (!survey) {
+      throw new NotFoundException(`Survey with ID ${id} not found`);
+    }
+    
+    // Sort questions by order
+    survey.questions.sort((a, b) => a.order - b.order);
+    
+    return survey;
+  }
+
+  async update(id: string, updateSurveyDto: UpdateSurveyDto): Promise<Survey> {
+    const survey = await this.findOne(id);
+    
+    // Update survey properties
+    Object.assign(survey, updateSurveyDto);
+    
+    return this.surveysRepository.save(survey);
+  }
+
+  async remove(id: string): Promise<void> {
+    const survey = await this.findOne(id);
+    await this.surveysRepository.remove(survey);
+  }
+
+  async submitResponses(createResponseDto: CreateSurveyResponseDto): Promise<void> {
+    const { surveyId, respondentId, responses } = createResponseDto;
+    
+    // Verify survey exists and is active
+    const survey = await this.surveysRepository.findOne({
+      where: { id: surveyId, isActive: true },
+      relations: ['questions'],
+    });
+    
+    if (!survey) {
+      throw new NotFoundException(`Survey with ID ${surveyId} not found or is not active`);
+    }
+    
+    // Create a map of question IDs for quick lookup
+    const questionMap = new Map();
+    survey.questions.forEach(q => questionMap.set(q.id, q));
+    
+    // Validate that all required questions are answered
+    const requiredQuestions = survey.questions.filter(q => q.isRequired);
+    const answeredQuestionIds = responses.map(r => r.questionId);
+    
+    const missingRequiredQuestions = requiredQuestions.filter(q => 
+      !answeredQuestionIds.includes(q.id)
+    );
+    
+    if (missingRequiredQuestions.length > 0) {
+      throw new BadRequestException(
+        `Missing responses for required questions: ${missingRequiredQuestions.map(q => q.text).join(', ')}`
+      );
+    }
+    
+    // Validate that all provided question IDs belong to this survey
+    for (const response of responses) {
+      if (!questionMap.has(response.questionId)) {
+        throw new BadRequestException(`Question with ID ${response.questionId} does not belong to survey ${surveyId}`);
+      }
+    }
+    
+    // Save responses
+    const responseEntities = responses.map(r => {
+      return this.responsesRepository.create({
+        questionId: r.questionId,
+        value: r.value,
+        respondentId,
+        question: questionMap.get(r.questionId),
+      });
+    });
+    
+    await this.responsesRepository.save(responseEntities);
+  }
+
+  async getSurveyResponses(surveyId: string): Promise<any> {
+    // Check if survey exists
+    const survey = await this.findOne(surveyId);
+    
+    // Get all questions for the survey
+    const questions = await this.questionsRepository.find({
+      where: { surveyId: survey.id },
+      relations: ['responses'],
+    });
+    
+    // Transform the data into a more usable format
+    const results = questions.map(question => {
+      return {
+        questionId: question.id,
+        questionText: question.text,
+        questionType: question.type,
+        responses: question.responses.map(response => ({
+          responseId: response.id,
+          respondentId: response.respondentId,
+          value: response.value,
+          createdAt: response.createdAt,
+        })),
+      };
+    });
+    
+    return {
+      surveyId: survey.id,
+      title: survey.title,
+      description: survey.description,
+      questions: results,
+    };
+  }
+}


### PR DESCRIPTION
# Survey Module Implementation

This PR adds a new survey feature to ManageHub as requested.

## Features
- Creation of surveys with different question types (text, single choice, multiple choice, rating)
- Participation in surveys by users
- Storage of questions and responses in separate tables
- No dependency on the user module, using string IDs instead

## Implementation Details
- Created new entities: Survey, Question, Response
- Added DTOs for creating surveys and submitting responses
- Implemented controller with REST endpoints
- Added comprehensive service with business logic
- Included unit tests for controller and service
- Added documentation in README.md

## How to Test
1. Create a survey using POST /surveys
2. Get available surveys using GET /surveys
3. Submit responses using POST /surveys/responses
4. Get survey responses using GET /surveys/:id/responses

Closes #78 