### PR TITLE
FRONTEND: Implement Page Title Component

### DIFF
--- a/frontend/components/ui/PageTitle.tsx
+++ b/frontend/components/ui/PageTitle.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { cn } from '@/utils/cn';
+
+interface PageTitleProps {
+  title: string;
+  subtitle?: string;
+  className?: string;
+}
+
+export function PageTitle({ title, subtitle, className }: PageTitleProps) {
+  return (
+    <div className={cn('mb-6', className)}>
+      <h1 className="text-2xl font-semibold text-gray-900">{title}</h1>
+      {subtitle && (
+        <p className="mt-1 text-sm text-gray-600">{subtitle}</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
FRONTEND: Implement Page Title Component #269

Add a PageTitle component in components/ui/PageTitle.tsx:

    Accepts title and optional subtitle props
    Renders them with Tailwind (text-2xl font-semibold, etc.)
    Used across pages to provide consistent headers
