### PR TITLE
feat(settings): implement system-wide settings module with CRUD APIs

### DIFF
--- a/backend/src/settings/dto/create-setting.dto.ts
+++ b/backend/src/settings/dto/create-setting.dto.ts
@@ -1,0 +1,16 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class CreateSettingDto {
+  @IsOptional()
+  @IsString()
+  defaultCurrency?: string;
+
+  @IsOptional()
+  @IsString()
+  timezone?: string;
+
+  @IsOptional()
+  @IsString()
+  depreciationMethod?: string;
+}
+

--- a/backend/src/settings/dto/update-setting.dto.ts
+++ b/backend/src/settings/dto/update-setting.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateSettingDto } from './create-setting.dto';
+
+export class UpdateSettingDto extends PartialType(CreateSettingDto) {}

--- a/backend/src/settings/entities/setting.entity.ts
+++ b/backend/src/settings/entities/setting.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('settings')
+export class Setting {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ default: 'USD' })
+  defaultCurrency: string;
+
+  @Column({ default: 'UTC' })
+  timezone: string;
+
+  @Column({ default: 'straight_line' })
+  depreciationMethod: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/settings/settings.controller.ts
+++ b/backend/src/settings/settings.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import { SettingsService } from './settings.service';
+import { CreateSettingDto } from './dto/create-setting.dto';
+import { UpdateSettingDto } from './dto/update-setting.dto';
+
+@Controller('settings')
+export class SettingsController {
+  constructor(private readonly settingsService: SettingsService) {}
+
+  @Post()
+  create(@Body() dto: CreateSettingDto) {
+    return this.settingsService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.settingsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.settingsService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateSettingDto) {
+    return this.settingsService.update(id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.settingsService.remove(id);
+  }
+}

--- a/backend/src/settings/settings.module.ts
+++ b/backend/src/settings/settings.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SettingsService } from './settings.service';
+import { SettingsController } from './settings.controller';
+import { Setting } from './entities/setting.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Setting])],
+  controllers: [SettingsController],
+  providers: [SettingsService],
+  exports: [SettingsService],
+})
+export class SettingsModule {}

--- a/backend/src/settings/settings.service.ts
+++ b/backend/src/settings/settings.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Setting } from './entities/setting.entity';
+import { CreateSettingDto } from './dto/create-setting.dto';
+import { UpdateSettingDto } from './dto/update-setting.dto';
+
+@Injectable()
+export class SettingsService {
+  constructor(
+    @InjectRepository(Setting)
+    private readonly settingsRepo: Repository<Setting>,
+  ) {}
+
+  async create(dto: CreateSettingDto): Promise<Setting> {
+    const setting = this.settingsRepo.create(dto);
+    return this.settingsRepo.save(setting);
+  }
+
+  async findAll(): Promise<Setting[]> {
+    return this.settingsRepo.find();
+  }
+
+  async findOne(id: string): Promise<Setting> {
+    const setting = await this.settingsRepo.findOne({ where: { id } });
+    if (!setting) throw new NotFoundException(`Setting with id ${id} not found`);
+    return setting;
+  }
+
+  async update(id: string, dto: UpdateSettingDto): Promise<Setting> {
+    const setting = await this.findOne(id);
+    Object.assign(setting, dto);
+    return this.settingsRepo.save(setting);
+  }
+
+  async remove(id: string): Promise<void> {
+    const setting = await this.findOne(id);
+    await this.settingsRepo.remove(setting);
+  }
+}


### PR DESCRIPTION
### Overview
This PR introduces a **Settings Module** to manage system-wide configurations at the company level.  
It includes entity definitions, DTOs, service, controller, and module setup with CRUD support.

---

### 🔨 Changes Introduced
- **Entity:** `Setting` with fields:
  - `defaultCurrency` (default: USD)  
  - `timezone` (default: UTC)  
  - `depreciationMethod` (default: straight_line)  
- **DTOs:** `CreateSettingDto` & `UpdateSettingDto` with validation rules  
- **Service:** CRUD methods (`create`, `findAll`, `findOne`, `update`, `remove`)  
- **Controller:** REST endpoints for managing settings  
- **Module:** Registered `SettingsModule` with `TypeOrmModule` integration  

---

### 📡 Endpoints
| Method | Endpoint         | Description             |
|--------|-----------------|-------------------------|
| POST   | `/settings`     | Create a new setting    |
| GET    | `/settings`     | Retrieve all settings   |
| GET    | `/settings/:id` | Retrieve a setting by id|
| PATCH  | `/settings/:id` | Update a setting        |
| DELETE | `/settings/:id` | Remove a setting        |

---

### ✅ Notes
- Validated with `class-validator` decorators  
- Supports extension for additional system-wide configuration fields  
- Exported `SettingsService` for reuse in other modules if needed  

---

### 🎯 Next Steps
- Add authentication/authorization (e.g., admin-only access)  
- Seed default system setting on fresh installation  

---
### Closing
closes #335 