### PR TITLE
feat: add user and auth type definitions

### DIFF
--- a/lib/types/user.ts
+++ b/lib/types/user.ts
@@ -1,0 +1,43 @@
+export enum UserRole {
+  USER = "user",
+  ADMIN = "admin",
+}
+
+export interface User {
+  id: string;
+  firstname: string;
+  lastname: string;
+  username?: string | null;
+  email: string;
+  role: UserRole;
+  isActive: boolean;
+  isSuspended: boolean;
+  isDeleted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export interface RegisterUser {
+  firstname: string;
+  lastname: string;
+  email: string;
+  password: string;
+}
+
+export interface LoginUser {
+  email: string;
+  password: string;
+}
+
+export interface AuthState {
+  user: User | null;
+  accessToken: string | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+}
+
+export interface AuthResponse {
+  user: User;
+  accessToken: string;
+}


### PR DESCRIPTION
# Fixes #179  
This implements the user and auth type definitions  

- [x] **UserRole enum** is defined with `"user"` and `"admin"`.  
- [x] **User interface** includes all properties listed above.  
- [x] **RegisterUser** and **LoginUser** interfaces include all required properties.  
- [x] **AuthState interface** reflects authentication status correctly.  
- [x] **AuthResponse interface** matches the expected backend response format.  
- [x] **Types are strongly typed**, with `null` and optional values properly handled.  
- [x] **File compiles** without TypeScript errors.  
