### PR TITLE
feat(contracts): tighten token fractionalization rules (#508)

### DIFF
--- a/contracts/manage_hub/src/fractionalization.rs
+++ b/contracts/manage_hub/src/fractionalization.rs
@@ -88,6 +88,9 @@ impl FractionalizationModule {
         if share_amount < info.min_fraction_size {
             return Err(Error::InvalidPaymentAmount);
         }
+        if share_amount % info.min_fraction_size != 0 {
+            return Err(Error::InvalidPaymentAmount);
+        }
 
         from.require_auth();
 


### PR DESCRIPTION
## Summary

  - Implemented and tightened token fractionalization behavior in manage_hub contracts.
  - Enforced minimum fraction granularity during transfers (share_amount must be a multiple of min_fraction_size).
  - Added regression tests for:
      - Invalid min_fraction_size configuration.
      - Invalid transfer amounts that violate fraction granularity.
  - Verified full contract test suite passes.

  ## Files Updated

  - contracts/manage_hub/src/fractionalization.rs
  - contracts/manage_hub/src/test.rs

  ## Validation

  - cargo test -p manage_hub (57 passed)

  Closes https://github.com/DistinctCodes/ManageHub/issues/506