### PR TITLE
feat: Implement partners management module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { MonitoringModule } from './monitoring/monitoring.module';
 import { SettingsModule } from './settings/settings.module';
 import { ParkingModule } from './parking/parking.module';
+import { PartnersModule } from './partners/partners.module';
 
 @Module({
   imports: [
@@ -41,6 +42,7 @@ import { ParkingModule } from './parking/parking.module';
     MonitoringModule,
     SettingsModule,
     ParkingModule,
+    PartnersModule,
   ],
   controllers: [AppController],
   providers: [AppService, LibraryService],

--- a/backend/src/partners/README.md
+++ b/backend/src/partners/README.md
@@ -1,0 +1,96 @@
+# Partners Management Module
+
+The Partners Management module allows administrators to store and manage a list of third-party partners, their contact information, and descriptions of their services. This module is fully standalone and doesn't depend on any other modules.
+
+## Features
+
+- Create, read, update, and delete partner organizations
+- Manage multiple contact information for each partner
+- Track services offered by each partner
+- Filter active/inactive partners
+
+## API Endpoints
+
+### Partners
+
+- `POST /partners` - Create a new partner
+- `GET /partners` - Get all partners
+- `GET /partners?active=true` - Get only active partners
+- `GET /partners/:id` - Get a specific partner by ID
+- `PATCH /partners/:id` - Update a partner
+- `DELETE /partners/:id` - Delete a partner
+
+### Partner Contacts
+
+- `POST /partners/:id/contacts` - Add a new contact to a partner
+- `PATCH /partners/contacts/:id` - Update a contact
+- `DELETE /partners/contacts/:id` - Delete a contact
+
+### Partner Services
+
+- `POST /partners/:id/services` - Add a new service to a partner
+- `PATCH /partners/services/:id` - Update a service
+- `DELETE /partners/services/:id` - Delete a service
+
+## Usage Examples
+
+### Creating a Partner
+
+```json
+POST /partners
+{
+  "name": "Acme Corporation",
+  "description": "A partner that provides various tech services",
+  "website": "https://acme.example.com",
+  "logo": "https://acme.example.com/logo.png",
+  "contacts": [
+    {
+      "type": "email",
+      "value": "contact@acme.example.com",
+      "label": "Main Contact",
+      "isPrimary": true
+    },
+    {
+      "type": "phone",
+      "value": "+1234567890",
+      "label": "Support"
+    },
+    {
+      "type": "address",
+      "value": "123 Main St, City, Country",
+      "label": "Headquarters"
+    }
+  ],
+  "services": [
+    {
+      "name": "IT Consulting",
+      "description": "Expert IT consulting services"
+    },
+    {
+      "name": "Cloud Solutions",
+      "description": "Managed cloud infrastructure services"
+    }
+  ]
+}
+```
+
+### Adding a Contact
+
+```json
+POST /partners/partner-uuid/contacts
+{
+  "type": "email",
+  "value": "sales@acme.example.com",
+  "label": "Sales Department"
+}
+```
+
+### Adding a Service
+
+```json
+POST /partners/partner-uuid/services
+{
+  "name": "Security Audits",
+  "description": "Comprehensive security audit services"
+}
+```

--- a/backend/src/partners/dto/partner-contact.dto.ts
+++ b/backend/src/partners/dto/partner-contact.dto.ts
@@ -1,0 +1,36 @@
+import { IsString, IsOptional, IsEnum, IsBoolean } from 'class-validator';
+import { ContactType } from '../entities/partner-contact.entity';
+
+export class CreatePartnerContactDto {
+  @IsEnum(ContactType)
+  type: ContactType;
+
+  @IsString()
+  value: string;
+
+  @IsString()
+  @IsOptional()
+  label?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isPrimary?: boolean;
+}
+
+export class UpdatePartnerContactDto {
+  @IsEnum(ContactType)
+  @IsOptional()
+  type?: ContactType;
+
+  @IsString()
+  @IsOptional()
+  value?: string;
+
+  @IsString()
+  @IsOptional()
+  label?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isPrimary?: boolean;
+}

--- a/backend/src/partners/dto/partner-service.dto.ts
+++ b/backend/src/partners/dto/partner-service.dto.ts
@@ -1,0 +1,28 @@
+import { IsString, IsOptional, IsBoolean } from 'class-validator';
+
+export class CreatePartnerServiceDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}
+
+export class UpdatePartnerServiceDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/backend/src/partners/dto/partner.dto.ts
+++ b/backend/src/partners/dto/partner.dto.ts
@@ -1,0 +1,55 @@
+import { IsString, IsOptional, IsBoolean, IsUrl, IsArray, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import { CreatePartnerContactDto } from './partner-contact.dto';
+import { CreatePartnerServiceDto } from './partner-service.dto';
+
+export class CreatePartnerDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsUrl()
+  @IsOptional()
+  website?: string;
+
+  @IsString()
+  @IsOptional()
+  logo?: string;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreatePartnerContactDto)
+  @IsOptional()
+  contacts?: CreatePartnerContactDto[];
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreatePartnerServiceDto)
+  @IsOptional()
+  services?: CreatePartnerServiceDto[];
+}
+
+export class UpdatePartnerDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsUrl()
+  @IsOptional()
+  website?: string;
+
+  @IsString()
+  @IsOptional()
+  logo?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/backend/src/partners/entities/partner-contact.entity.ts
+++ b/backend/src/partners/entities/partner-contact.entity.ts
@@ -1,0 +1,38 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Partner } from './partner.entity';
+
+export enum ContactType {
+  EMAIL = 'email',
+  PHONE = 'phone',
+  ADDRESS = 'address',
+  OTHER = 'other',
+}
+
+@Entity()
+export class PartnerContact {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({
+    type: 'varchar',
+    enum: ContactType,
+    default: ContactType.EMAIL,
+  })
+  type: ContactType;
+
+  @Column()
+  value: string;
+
+  @Column({ nullable: true })
+  label: string;
+
+  @Column({ default: true })
+  isPrimary: boolean;
+
+  @ManyToOne(() => Partner, (partner) => partner.contacts, { onDelete: 'CASCADE' })
+  @JoinColumn()
+  partner: Partner;
+
+  @Column()
+  partnerId: string;
+}

