### PR TITLE
feat(asset-disposals): add asset disposal module

### DIFF
--- a/backend/src/asset-disposals/asset-disposals.controller.ts
+++ b/backend/src/asset-disposals/asset-disposals.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Post, Body } from '@nestjs/common';
+import { AssetDisposalsService } from './asset-disposals.service';
+import { CreateAssetDisposalDto } from './dto/create-asset-disposal.dto';
+import { ApiTags, ApiCreatedResponse } from '@nestjs/swagger';
+
+@ApiTags('asset-disposals')
+@Controller('api/v1/asset-disposals')
+export class AssetDisposalsController {
+  constructor(private readonly service: AssetDisposalsService) {}
+
+  @Post()
+  @ApiCreatedResponse({ description: 'Asset marked as disposed' })
+  dispose(@Body() dto: CreateAssetDisposalDto) {
+    return this.service.disposeAsset(dto);
+  }
+}

--- a/backend/src/asset-disposals/asset-disposals.module.ts
+++ b/backend/src/asset-disposals/asset-disposals.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AssetDisposalsService } from './asset-disposals.service';
+import { AssetDisposalsController } from './asset-disposals.controller';
+import { AssetDisposal } from './entities/asset-disposal.entity';
+import { Asset } from 'src/assets/assets.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AssetDisposal, Asset])],
+  controllers: [AssetDisposalsController],
+  providers: [AssetDisposalsService],
+})
+export class AssetDisposalsModule {}

--- a/backend/src/asset-disposals/asset-disposals.service.ts
+++ b/backend/src/asset-disposals/asset-disposals.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AssetDisposal } from './entities/asset-disposal.entity';
+import { CreateAssetDisposalDto } from './dto/create-asset-disposal.dto';
+import { Asset } from 'src/assets/assets.entity';
+
+@Injectable()
+export class AssetDisposalsService {
+  constructor(
+    @InjectRepository(AssetDisposal)
+    private disposalRepo: Repository<AssetDisposal>,
+    @InjectRepository(Asset)
+    private assetRepo: Repository<Asset>,
+  ) {}
+
+  async disposeAsset(dto: CreateAssetDisposalDto): Promise<AssetDisposal> {
+    const asset = await this.assetRepo.findOne({ where: { id: Number(dto.assetId) } });
+
+    if (!asset) throw new NotFoundException('Asset not found');
+    if (asset.status === 'disposed')
+      throw new BadRequestException('Asset already disposed');
+
+    // Create disposal record
+    const disposal = this.disposalRepo.create({
+      disposalDate: new Date(dto.disposalDate),
+      method: dto.method,
+      reason: dto.reason,
+      approvedBy: dto.approvedBy,
+    });
+    await this.disposalRepo.save(disposal);
+
+    // Update asset status
+    asset.status = 'disposed';
+    await this.assetRepo.save(asset);
+
+    return disposal;
+  }
+}

--- a/backend/src/asset-disposals/dto/create-asset-disposal.dto.ts
+++ b/backend/src/asset-disposals/dto/create-asset-disposal.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, IsUUID, IsDateString } from 'class-validator';
+
+export class CreateAssetDisposalDto {
+  @IsUUID()
+  assetId: string;
+
+  @IsDateString()
+  disposalDate: string;
+
+  @IsString()
+  method: string;
+
+  @IsString()
+  reason: string;
+
+  @IsString()
+  approvedBy: string;
+}

--- a/backend/src/asset-disposals/entities/asset-disposal.entity.ts
+++ b/backend/src/asset-disposals/entities/asset-disposal.entity.ts
@@ -1,0 +1,37 @@
+import { Asset } from 'src/assets/assets.entity';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from 'typeorm';
+
+@Entity('asset_disposals')
+export class AssetDisposal {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Asset, (asset) => asset.disposals, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'assetId' })
+  asset: Asset;
+
+  @Column()
+  assetId: string;
+
+  @Column({ type: 'date' })
+  disposalDate: Date;
+
+  @Column({ type: 'varchar', length: 50 })
+  method: string; // e.g., sale, donation, scrap
+
+  @Column({ type: 'text' })
+  reason: string;
+
+  @Column({ type: 'varchar', length: 100 })
+  approvedBy: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/assets/assets.entity.ts
+++ b/backend/src/assets/assets.entity.ts
@@ -1,5 +1,6 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany } from 'typeorm';
 import { Supplier } from '../suppliers/suppliers.entity';
+import { AssetDisposal } from 'src/asset-disposals/entities/asset-disposal.entity';
 
 @Entity('assets')
 export class Asset {
@@ -14,4 +15,10 @@ export class Asset {
 
   @ManyToOne(() => Supplier, supplier => supplier.assets)
   supplier: Supplier;
+
+  @OneToMany(() => AssetDisposal, (disposal) => disposal.asset)
+  disposals: AssetDisposal[];
+
+  @Column({ default: 'active' })
+  status: 'active' | 'disposed';
 }

--- a/backend/src/assets/assets.service.ts
+++ b/backend/src/assets/assets.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { Asset } from "./assets.entity";
+
+@Injectable()
+export class AssetService {
+constructor(
+    @InjectRepository(Asset)
+    private assetRepo: Repository<Asset>,
+) {}
+
+async findActive() {
+  return this.assetRepo.find({ where: { status: 'active' } });
+}
+}


### PR DESCRIPTION
### Summary
Implements the Asset Disposals module for managing retirement of assets.

closses issue #319 

### Details
- New table `asset_disposals` with fields (assetId, disposalDate, method, reason, approvedBy).
- Added DTO validation (UUID, string, date).
- Service logic:
  - Records disposal entry.
  - Updates asset status to 'disposed'.
- Controller endpoint: POST /api/v1/asset-disposals.
- Modified asset queries to exclude disposed assets.

### Acceptance Criteria
- [x] Disposed assets no longer returned in active asset queries.
- [x] Disposal requires valid input and approvedBy.
- [x] Swagger shows new endpoint.
