### PR TITLE
feat(auth): auto-initialize auth state on app startup

### DIFF
--- a/frontend/lib/hooks/useAuthInit.ts
+++ b/frontend/lib/hooks/useAuthInit.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAuthActions } from "../store/authStore";
+
+export const useAuthInit = () => {
+  const { initializeAuth } = useAuthActions();
+
+  useEffect(() => {
+    initializeAuth(); // loads token + user from storage into Zustand
+  }, [initializeAuth]);
+};

--- a/frontend/lib/store/authStore.ts
+++ b/frontend/lib/store/authStore.ts
@@ -222,13 +222,22 @@ export const useAuthState = () =>
     }))
   );
 
-export const useAuthActions = () =>
-  useAuthStore((state) => ({
-    login: state.login,
-    register: state.register,
-    logout: state.logout,
-    refreshAccessToken: state.refreshAccessToken,
-    updateProfile: state.updateProfile,
-    initializeAuth: state.initializeAuth,
-    clearAuth: state.clearAuth,
-  }));
+export const useAuthActions = () => {
+  const login = useAuthStore((state) => state.login);
+  const register = useAuthStore((state) => state.register);
+  const logout = useAuthStore((state) => state.logout);
+  const refreshAccessToken = useAuthStore((state) => state.refreshAccessToken);
+  const updateProfile = useAuthStore((state) => state.updateProfile);
+  const initializeAuth = useAuthStore((state) => state.initializeAuth);
+  const clearAuth = useAuthStore((state) => state.clearAuth);
+
+  return {
+    login,
+    register,
+    logout,
+    refreshAccessToken,
+    updateProfile,
+    initializeAuth,
+    clearAuth,
+  };
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1503,12 +1503,8 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
-<<<<<<< HEAD
       "devOptional": true,
-=======
-      "dev": true,
       "license": "MIT",
->>>>>>> 546cc27cb082af3eb64d98c18337226b907c759f
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }

--- a/frontend/providers/Providers.tsx
+++ b/frontend/providers/Providers.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { ThemeProvider } from 'next-themes';
+import { ThemeProvider } from "next-themes";
 import ReactQueryProvider from "./ReactQueryProvider";
+import { AuthInitializerProvider } from "./authInitializer"; // import the new provider
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
-      <ReactQueryProvider>{children}</ReactQueryProvider>
+      <ReactQueryProvider>
+        <AuthInitializerProvider>{children}</AuthInitializerProvider>
+      </ReactQueryProvider>
     </ThemeProvider>
   );
 }

--- a/frontend/providers/authInitializer.tsx
+++ b/frontend/providers/authInitializer.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { useAuthInit } from "@/lib/hooks/useAuthInit";
+import { ReactNode } from "react";
+
+interface AuthInitializerProviderProps {
+  children: ReactNode;
+}
+
+export const AuthInitializerProvider = ({
+  children,
+}: AuthInitializerProviderProps) => {
+  useAuthInit(); // triggers auth initialization on mount
+
+  return <>{children}</>; // renders nothing extra
+};


### PR DESCRIPTION
- Created `useAuthInit` hook to load token + user from localStorage into Zustand
- Added `AuthInitializerProvider` to wrap app children and run auth initialization
- Updated main `Providers` to include `AuthInitializerProvider` inside `ReactQueryProvider`
- Ensures logged-in users are restored automatically without extra UI