--- a/backend/src/partners/entities/partner-service.entity.ts
+++ b/backend/src/partners/entities/partner-service.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Partner } from './partner.entity';
+
+@Entity()
+export class PartnerService {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @ManyToOne(() => Partner, (partner) => partner.services, { onDelete: 'CASCADE' })
+  @JoinColumn()
+  partner: Partner;
+
+  @Column()
+  partnerId: string;
+}

--- a/backend/src/partners/entities/partner.entity.ts
+++ b/backend/src/partners/entities/partner.entity.ts
@@ -1,0 +1,36 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, OneToMany } from 'typeorm';
+
+@Entity()
+export class Partner {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column({ nullable: true })
+  website: string;
+
+  @Column({ nullable: true })
+  logo: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  // Forward reference to avoid circular dependencies
+  @OneToMany('PartnerContact', 'partner', { cascade: true })
+  contacts: any[];
+
+  // Forward reference to avoid circular dependencies
+  @OneToMany('PartnerService', 'partner', { cascade: true })
+  services: any[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/partners/partners.controller.spec.ts
+++ b/backend/src/partners/partners.controller.spec.ts
@@ -1,0 +1,164 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PartnersController } from './partners.controller';
+import { PartnersService } from './partners.service';
+import { CreatePartnerDto } from './dto/partner.dto';
+import { ContactType } from './entities/partner-contact.entity';
+
+describe('PartnersController', () => {
+  let controller: PartnersController;
+  let service: PartnersService;
+
+  const mockPartnersService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    addContact: jest.fn(),
+    updateContact: jest.fn(),
+    removeContact: jest.fn(),
+    addService: jest.fn(),
+    updateService: jest.fn(),
+    removeService: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PartnersController],
+      providers: [
+        {
+          provide: PartnersService,
+          useValue: mockPartnersService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<PartnersController>(PartnersController);
+    service = module.get<PartnersService>(PartnersService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('create', () => {
+    it('should create a new partner', async () => {
+      const createPartnerDto: CreatePartnerDto = {
+        name: 'Acme Corp',
+        description: 'A partner company',
+        website: 'https://example.com',
+        contacts: [
+          {
+            type: ContactType.EMAIL,
+            value: 'contact@acme.com',
+            label: 'Main Contact',
+            isPrimary: true,
+          },
+        ],
+        services: [
+          {
+            name: 'Consulting',
+            description: 'Business consulting services',
+          },
+        ],
+      };
+
+      const expectedResult = {
+        id: 'partner-uuid',
+        ...createPartnerDto,
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      jest.spyOn(service, 'create').mockResolvedValue(expectedResult as any);
+
+      const result = await controller.create(createPartnerDto);
+      expect(result).toEqual(expectedResult);
+      expect(service.create).toHaveBeenCalledWith(createPartnerDto);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return an array of partners', async () => {
+      const expectedResult = [
+        {
+          id: 'partner-uuid-1',
+          name: 'Partner 1',
+          isActive: true,
+        },
+        {
+          id: 'partner-uuid-2',
+          name: 'Partner 2',
+          isActive: false,
+        },
+      ];
+
+      jest.spyOn(service, 'findAll').mockResolvedValue(expectedResult as any);
+
+      const result = await controller.findAll();
+      expect(result).toEqual(expectedResult);
+      expect(service.findAll).toHaveBeenCalled();
+    });
+
+    it('should return only active partners when active=true', async () => {
+      const expectedResult = [
+        {
+          id: 'partner-uuid-1',
+          name: 'Partner 1',
+          isActive: true,
+        },
+      ];
+
+      jest.spyOn(service, 'findAll').mockResolvedValue(expectedResult as any);
+
+      const result = await controller.findAll('true');
+      expect(result).toEqual(expectedResult);
+      expect(service.findAll).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('contact management', () => {
+    it('should add a new contact to a partner', async () => {
+      const partnerId = 'partner-uuid';
+      const contactDto = {
+        type: ContactType.EMAIL,
+        value: 'new@example.com',
+      };
+
+      const expectedResult = {
+        id: 'contact-uuid',
+        ...contactDto,
+        partnerId,
+      };
+
+      jest.spyOn(service, 'addContact').mockResolvedValue(expectedResult as any);
+
+      const result = await controller.addContact(partnerId, contactDto);
+      expect(result).toEqual(expectedResult);
+      expect(service.addContact).toHaveBeenCalledWith(partnerId, contactDto);
+    });
+  });
+
+  describe('service management', () => {
+    it('should add a new service to a partner', async () => {
+      const partnerId = 'partner-uuid';
+      const serviceDto = {
+        name: 'New Service',
+        description: 'Description of new service',
+      };
+
+      const expectedResult = {
+        id: 'service-uuid',
+        ...serviceDto,
+        partnerId,
+      };
+
+      jest.spyOn(service, 'addService').mockResolvedValue(expectedResult as any);
+
+      const result = await controller.addService(partnerId, serviceDto);
+      expect(result).toEqual(expectedResult);
+      expect(service.addService).toHaveBeenCalledWith(partnerId, serviceDto);
+    });
+  });
+});

--- a/backend/src/partners/partners.controller.ts
+++ b/backend/src/partners/partners.controller.ts
@@ -1,0 +1,86 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete, Query, ParseUUIDPipe } from '@nestjs/common';
+import { PartnersService } from './partners.service';
+import { CreatePartnerDto, UpdatePartnerDto } from './dto/partner.dto';
+import { CreatePartnerContactDto, UpdatePartnerContactDto } from './dto/partner-contact.dto';
+import { CreatePartnerServiceDto, UpdatePartnerServiceDto } from './dto/partner-service.dto';
+import { Partner } from './entities/partner.entity';
+import { PartnerContact } from './entities/partner-contact.entity';
+import { PartnerService } from './entities/partner-service.entity';
+
+@Controller('partners')
+export class PartnersController {
+  constructor(private readonly partnersService: PartnersService) {}
+
+  @Post()
+  create(@Body() createPartnerDto: CreatePartnerDto): Promise<Partner> {
+    return this.partnersService.create(createPartnerDto);
+  }
+
+  @Get()
+  findAll(@Query('active') active?: string): Promise<Partner[]> {
+    const activeOnly = active === 'true';
+    return this.partnersService.findAll(activeOnly);
+  }
+
+  @Get(':id')
+  findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Partner> {
+    return this.partnersService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updatePartnerDto: UpdatePartnerDto,
+  ): Promise<Partner> {
+    return this.partnersService.update(id, updatePartnerDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    return this.partnersService.remove(id);
+  }
+
+  // Contact management endpoints
+  @Post(':id/contacts')
+  addContact(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() createContactDto: CreatePartnerContactDto,
+  ): Promise<PartnerContact> {
+    return this.partnersService.addContact(id, createContactDto);
+  }
+
+  @Patch('contacts/:id')
+  updateContact(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateContactDto: UpdatePartnerContactDto,
+  ): Promise<PartnerContact> {
+    return this.partnersService.updateContact(id, updateContactDto);
+  }
+
+  @Delete('contacts/:id')
+  removeContact(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    return this.partnersService.removeContact(id);
+  }
+
+  // Service management endpoints
+  @Post(':id/services')
+  addService(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() createServiceDto: CreatePartnerServiceDto,
+  ): Promise<PartnerService> {
+    return this.partnersService.addService(id, createServiceDto);
+  }
+
+  @Patch('services/:id')
+  updateService(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateServiceDto: UpdatePartnerServiceDto,
+  ): Promise<PartnerService> {
+    return this.partnersService.updateService(id, updateServiceDto);
+  }
+
+  @Delete('services/:id')
+  removeService(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    return this.partnersService.removeService(id);
+  }
+}

--- a/backend/src/partners/partners.module.ts
+++ b/backend/src/partners/partners.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PartnersController } from './partners.controller';
+import { PartnersService } from './partners.service';
+import { Partner } from './entities/partner.entity';
+import { PartnerContact } from './entities/partner-contact.entity';
+import { PartnerService } from './entities/partner-service.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Partner,
+      PartnerContact,
+      PartnerService,
+    ])
+  ],
+  controllers: [PartnersController],
+  providers: [PartnersService],
+  exports: [PartnersService],
+})
+export class PartnersModule {}

--- a/backend/src/partners/partners.service.spec.ts
+++ b/backend/src/partners/partners.service.spec.ts
@@ -1,0 +1,178 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PartnersService } from './partners.service';
+import { Partner } from './entities/partner.entity';
+import { PartnerContact } from './entities/partner-contact.entity';
+import { PartnerService } from './entities/partner-service.entity';
+import { NotFoundException } from '@nestjs/common';
+
+type MockRepository<T = any> = Partial<Record<keyof Repository<T>, jest.Mock>>;
+
+const createMockRepository = <T = any>(): MockRepository<T> => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+});
+
+describe('PartnersService', () => {
+  let service: PartnersService;
+  let partnerRepository: MockRepository<Partner>;
+  let contactRepository: MockRepository<PartnerContact>;
+  let serviceRepository: MockRepository<PartnerService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PartnersService,
+        {
+          provide: getRepositoryToken(Partner),
+          useValue: createMockRepository(),
+        },
+        {
+          provide: getRepositoryToken(PartnerContact),
+          useValue: createMockRepository(),
+        },
+        {
+          provide: getRepositoryToken(PartnerService),
+          useValue: createMockRepository(),
+        },
+      ],
+    }).compile();
+
+    service = module.get<PartnersService>(PartnersService);
+    partnerRepository = module.get<MockRepository<Partner>>(getRepositoryToken(Partner));
+    contactRepository = module.get<MockRepository<PartnerContact>>(getRepositoryToken(PartnerContact));
+    serviceRepository = module.get<MockRepository<PartnerService>>(getRepositoryToken(PartnerService));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('findOne', () => {
+    it('should return a partner by id', async () => {
+      const partnerId = 'partner-uuid';
+      const expectedPartner = {
+        id: partnerId,
+        name: 'Acme Corp',
+        contacts: [],
+        services: [],
+      };
+
+      partnerRepository.findOne.mockResolvedValue(expectedPartner);
+
+      const result = await service.findOne(partnerId);
+
+      expect(partnerRepository.findOne).toHaveBeenCalledWith({
+        where: { id: partnerId },
+        relations: ['contacts', 'services'],
+      });
+      expect(result).toEqual(expectedPartner);
+    });
+
+    it('should throw NotFoundException when partner not found', async () => {
+      const partnerId = 'non-existent-id';
+      partnerRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne(partnerId)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a partner with contacts and services', async () => {
+      const createPartnerDto = {
+        name: 'Acme Corp',
+        contacts: [
+          {
+            type: 'email' as any,
+            value: 'contact@acme.com',
+          },
+        ],
+        services: [
+          {
+            name: 'Consulting',
+            description: 'Business consulting services',
+          },
+        ],
+      };
+
+      const savedPartner = {
+        id: 'partner-uuid',
+        name: 'Acme Corp',
+        isActive: true,
+      };
+
+      const contact = {
+        id: 'contact-uuid',
+        type: 'email',
+        value: 'contact@acme.com',
+        partnerId: 'partner-uuid',
+      };
+
+      const service = {
+        id: 'service-uuid',
+        name: 'Consulting',
+        description: 'Business consulting services',
+        partnerId: 'partner-uuid',
+      };
+
+      const partnerWithRelations = {
+        ...savedPartner,
+        contacts: [contact],
+        services: [service],
+      };
+
+      partnerRepository.create.mockReturnValue(savedPartner);
+      partnerRepository.save.mockResolvedValue(savedPartner);
+      contactRepository.create.mockReturnValue(contact);
+      serviceRepository.create.mockReturnValue(service);
+      partnerRepository.findOne.mockResolvedValue(partnerWithRelations);
+
+      const result = await service.create(createPartnerDto);
+
+      expect(partnerRepository.create).toHaveBeenCalled();
+      expect(partnerRepository.save).toHaveBeenCalled();
+      expect(contactRepository.create).toHaveBeenCalled();
+      expect(serviceRepository.create).toHaveBeenCalled();
+      expect(result).toEqual(partnerWithRelations);
+    });
+  });
+
+  describe('contact management', () => {
+    it('should add a contact to a partner', async () => {
+      const partnerId = 'partner-uuid';
+      const partner = {
+        id: partnerId,
+        name: 'Acme Corp',
+      };
+      const contactDto = {
+        type: 'email' as any,
+        value: 'new@acme.com',
+      };
+      const contact = {
+        ...contactDto,
+        id: 'contact-uuid',
+        partnerId,
+        partner,
+      };
+
+      partnerRepository.findOne.mockResolvedValue(partner);
+      contactRepository.create.mockReturnValue(contact);
+      contactRepository.save.mockResolvedValue(contact);
+
+      const result = await service.addContact(partnerId, contactDto);
+
+      expect(partnerRepository.findOne).toHaveBeenCalled();
+      expect(contactRepository.create).toHaveBeenCalledWith({
+        ...contactDto,
+        partner,
+        partnerId,
+      });
+      expect(contactRepository.save).toHaveBeenCalled();
+      expect(result).toEqual(contact);
+    });
+  });
+});

