### PR TITLE
feat: Implemented admin creation endpoint

### DIFF
--- a/backend/src/users/dto/createUser.dto.ts
+++ b/backend/src/users/dto/createUser.dto.ts
@@ -1,5 +1,6 @@
-import { IsString, IsEmail, IsOptional, MinLength, MaxLength, Matches, IsNotEmpty } from 'class-validator';
+import { IsString, IsEmail, IsOptional, MinLength, MaxLength, Matches, IsNotEmpty, IsEnum } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { UserRole } from '../enums/userRoles.enum'; // import your enum
 
 export class CreateUserDto {
   @ApiProperty({ minLength: 1, maxLength: 30 })
@@ -38,4 +39,9 @@ export class CreateUserDto {
     message: 'Password must contain at least one lowercase letter, one uppercase letter, one number, and one special character (@$!%*?&-_.).',
   })
   password: string;
+
+  @ApiPropertyOptional({ enum: UserRole, default: UserRole.USER })
+  @IsOptional()
+  @IsEnum(UserRole)
+  role?: UserRole;
 }


### PR DESCRIPTION
# PR Title
**Implement Admin Registration and Authentication via Users Module**

## Description
This PR introduces the ability to create and authenticate admin users using the existing Users module. Instead of a separate Admin module, admin creation is handled through the `auth/register` endpoint by specifying the `role` as `admin`.

## Reasoning
To reduce code duplication and simplify user management, admin creation reuses the existing user registration flow. This ensures consistency in validation, password hashing, token generation, and refresh token handling, while keeping all authentication logic in one place.

## Key Changes
1. **Admin Role Support**
   - `CreateUserDto` updated to accept `role` (`user` | `admin`).  
   - UsersService now supports creation of users with the `admin` role.

2. **Authentication**
   - Admin users can log in via the existing `/auth/login` endpoint.  
   - Reuses `LoginUserProvider` for token generation, refresh token handling, and cookie setup.

3. **Database**
   - Admin users are stored in the `users` table with `role = 'admin'`. No separate admin table needed.

4. **Validation & Security**
   - Passwords are hashed using bcrypt before being saved to the database.  
   - Existing `LocalAuthGuard` and JWT strategy work seamlessly for admins.

5. **Testing**
   - Admin registration via:
   ```bash
   curl -X POST http://127.0.0.1:6000/auth/register \
     -H "Content-Type: application/json" \
     -d '{"firstname":"John","lastname":"Doe","email":"john.doe@example.com","password":"Password123!","role":"admin"}'

## Screenshot
<img width="1094" height="404" alt="image" src="https://github.com/user-attachments/assets/9358fcbc-a186-4b0e-8512-259332cddefd" />

