### PR TITLE
Create-a-Reusable-Button

### DIFF
--- a/frontend/components/ui/genericButton.tsx
+++ b/frontend/components/ui/genericButton.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { ButtonHTMLAttributes } from 'react';
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+  size?: 'sm' | 'md' | 'lg';
+  disabled?: boolean;
+}
+
+const Button: React.FC<ButtonProps> = ({
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  className = '',
+  children,
+  ...props
+}) => {
+  const baseClasses = 'inline-flex items-center justify-center rounded-lg font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+
+  const variantClasses = {
+    primary: 'bg-blue-600 text-white hover:bg-blue-700 active:bg-blue-800 focus-visible:ring-blue-500',
+    secondary: 'bg-gray-100 text-gray-700 hover:bg-gray-200 active:bg-gray-300 focus-visible:ring-gray-400'
+  };
+
+  const sizeClasses = {
+    sm: 'h-8 px-3 text-sm',
+    md: 'h-10 px-4 text-sm',
+    lg: 'h-12 px-6 text-base'
+  };
+
+  const buttonClasses = `${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${className}`.trim();
+
+  return (
+    <button
+      className={buttonClasses}
+      disabled={disabled}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
close #243 

Created the Button component in components/ui/genericButton.tsx with:

  - [x] Props: variant (primary, secondary), size (sm, md, lg), and disabled
  - [x] Tailwind classes: Conditional styling based on variant and size
  - [x] TypeScript: Fully typed with React.FC<ButtonProps>
  - [x] Export: Exported as default export for reusability

  The component is simple, lightweight, and ready to use across your app for consistent button styling. 