--- a/backend/src/partners/partners.service.ts
+++ b/backend/src/partners/partners.service.ts
@@ -1,0 +1,166 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Partner } from './entities/partner.entity';
+import { PartnerContact } from './entities/partner-contact.entity';
+import { PartnerService } from './entities/partner-service.entity';
+import { CreatePartnerDto, UpdatePartnerDto } from './dto/partner.dto';
+import { CreatePartnerContactDto, UpdatePartnerContactDto } from './dto/partner-contact.dto';
+import { CreatePartnerServiceDto, UpdatePartnerServiceDto } from './dto/partner-service.dto';
+
+@Injectable()
+export class PartnersService {
+  constructor(
+    @InjectRepository(Partner)
+    private partnersRepository: Repository<Partner>,
+    @InjectRepository(PartnerContact)
+    private contactsRepository: Repository<PartnerContact>,
+    @InjectRepository(PartnerService)
+    private servicesRepository: Repository<PartnerService>,
+  ) {}
+
+  async create(createPartnerDto: CreatePartnerDto): Promise<Partner> {
+    const { contacts, services, ...partnerData } = createPartnerDto;
+    
+    // Create partner without contacts and services first
+    const partner = this.partnersRepository.create(partnerData);
+    const savedPartner = await this.partnersRepository.save(partner);
+    
+    // Create contacts if provided
+    if (contacts && contacts.length > 0) {
+      for (const contact of contacts) {
+        const contactEntity = this.contactsRepository.create({
+          ...contact,
+          partner: savedPartner,
+          partnerId: savedPartner.id,
+        });
+        await this.contactsRepository.save(contactEntity);
+      }
+    }
+    
+    // Create services if provided
+    if (services && services.length > 0) {
+      for (const service of services) {
+        const serviceEntity = this.servicesRepository.create({
+          ...service,
+          partner: savedPartner,
+          partnerId: savedPartner.id,
+        });
+        await this.servicesRepository.save(serviceEntity);
+      }
+    }
+    
+    // Return the partner with all relations
+    return this.findOne(savedPartner.id);
+  }
+
+  async findAll(activeOnly: boolean = false): Promise<Partner[]> {
+    const queryOptions: any = {
+      relations: ['contacts', 'services'],
+      order: { createdAt: 'DESC' },
+    };
+    
+    if (activeOnly) {
+      queryOptions.where = { isActive: true };
+    }
+    
+    return this.partnersRepository.find(queryOptions);
+  }
+
+  async findOne(id: string): Promise<Partner> {
+    const partner = await this.partnersRepository.findOne({
+      where: { id },
+      relations: ['contacts', 'services'],
+    });
+    
+    if (!partner) {
+      throw new NotFoundException(`Partner with ID ${id} not found`);
+    }
+    
+    return partner;
+  }
+
+  async update(id: string, updatePartnerDto: UpdatePartnerDto): Promise<Partner> {
+    const partner = await this.findOne(id);
+    
+    // Update partner properties
+    Object.assign(partner, updatePartnerDto);
+    
+    return this.partnersRepository.save(partner);
+  }
+
+  async remove(id: string): Promise<void> {
+    const partner = await this.findOne(id);
+    await this.partnersRepository.remove(partner);
+  }
+
+  // Contact management
+  async addContact(partnerId: string, createContactDto: CreatePartnerContactDto): Promise<PartnerContact> {
+    const partner = await this.findOne(partnerId);
+    
+    const contact = this.contactsRepository.create({
+      ...createContactDto,
+      partner,
+      partnerId,
+    });
+    
+    return this.contactsRepository.save(contact);
+  }
+
+  async updateContact(contactId: string, updateContactDto: UpdatePartnerContactDto): Promise<PartnerContact> {
+    const contact = await this.contactsRepository.findOne({ where: { id: contactId } });
+    
+    if (!contact) {
+      throw new NotFoundException(`Contact with ID ${contactId} not found`);
+    }
+    
+    Object.assign(contact, updateContactDto);
+    
+    return this.contactsRepository.save(contact);
+  }
+
+  async removeContact(contactId: string): Promise<void> {
+    const contact = await this.contactsRepository.findOne({ where: { id: contactId } });
+    
+    if (!contact) {
+      throw new NotFoundException(`Contact with ID ${contactId} not found`);
+    }
+    
+    await this.contactsRepository.remove(contact);
+  }
+
+  // Service management
+  async addService(partnerId: string, createServiceDto: CreatePartnerServiceDto): Promise<PartnerService> {
+    const partner = await this.findOne(partnerId);
+    
+    const service = this.servicesRepository.create({
+      ...createServiceDto,
+      partner,
+      partnerId,
+    });
+    
+    return this.servicesRepository.save(service);
+  }
+
+  async updateService(serviceId: string, updateServiceDto: UpdatePartnerServiceDto): Promise<PartnerService> {
+    const service = await this.servicesRepository.findOne({ where: { id: serviceId } });
+    
+    if (!service) {
+      throw new NotFoundException(`Service with ID ${serviceId} not found`);
+    }
+    
+    Object.assign(service, updateServiceDto);
+    
+    return this.servicesRepository.save(service);
+  }
+
+  async removeService(serviceId: string): Promise<void> {
+    const service = await this.servicesRepository.findOne({ where: { id: serviceId } });
+    
+    if (!service) {
+      throw new NotFoundException(`Service with ID ${serviceId} not found`);
+    }
+    
+    await this.servicesRepository.remove(service);
+  }
+}


### PR DESCRIPTION
# Partners Management Module Implementation

This PR adds a new feature to ManageHub for managing third-party partners.

## Features
- Store and manage a list of third-party partners
- Track contact information for each partner
- Manage descriptions of services offered by each partner
- Fully standalone module with no dependencies on other modules

## Implementation Details
- Created entities for Partner, PartnerContact, and PartnerService
- Added DTOs for creating and updating partners, contacts, and services
- Implemented controller with REST endpoints for full CRUD operations
- Added comprehensive service with business logic
- Included unit tests for controller and service
- Added documentation in README.md

## How to Test
1. Create a partner using POST /partners
2. Get all partners using GET /partners
3. Add contacts using POST /partners/:id/contacts
4. Add services using POST /partners/:id/services
5. Manage partners with PATCH and DELETE endpoints

Closes #87