### PR TITLE
feat(auth): pluggable hashing provider (bcrypt as default)

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -10,7 +10,7 @@ export class AppController {
     return this.appService.getHello();
   }
 
-  @Get()
+  @Get('health')
   getHealth() {
     return {
       status: 'OK',

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -3,6 +3,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
             : false,
       }),
     }),
+    AuthModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { HashingProvider } from './providers/hashing.provider';
+import { BcryptProvider } from './providers/bcrypt.provider';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [{ provide: HashingProvider, useClass: BcryptProvider }],
+  exports: [HashingProvider],
+})
+export class AuthModule {}

--- a/backend/src/auth/providers/bcrypt.provider.ts
+++ b/backend/src/auth/providers/bcrypt.provider.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import * as bcrypt from 'bcrypt';
+import { HashingProvider } from './hashing.provider';
+
+@Injectable()
+export class BcryptProvider extends HashingProvider {
+  private readonly saltRounds: number;
+
+  constructor() {
+    super();
+    this.saltRounds = Number(process.env.BCRYPT_SALT_ROUNDS || 10);
+  }
+
+  async hash(data: string | Buffer): Promise<string> {
+    const plain = Buffer.isBuffer(data) ? data.toString('utf8') : data;
+    const salt = await bcrypt.genSalt(this.saltRounds);
+    return bcrypt.hash(plain, salt);
+  }
+
+  async compare(data: string | Buffer, hashedData: string): Promise<boolean> {
+    const plain = Buffer.isBuffer(data) ? data.toString('utf8') : data;
+    return bcrypt.compare(plain, hashedData);
+  }
+}

--- a/backend/src/auth/providers/hashing.provider.ts
+++ b/backend/src/auth/providers/hashing.provider.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export abstract class HashingProvider {
+  abstract hash(data: string | Buffer): Promise<string>;
+  abstract compare(data: string | Buffer, hashedData: string): Promise<boolean>;
+}

--- a/backend/src/auth/providers/test/bcrypt.provider.spec.ts
+++ b/backend/src/auth/providers/test/bcrypt.provider.spec.ts
@@ -1,0 +1,11 @@
+import { BcryptProvider } from '../bcrypt.provider';
+
+describe('BcryptProvider', () => {
+  it('hashes and compares correctly', async () => {
+    const provider = new BcryptProvider();
+    const hash = await provider.hash('secret');
+    expect(typeof hash).toBe('string');
+    await expect(provider.compare('secret', hash)).resolves.toBe(true);
+    await expect(provider.compare('wrong', hash)).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
**What & Why**
- Introduce `HashingProvider` (abstract) with `hash` and `compare`
- Implement `BcryptProvider` as default, supports `string | Buffer`
- Bind `HashingProvider -> BcryptProvider` in `AuthModule`, export provider
- Import `AuthModule` in `AppModule`
- Expose health route at `/health`

**Tech Notes**
- Salt rounds via `BCRYPT_SALT_ROUNDS` (default 10)

**How to Test**
1. npm i
2. npm run build
3. npm test
4. npm run start:dev
6. In any service, inject `HashingProvider` and verify:
   - `hash('secret')` → string
   - `compare('secret', hash)` → true
   - `compare('nope', hash)` → false

**Acceptance Criteria**
- [x] Abstract `HashingProvider` with `hash` and `compare`
- [x] `BcryptProvider` implements both using `bcrypt`
- [x] `AuthModule` binds and exports `HashingProvider`
- [x] Modular/extensible design for future providers

**Linked Issue**
Closes #203

**Files Touched**
- `src/auth/providers/hashing.provider.ts`
- `src/auth/providers/bcrypt.provider.ts`
- `src/auth/auth.module.ts`
- `src/app.module.ts`
- `src/app.controller.ts`
- `src/auth/providers/test/bcrypt.provider.spec.ts`
