### PR TITLE
implemented the file upload module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -8,6 +8,7 @@ import { UsersModule } from './users/users.module';
 import { EmailModule } from './email/email.module';
 import { NewsletterModule } from './newsletter/newsletter.module';
 import { AssetAuditsModule } from './asset-audits/asset-audits.module';
+import { FileUploadsModule } from './file-uploads/file-uploads.module';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtAuthGuard } from './auth/guards/jwt.guard';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
@@ -67,6 +68,7 @@ import { CountriesCurrenciesModule } from './countries-currencies/countries-curr
     InventoryItemsModule,
     CountriesCurrenciesModule,
     AssetAuditsModule,
+    FileUploadsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/assets/assets.controller.ts
+++ b/backend/src/assets/assets.controller.ts
@@ -1,0 +1,29 @@
+import {
+  Controller,
+  Post,
+  Param,
+  UseInterceptors,
+  UploadedFile,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { multerOptions } from '../file-uploads/multer.provider';
+import { FileUploadsService } from '../file-uploads/file-uploads.service';
+import { AssetsService } from './assets.service';
+
+@Controller('assets')
+export class AssetsController {
+  constructor(
+    private readonly assetsService: AssetsService,
+    private readonly fileUploadsService: FileUploadsService,
+  ) {}
+
+  @Post(':id/uploads')
+  @UseInterceptors(FileInterceptor('file', multerOptions))
+  async uploadForAsset(
+    @Param('id') id: string,
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    const dto = { relatedType: 'asset', relatedId: id };
+    return this.fileUploadsService.create(file, dto as any);
+  }
+}

--- a/backend/src/assets/assets.module.ts
+++ b/backend/src/assets/assets.module.ts
@@ -2,10 +2,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Module } from '@nestjs/common';
 import { Asset } from './assets.entity';
 import { AssetsService } from './assets.service';
+import { AssetsController } from './assets.controller';
+import { FileUploadsService } from '../file-uploads/file-uploads.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Asset])],
-  providers: [AssetsService],
+  providers: [AssetsService, FileUploadsService],
+  controllers: [AssetsController],
   exports: [AssetsService], // Export AssetsService
 })
 export class AssetsModule {}

--- a/backend/src/file-uploads/dto/create-file-upload.dto.ts
+++ b/backend/src/file-uploads/dto/create-file-upload.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class CreateFileUploadDto {
+  @IsOptional()
+  @IsString()
+  relatedType?: string;
+
+  @IsOptional()
+  @IsString()
+  relatedId?: string;
+}

--- a/backend/src/file-uploads/dto/link-file.dto.ts
+++ b/backend/src/file-uploads/dto/link-file.dto.ts
@@ -1,0 +1,11 @@
+import { IsString, IsUUID, IsOptional } from 'class-validator';
+
+export class LinkFileDto {
+  @IsOptional()
+  @IsString()
+  relatedType?: string;
+
+  @IsOptional()
+  @IsUUID()
+  relatedId?: string;
+}

--- a/backend/src/file-uploads/dto/update-file-upload.dto.ts
+++ b/backend/src/file-uploads/dto/update-file-upload.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateFileUploadDto {
+  @IsOptional()
+  @IsString()
+  relatedType?: string;
+
+  @IsOptional()
+  @IsString()
+  relatedId?: string;
+}

--- a/backend/src/file-uploads/file-uploads.controller.ts
+++ b/backend/src/file-uploads/file-uploads.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Controller,
+  Post,
+  UseInterceptors,
+  UploadedFile,
+  Body,
+  Get,
+  Param,
+  Delete,
+  HttpCode,
+  HttpStatus,
+  Patch,
+} from '@nestjs/common';
+import { FileUploadsService } from './file-uploads.service';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { multerOptions } from './multer.provider';
+import { CreateFileUploadDto } from './dto/create-file-upload.dto';
+
+@Controller('file-uploads')
+export class FileUploadsController {
+  constructor(private readonly service: FileUploadsService) {}
+
+  @Post()
+  @UseInterceptors(FileInterceptor('file', multerOptions))
+  async upload(
+    @UploadedFile() file: Express.Multer.File,
+    @Body() dto: CreateFileUploadDto,
+  ) {
+    return this.service.create(file, dto);
+  }
+
+  @Get(':id')
+  async getOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Patch(':id/link')
+  async link(
+    @Param('id') id: string,
+    @Body() dto: import('./dto/link-file.dto').LinkFileDto,
+  ) {
+    return this.service.link(id, dto.relatedType, dto.relatedId);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Param('id') id: string) {
+    await this.service.remove(id);
+  }
+}

