### PR TITLE
Add reusable Pagination component

### DIFF
--- a/frontend/components/ui/Pagination.tsx
+++ b/frontend/components/ui/Pagination.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { cn } from '@/utils/cn';
+
+interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  className?: string;
+}
+
+const Pagination = ({ currentPage, totalPages, onPageChange, className }: PaginationProps) => {
+  const canGoPrevious = currentPage > 1;
+  const canGoNext = currentPage < totalPages;
+
+  const getVisiblePages = () => {
+    const delta = 2;
+    const range = [];
+    const rangeWithDots = [];
+
+    for (let i = Math.max(2, currentPage - delta); i <= Math.min(totalPages - 1, currentPage + delta); i++) {
+      range.push(i);
+    }
+
+    if (currentPage - delta > 2) {
+      rangeWithDots.push(1, '...');
+    } else {
+      rangeWithDots.push(1);
+    }
+
+    rangeWithDots.push(...range);
+
+    if (currentPage + delta < totalPages - 1) {
+      rangeWithDots.push('...', totalPages);
+    } else if (totalPages > 1) {
+      rangeWithDots.push(totalPages);
+    }
+
+    return rangeWithDots;
+  };
+
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  return (
+    <div className={cn('flex items-center justify-center space-x-2', className)}>
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={!canGoPrevious}
+        className={cn(
+          'flex h-10 items-center justify-center rounded-lg px-4 text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2563EB] focus-visible:ring-offset-2',
+          canGoPrevious
+            ? 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50 hover:border-gray-300'
+            : 'bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed'
+        )}
+      >
+        Prev
+      </button>
+
+      {getVisiblePages().map((page, index) => {
+        if (page === '...') {
+          return (
+            <span
+              key={`dots-${index}`}
+              className="flex h-10 w-10 items-center justify-center text-gray-500"
+            >
+              ...
+            </span>
+          );
+        }
+
+        const pageNumber = page as number;
+        const isCurrentPage = pageNumber === currentPage;
+
+        return (
+          <button
+            key={pageNumber}
+            onClick={() => onPageChange(pageNumber)}
+            className={cn(
+              'flex h-10 w-10 items-center justify-center rounded-lg text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+              isCurrentPage
+                ? 'bg-[#2563EB] text-white focus-visible:ring-[#3b82f6]'
+                : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50 hover:border-gray-300 focus-visible:ring-[#2563EB]'
+            )}
+          >
+            {pageNumber}
+          </button>
+        );
+      })}
+
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={!canGoNext}
+        className={cn(
+          'flex h-10 items-center justify-center rounded-lg px-4 text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#2563EB] focus-visible:ring-offset-2',
+          canGoNext
+            ? 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50 hover:border-gray-300'
+            : 'bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed'
+        )}
+      >
+        Next
+      </button>
+    </div>
+  );
+};
+
+export { Pagination };


### PR DESCRIPTION
● What was implemented:

Reusable Pagination component at frontend/components/ui/Pagination.tsx
Accepts currentPage, totalPages, and onPageChange callback props
Renders numbered page buttons with "Prev" and "Next" navigation
Smart pagination with ellipsis (...) for large page counts
Proper TypeScript interface for type safety
Tailwind CSS styling with hover states and disabled states
Follows existing UI component patterns in the codebase
Technical details:

Uses the same cn() utility and styling patterns as other UI components
Includes proper focus states and accessibility considerations
Returns null when there's only 1 or fewer pages
Handles edge cases for first/last page navigation
The component is now ready for reuse across pages where lists need pagination (users, assets, etc.).