--- a/backend/src/file-uploads/file-uploads.entity.ts
+++ b/backend/src/file-uploads/file-uploads.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  DeleteDateColumn,
+} from 'typeorm';
+
+@Entity('file_uploads')
+export class FileUpload {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  filename: string;
+
+  @Column()
+  originalName: string;
+
+  @Column()
+  mimeType: string;
+
+  @Column('bigint')
+  size: number;
+
+  // either local path or remote url
+  @Column({ nullable: true })
+  path?: string;
+
+  // linkable entity type: 'asset' | 'supplier' | etc.
+  @Column({ nullable: true })
+  relatedType?: string;
+
+  // id of related entity
+  @Column({ nullable: true })
+  relatedId?: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt?: Date;
+}

--- a/backend/src/file-uploads/file-uploads.module.ts
+++ b/backend/src/file-uploads/file-uploads.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FileUpload } from './file-uploads.entity';
+import { FileUploadsService } from './file-uploads.service';
+import { FileUploadsController } from './file-uploads.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([FileUpload])],
+  providers: [FileUploadsService],
+  controllers: [FileUploadsController],
+  exports: [FileUploadsService],
+})
+export class FileUploadsModule {}

--- a/backend/src/file-uploads/file-uploads.service.ts
+++ b/backend/src/file-uploads/file-uploads.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { FileUpload } from './file-uploads.entity';
+import { CreateFileUploadDto } from './dto/create-file-upload.dto';
+
+@Injectable()
+export class FileUploadsService {
+  constructor(
+    @InjectRepository(FileUpload)
+    private readonly repo: Repository<FileUpload>,
+  ) {}
+
+  async create(file: Express.Multer.File, dto: CreateFileUploadDto) {
+    const entity = this.repo.create({
+      filename: file.filename,
+      originalName: file.originalname,
+      mimeType: file.mimetype,
+      size: file.size,
+      path: (file as any).path || (file as any).location || null,
+      relatedType: dto.relatedType,
+      relatedId: dto.relatedId,
+    });
+
+    return this.repo.save(entity);
+  }
+
+  async findOne(id: string) {
+    const file = await this.repo.findOne({ where: { id } });
+    if (!file) throw new NotFoundException('File not found');
+    return file;
+  }
+
+  async remove(id: string) {
+    const file = await this.findOne(id);
+    return this.repo.remove(file);
+  }
+
+  async link(id: string, relatedType?: string, relatedId?: string) {
+    const file = await this.findOne(id);
+    file.relatedType = relatedType ?? file.relatedType;
+    file.relatedId = relatedId ?? file.relatedId;
+    return this.repo.save(file);
+  }
+}

--- a/backend/src/file-uploads/multer.provider.ts
+++ b/backend/src/file-uploads/multer.provider.ts
@@ -1,0 +1,26 @@
+import { diskStorage } from 'multer';
+import { extname } from 'path';
+
+export const multerOptions = {
+  storage: diskStorage({
+    destination: './uploads',
+    filename: (req, file, cb) => {
+      const safeName = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+      const fileExt = extname(file.originalname);
+      cb(null, safeName + fileExt);
+    },
+  }),
+  limits: {
+    fileSize: 10 * 1024 * 1024, // 10MB
+  },
+  fileFilter: (req, file, cb) => {
+    // accept common document and image types
+    const allowed = /jpeg|jpg|png|pdf|doc|docx|xls|xlsx|txt/;
+    const ext = extname(file.originalname).toLowerCase();
+    if (allowed.test(ext) || allowed.test(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error('Unsupported file type'), false);
+    }
+  },
+};

--- a/backend/src/migrations/1729000000000-CreateFileUploadsTable.ts
+++ b/backend/src/migrations/1729000000000-CreateFileUploadsTable.ts
@@ -1,0 +1,69 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateFileUploadsTable1729000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'file_uploads',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            default: 'uuid_generate_v4()',
+          },
+          {
+            name: 'filename',
+            type: 'varchar',
+          },
+          {
+            name: 'originalName',
+            type: 'varchar',
+          },
+          {
+            name: 'mimeType',
+            type: 'varchar',
+          },
+          {
+            name: 'size',
+            type: 'bigint',
+          },
+          {
+            name: 'path',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'relatedType',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
+            name: 'relatedId',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'createdAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'updatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'deletedAt',
+            type: 'timestamp',
+            isNullable: true,
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('file_uploads');
+  }
+}

--- a/backend/src/suppliers/suppliers.controller.ts
+++ b/backend/src/suppliers/suppliers.controller.ts
@@ -1,6 +1,20 @@
 // ...existing code...
 // ...existing code...
-import { Controller, Get, Post, Body, Patch, Param, Delete, Query } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Query,
+  UseInterceptors,
+  UploadedFile,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { multerOptions } from '../file-uploads/multer.provider';
+import { FileUploadsService } from '../file-uploads/file-uploads.service';
 import { SuppliersService } from './suppliers.service';
 import { CreateSupplierDto } from './dto/create-supplier.dto';
 import { UpdateSupplierDto } from './dto/update-supplier.dto';
@@ -9,7 +23,10 @@ import { AssignAssetDto } from './dto/assign-asset.dto';
 
 @Controller('suppliers')
 export class SuppliersController {
-  constructor(private readonly suppliersService: SuppliersService) {}
+  constructor(
+    private readonly suppliersService: SuppliersService,
+    private readonly fileUploadsService: FileUploadsService,
+  ) {}
 
   @Post()
   create(@Body() createSupplierDto: CreateSupplierDto) {
@@ -20,15 +37,31 @@ export class SuppliersController {
   findAll(@Query() query: QuerySupplierDto) {
     return this.suppliersService.findAll(query);
   }
-  
   @Post('assign-asset')
   assignAsset(@Body() assignAssetDto: AssignAssetDto) {
-    return this.suppliersService.assignAsset(assignAssetDto.supplierId, assignAssetDto.assetId);
+    return this.suppliersService.assignAsset(
+      assignAssetDto.supplierId,
+      assignAssetDto.assetId,
+    );
   }
 
   @Post('unassign-asset')
   unassignAsset(@Body() assignAssetDto: AssignAssetDto) {
-    return this.suppliersService.unassignAsset(assignAssetDto.supplierId, assignAssetDto.assetId);
+    return this.suppliersService.unassignAsset(
+      assignAssetDto.supplierId,
+      assignAssetDto.assetId,
+    );
+  }
+
+  @Post(':id/uploads')
+  @UseInterceptors(FileInterceptor('file', multerOptions))
+  async uploadForSupplier(
+    @Param('id') id: string,
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    // create a file upload record and link to this supplier
+    const dto = { relatedType: 'supplier', relatedId: id };
+    return this.fileUploadsService.create(file, dto as any);
   }
 
   @Get(':id')
@@ -37,7 +70,10 @@ export class SuppliersController {
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateSupplierDto: UpdateSupplierDto) {
+  update(
+    @Param('id') id: string,
+    @Body() updateSupplierDto: UpdateSupplierDto,
+  ) {
     return this.suppliersService.update(+id, updateSupplierDto);
   }
 

--- a/backend/src/suppliers/suppliers.module.ts
+++ b/backend/src/suppliers/suppliers.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { SuppliersService } from './suppliers.service';
 import { SuppliersController } from './suppliers.controller';
+import { FileUploadsService } from '../file-uploads/file-uploads.service';
 import { Supplier } from './suppliers.entity';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Supplier])],
   controllers: [SuppliersController],
-  providers: [SuppliersService],
+  providers: [SuppliersService, FileUploadsService],
 })
 export class SuppliersModule {}


### PR DESCRIPTION
this closes 330.

Added file uploads support: new `file-uploads` Nest module (entity, DTOs, service, controller, multer provider), local disk storage under uploads, and a TypeORM migration for `file_uploads`. Implemented endpoints to upload/link files and metadata:
- POST /file-uploads (multipart) — store file + metadata
- GET /file-uploads/:id, DELETE /file-uploads/:id
- POST /assets/:id/uploads and POST /suppliers/:id/uploads — convenience endpoints that attach uploads to asset/supplier

Files of interest:
- src/file-uploads/* (entity, DTOs, service, controller, multer.provider, module)
- 1729000000000-CreateFileUploadsTable.ts
- src/assets/assets.controller.ts, suppliers.controller.ts (upload routes)
- added backend/uploads/ directory
