### PR TITLE
feat(contracts): add token upgrade mechanism (issue #507)

### DIFF
--- a/contracts/manage_hub/src/membership_token.rs
+++ b/contracts/manage_hub/src/membership_token.rs
@@ -24,6 +24,12 @@ pub enum DataKey {
     EmergencyPauseState,
     /// Per-token pause state (persistent storage keyed by token ID).
     TokenPaused(BytesN<32>),
+    /// Global upgrade configuration (instance storage).
+    UpgradeConfig,
+    /// Upgrade history list for a token (persistent storage keyed by token ID).
+    UpgradeHistory(BytesN<32>),
+    /// Version snapshot for rollback, keyed by token ID and version number.
+    VersionSnapshot(BytesN<32>, u32),
 }
 
 #[contracttype]
@@ -44,6 +50,8 @@ pub struct MembershipToken {
     pub renewal_attempts: u32,
     /// Timestamp of last renewal attempt
     pub last_renewal_attempt_at: Option<u64>,
+    /// Current version number of this token (starts at 0, increments on each upgrade)
+    pub current_version: u32,
 }
 
 pub struct MembershipTokenContract;
@@ -89,6 +97,7 @@ impl MembershipTokenContract {
             grace_period_expires_at: None,
             renewal_attempts: 0,
             last_renewal_attempt_at: None,
+            current_version: 0,
         };
         env.storage()
             .persistent()

--- a/contracts/manage_hub/src/migration.rs
+++ b/contracts/manage_hub/src/migration.rs
@@ -1,0 +1,159 @@
+//! Migration helpers for token upgrade data transformation.
+//!
+//! This module provides utilities to migrate token state when upgrading between
+//! versions. Migrations preserve token identity (id, user, issue_date) while
+//! allowing modifications to mutable fields (expiry_date, tier_id, status).
+
+use crate::membership_token::{DataKey, MembershipToken};
+use crate::types::{MembershipStatus, TokenVersionSnapshot, UpgradeRecord};
+use soroban_sdk::{Address, BytesN, Env, String, Vec};
+
+pub struct MigrationModule;
+
+impl MigrationModule {
+    /// Capture a snapshot of the token's current state for rollback purposes.
+    ///
+    /// Must be called **before** mutating the token so the snapshot reflects
+    /// the pre-upgrade state.
+    pub fn capture_snapshot(
+        env: &Env,
+        token: &MembershipToken,
+        label: Option<String>,
+    ) -> TokenVersionSnapshot {
+        TokenVersionSnapshot {
+            version: token.current_version,
+            expiry_date: token.expiry_date,
+            status: token.status.clone(),
+            tier_id: token.tier_id.clone(),
+            captured_at: env.ledger().timestamp(),
+            label,
+        }
+    }
+
+    /// Persist a version snapshot to storage.
+    pub fn store_snapshot(env: &Env, token_id: &BytesN<32>, snapshot: &TokenVersionSnapshot) {
+        env.storage().persistent().set(
+            &DataKey::VersionSnapshot(token_id.clone(), snapshot.version),
+            snapshot,
+        );
+    }
+
+    /// Retrieve a version snapshot from storage, if it exists.
+    pub fn get_snapshot(
+        env: &Env,
+        token_id: &BytesN<32>,
+        version: u32,
+    ) -> Option<TokenVersionSnapshot> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::VersionSnapshot(token_id.clone(), version))
+    }
+
+    /// Append an upgrade record to the token's history.
+    pub fn record_upgrade(env: &Env, record: &UpgradeRecord) {
+        let key = DataKey::UpgradeHistory(record.token_id.clone());
+        let mut history: Vec<UpgradeRecord> = env
+            .storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or_else(|| Vec::new(env));
+        history.push_back(record.clone());
+        env.storage().persistent().set(&key, &history);
+    }
+
+    /// Return the full upgrade history for a token.
+    pub fn get_upgrade_history(env: &Env, token_id: &BytesN<32>) -> Vec<UpgradeRecord> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::UpgradeHistory(token_id.clone()))
+            .unwrap_or_else(|| Vec::new(env))
+    }
+
+    /// Count how many rollbacks have already occurred for a token.
+    ///
+    /// A rollback is any `UpgradeRecord` where `is_rollback == true`.
+    pub fn count_rollbacks(env: &Env, token_id: &BytesN<32>) -> u32 {
+        let history = Self::get_upgrade_history(env, token_id);
+        let mut count: u32 = 0;
+        for record in history.iter() {
+            if record.is_rollback {
+                count += 1;
+            }
+        }
+        count
+    }
+
+    /// Apply a snapshot to a token, restoring it to a previous version's state.
+    ///
+    /// Identity fields (id, user, issue_date, renewal_attempts) are preserved.
+    /// The version number is NOT reverted — it continues to increment so history
+    /// is never lost.
+    pub fn apply_snapshot_to_token(
+        token: &MembershipToken,
+        snapshot: &TokenVersionSnapshot,
+        new_version: u32,
+        rollback_label: Option<String>,
+    ) -> MembershipToken {
+        let _ = rollback_label; // label is stored in UpgradeRecord, not the token itself
+        MembershipToken {
+            id: token.id.clone(),
+            user: token.user.clone(),
+            status: snapshot.status.clone(),
+            issue_date: token.issue_date,
+            expiry_date: snapshot.expiry_date,
+            tier_id: snapshot.tier_id.clone(),
+            grace_period_entered_at: token.grace_period_entered_at,
+            grace_period_expires_at: token.grace_period_expires_at,
+            renewal_attempts: token.renewal_attempts,
+            last_renewal_attempt_at: token.last_renewal_attempt_at,
+            current_version: new_version,
+        }
+    }
+
+    /// Migrate a token's mutable fields to a new version.
+    ///
+    /// Only the fields provided as `Some(...)` are updated; `None` means "keep
+    /// existing value". Returns the updated token (caller must persist it).
+    pub fn migrate_token_fields(
+        token: &MembershipToken,
+        new_version: u32,
+        new_expiry_date: Option<u64>,
+        new_tier_id: Option<Option<String>>,
+        new_status: Option<MembershipStatus>,
+    ) -> MembershipToken {
+        MembershipToken {
+            id: token.id.clone(),
+            user: token.user.clone(),
+            status: new_status.unwrap_or_else(|| token.status.clone()),
+            issue_date: token.issue_date,
+            expiry_date: new_expiry_date.unwrap_or(token.expiry_date),
+            tier_id: new_tier_id.unwrap_or_else(|| token.tier_id.clone()),
+            grace_period_entered_at: token.grace_period_entered_at,
+            grace_period_expires_at: token.grace_period_expires_at,
+            renewal_attempts: token.renewal_attempts,
+            last_renewal_attempt_at: token.last_renewal_attempt_at,
+            current_version: new_version,
+        }
+    }
+
+    /// Build an `UpgradeRecord` for a successful upgrade or rollback.
+    pub fn build_record(
+        env: &Env,
+        token_id: BytesN<32>,
+        from_version: u32,
+        to_version: u32,
+        upgraded_by: Address,
+        label: Option<String>,
+        is_rollback: bool,
+    ) -> UpgradeRecord {
+        UpgradeRecord {
+            token_id,
+            from_version,
+            to_version,
+            upgraded_by,
+            upgraded_at: env.ledger().timestamp(),
+            label,
+            is_rollback,
+        }
+    }
+}

--- a/contracts/manage_hub/src/types.rs
+++ b/contracts/manage_hub/src/types.rs
@@ -414,6 +414,72 @@ pub struct StakingConfig {
 }
 
 // ============================================================================
+// Token Upgrade Types
+// ============================================================================
+
+/// Configuration for the token upgrade system.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct UpgradeConfig {
+    /// Whether token upgrades are currently enabled
+    pub upgrades_enabled: bool,
+    /// Whether only the admin can trigger upgrades (false = token owner can also upgrade)
+    pub admin_only: bool,
+    /// Maximum number of rollbacks allowed per token (0 = unlimited)
+    pub max_rollbacks: u32,
+}
+
+/// A snapshot of a token's version state, stored for rollback purposes.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct TokenVersionSnapshot {
+    /// The version number this snapshot represents
+    pub version: u32,
+    /// Token expiry date at this version
+    pub expiry_date: u64,
+    /// Token status at this version
+    pub status: MembershipStatus,
+    /// Tier ID at this version
+    pub tier_id: Option<String>,
+    /// Timestamp when this snapshot was taken
+    pub captured_at: u64,
+    /// Human-readable label for this version (e.g. "v1", "v2-enhanced")
+    pub label: Option<String>,
+}
+
+/// A single entry in a token's upgrade history.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct UpgradeRecord {
+    /// Token ID that was upgraded
+    pub token_id: BytesN<32>,
+    /// Version before the upgrade
+    pub from_version: u32,
+    /// Version after the upgrade
+    pub to_version: u32,
+    /// Address that triggered the upgrade
+    pub upgraded_by: Address,
+    /// Timestamp of the upgrade
+    pub upgraded_at: u64,
+    /// Human-readable label for the new version
+    pub label: Option<String>,
+    /// Whether this was a rollback operation
+    pub is_rollback: bool,
+}
+
+/// Result for a single token in a batch upgrade operation.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct BatchUpgradeResult {
+    /// Token ID that was processed
+    pub token_id: BytesN<32>,
+    /// Whether the upgrade succeeded
+    pub success: bool,
+    /// New version number (if success)
+    pub new_version: Option<u32>,
+}
+
+// ============================================================================
 // Token Fractionalization Types
 // ============================================================================
 

--- a/contracts/manage_hub/src/upgrade.rs
+++ b/contracts/manage_hub/src/upgrade.rs
@@ -1,0 +1,430 @@
+//! Token upgrade mechanism for ManageHub.
+//!
+//! This module implements:
+//! - `set_upgrade_config`     — admin configures upgrade behaviour
+//! - `upgrade_token`          — upgrade a single token to a new version
+//! - `batch_upgrade_tokens`   — upgrade multiple tokens in one call
+//! - `get_token_version`      — query a token's current version number
+//! - `get_upgrade_history`    — retrieve a token's full upgrade history
+//! - `rollback_token_upgrade` — revert a token to a previous version
+
+#![allow(deprecated)]
+
+use crate::errors::Error;
+use crate::membership_token::{DataKey, MembershipToken};
+use crate::migration::MigrationModule;
+use crate::types::{BatchUpgradeResult, MembershipStatus, UpgradeConfig};
+use crate::upgrade_errors::UpgradeError;
+use soroban_sdk::{Address, BytesN, Env, String, Vec};
+
+// ---------------------------------------------------------------------------
+// TTL constants (in ledgers; ~1 ledger / 5 s on Stellar)
+// ---------------------------------------------------------------------------
+
+/// Keep upgrade history for ~90 days.
+const UPGRADE_HISTORY_TTL_LEDGERS: u32 = 1_555_200;
+
+/// Keep version snapshots for ~90 days.
+const VERSION_SNAPSHOT_TTL_LEDGERS: u32 = 1_555_200;
+
+// ---------------------------------------------------------------------------
+// Module
+// ---------------------------------------------------------------------------
+
+pub struct UpgradeModule;
+
+impl UpgradeModule {
+    // -----------------------------------------------------------------------
+    // Admin — configuration
+    // -----------------------------------------------------------------------
+
+    /// Initialise or update the global upgrade configuration. Admin only.
+    pub fn set_upgrade_config(
+        env: Env,
+        admin: Address,
+        config: UpgradeConfig,
+    ) -> Result<(), Error> {
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)?;
+        stored_admin.require_auth();
+        if stored_admin != admin {
+            return Err(Error::Unauthorized);
+        }
+
+        env.storage()
+            .instance()
+            .set(&DataKey::UpgradeConfig, &config);
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Core upgrade operations
+    // -----------------------------------------------------------------------
+
+    /// Upgrade a single token to the next version.
+    ///
+    /// - Captures a snapshot of the current state for rollback purposes.
+    /// - Increments the token's `current_version`.
+    /// - Optionally updates `expiry_date`, `tier_id`, and `status`.
+    /// - Emits a `TokenUpgraded` event.
+    ///
+    /// Authorization: admin always allowed; token owner allowed only if
+    /// `upgrade_config.admin_only == false`.
+    pub fn upgrade_token(
+        env: Env,
+        caller: Address,
+        token_id: BytesN<32>,
+        label: Option<String>,
+        new_expiry_date: Option<u64>,
+        new_tier_id: Option<String>,
+        new_status: Option<MembershipStatus>,
+    ) -> Result<u32, Error> {
+        caller.require_auth();
+
+        let config = Self::get_config(&env)?;
+        if !config.upgrades_enabled {
+            return Err(UpgradeError::UpgradesDisabled.into());
+        }
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)?;
+
+        // Authorisation check
+        let is_admin = stored_admin == caller;
+        if config.admin_only && !is_admin {
+            return Err(UpgradeError::Unauthorized.into());
+        }
+
+        // Load token
+        let token: MembershipToken = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token(token_id.clone()))
+            .ok_or(UpgradeError::TokenNotFound)?;
+
+        // If not admin, verify the caller owns the token
+        if !is_admin && token.user != caller {
+            return Err(UpgradeError::Unauthorized.into());
+        }
+
+        let from_version = token.current_version;
+        let to_version = from_version.checked_add(1).ok_or(UpgradeError::Overflow)?;
+
+        // Capture pre-upgrade snapshot (so we can rollback to this version)
+        let snapshot = MigrationModule::capture_snapshot(&env, &token, label.clone());
+        MigrationModule::store_snapshot(&env, &token_id, &snapshot);
+        env.storage().persistent().extend_ttl(
+            &DataKey::VersionSnapshot(token_id.clone(), from_version),
+            VERSION_SNAPSHOT_TTL_LEDGERS,
+            VERSION_SNAPSHOT_TTL_LEDGERS,
+        );
+
+        // Apply field migrations
+        let new_tier_opt: Option<Option<String>> = new_tier_id.map(Some);
+        let updated_token = MigrationModule::migrate_token_fields(
+            &token,
+            to_version,
+            new_expiry_date,
+            new_tier_opt,
+            new_status,
+        );
+
+        // Persist updated token
+        env.storage()
+            .persistent()
+            .set(&DataKey::Token(token_id.clone()), &updated_token);
+
+        // Record upgrade history
+        let record = MigrationModule::build_record(
+            &env,
+            token_id.clone(),
+            from_version,
+            to_version,
+            caller.clone(),
+            label,
+            false,
+        );
+        MigrationModule::record_upgrade(&env, &record);
+        env.storage().persistent().extend_ttl(
+            &DataKey::UpgradeHistory(token_id.clone()),
+            UPGRADE_HISTORY_TTL_LEDGERS,
+            UPGRADE_HISTORY_TTL_LEDGERS,
+        );
+
+        // Emit TokenUpgraded event
+        env.events().publish(
+            (
+                String::from_str(&env, "TokenUpgraded"),
+                token_id.clone(),
+                caller,
+            ),
+            (from_version, to_version),
+        );
+
+        Ok(to_version)
+    }
+
+    /// Upgrade multiple tokens in a single call.
+    ///
+    /// Processes each token ID independently; individual failures do NOT abort
+    /// the entire batch — they are recorded as `success: false` in the result
+    /// list. Admin only.
+    pub fn batch_upgrade_tokens(
+        env: Env,
+        admin: Address,
+        token_ids: Vec<BytesN<32>>,
+        label: Option<String>,
+        new_expiry_date: Option<u64>,
+    ) -> Result<Vec<BatchUpgradeResult>, Error> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)?;
+        if stored_admin != admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let config = Self::get_config(&env)?;
+        if !config.upgrades_enabled {
+            return Err(UpgradeError::UpgradesDisabled.into());
+        }
+
+        let mut results: Vec<BatchUpgradeResult> = Vec::new(&env);
+
+        for token_id in token_ids.iter() {
+            let result = Self::upgrade_single_for_batch(
+                &env,
+                &admin,
+                &token_id,
+                label.clone(),
+                new_expiry_date,
+            );
+            match result {
+                Ok(new_version) => results.push_back(BatchUpgradeResult {
+                    token_id: token_id.clone(),
+                    success: true,
+                    new_version: Some(new_version),
+                }),
+                Err(_) => results.push_back(BatchUpgradeResult {
+                    token_id: token_id.clone(),
+                    success: false,
+                    new_version: None,
+                }),
+            }
+        }
+
+        Ok(results)
+    }
+
+    // -----------------------------------------------------------------------
+    // Rollback
+    // -----------------------------------------------------------------------
+
+    /// Roll back a token to a specific previous version.
+    ///
+    /// - The token's version number continues to increment (not reset) so that
+    ///   history is never lost.
+    /// - Emits a `TokenUpgraded` event with `is_rollback = true` in the record.
+    /// - Admin only.
+    pub fn rollback_token_upgrade(
+        env: Env,
+        admin: Address,
+        token_id: BytesN<32>,
+        target_version: u32,
+    ) -> Result<u32, Error> {
+        admin.require_auth();
+
+        let stored_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)?;
+        if stored_admin != admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let config = Self::get_config(&env)?;
+
+        // Check rollback limit
+        if config.max_rollbacks > 0 {
+            let rollback_count = MigrationModule::count_rollbacks(&env, &token_id);
+            if rollback_count >= config.max_rollbacks {
+                return Err(UpgradeError::RollbackLimitExceeded.into());
+            }
+        }
+
+        // Load current token
+        let token: MembershipToken = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token(token_id.clone()))
+            .ok_or(UpgradeError::TokenNotFound)?;
+
+        // Retrieve target snapshot
+        let snapshot = MigrationModule::get_snapshot(&env, &token_id, target_version)
+            .ok_or(UpgradeError::NoUpgradeHistory)?;
+
+        let from_version = token.current_version;
+        let to_version = from_version.checked_add(1).ok_or(UpgradeError::Overflow)?;
+
+        // Build rollback label
+        let rollback_label = Some(String::from_str(&env, "rollback"));
+
+        // Capture snapshot of current state before overwriting
+        let current_snapshot =
+            MigrationModule::capture_snapshot(&env, &token, rollback_label.clone());
+        MigrationModule::store_snapshot(&env, &token_id, &current_snapshot);
+
+        // Apply snapshot fields but keep version incrementing
+        let rolled_back_token = MigrationModule::apply_snapshot_to_token(
+            &token,
+            &snapshot,
+            to_version,
+            rollback_label.clone(),
+        );
+
+        // Persist
+        env.storage()
+            .persistent()
+            .set(&DataKey::Token(token_id.clone()), &rolled_back_token);
+
+        // Record rollback in history
+        let record = MigrationModule::build_record(
+            &env,
+            token_id.clone(),
+            from_version,
+            to_version,
+            admin.clone(),
+            rollback_label,
+            true,
+        );
+        MigrationModule::record_upgrade(&env, &record);
+        env.storage().persistent().extend_ttl(
+            &DataKey::UpgradeHistory(token_id.clone()),
+            UPGRADE_HISTORY_TTL_LEDGERS,
+            UPGRADE_HISTORY_TTL_LEDGERS,
+        );
+
+        // Emit event
+        env.events().publish(
+            (
+                String::from_str(&env, "TokenUpgraded"),
+                token_id.clone(),
+                admin,
+            ),
+            (from_version, to_version),
+        );
+
+        Ok(to_version)
+    }
+
+    // -----------------------------------------------------------------------
+    // Queries
+    // -----------------------------------------------------------------------
+
+    /// Return the current version number of a token.
+    pub fn get_token_version(env: Env, token_id: BytesN<32>) -> Result<u32, Error> {
+        let token: MembershipToken = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token(token_id))
+            .ok_or(Error::TokenNotFound)?;
+        Ok(token.current_version)
+    }
+
+    /// Return the full upgrade history for a token.
+    pub fn get_upgrade_history(env: Env, token_id: BytesN<32>) -> Vec<crate::types::UpgradeRecord> {
+        MigrationModule::get_upgrade_history(&env, &token_id)
+    }
+
+    /// Return the global upgrade configuration.
+    pub fn get_upgrade_config(env: Env) -> Result<UpgradeConfig, Error> {
+        Self::get_config(&env)
+    }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    fn get_config(env: &Env) -> Result<UpgradeConfig, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::UpgradeConfig)
+            .ok_or(UpgradeError::UpgradeNotConfigured.into())
+    }
+
+    /// Inner upgrade logic reused by the batch operation.
+    ///
+    /// Does not call `require_auth` — the batch function's auth covers all
+    /// tokens in the batch.
+    fn upgrade_single_for_batch(
+        env: &Env,
+        admin: &Address,
+        token_id: &BytesN<32>,
+        label: Option<String>,
+        new_expiry_date: Option<u64>,
+    ) -> Result<u32, Error> {
+        let token: MembershipToken = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token(token_id.clone()))
+            .ok_or(UpgradeError::TokenNotFound)?;
+
+        let from_version = token.current_version;
+        let to_version = from_version.checked_add(1).ok_or(UpgradeError::Overflow)?;
+
+        // Snapshot pre-upgrade state
+        let snapshot = MigrationModule::capture_snapshot(env, &token, label.clone());
+        MigrationModule::store_snapshot(env, token_id, &snapshot);
+        env.storage().persistent().extend_ttl(
+            &DataKey::VersionSnapshot(token_id.clone(), from_version),
+            VERSION_SNAPSHOT_TTL_LEDGERS,
+            VERSION_SNAPSHOT_TTL_LEDGERS,
+        );
+
+        // Migrate fields (only expiry for batch; status/tier unchanged)
+        let updated_token =
+            MigrationModule::migrate_token_fields(&token, to_version, new_expiry_date, None, None);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Token(token_id.clone()), &updated_token);
+
+        // Record
+        let record = MigrationModule::build_record(
+            env,
+            token_id.clone(),
+            from_version,
+            to_version,
+            admin.clone(),
+            label,
+            false,
+        );
+        MigrationModule::record_upgrade(env, &record);
+        env.storage().persistent().extend_ttl(
+            &DataKey::UpgradeHistory(token_id.clone()),
+            UPGRADE_HISTORY_TTL_LEDGERS,
+            UPGRADE_HISTORY_TTL_LEDGERS,
+        );
+
+        env.events().publish(
+            (
+                String::from_str(env, "TokenUpgraded"),
+                token_id.clone(),
+                admin.clone(),
+            ),
+            (from_version, to_version),
+        );
+
+        Ok(to_version)
+    }
+}

--- a/contracts/manage_hub/src/upgrade_errors.rs
+++ b/contracts/manage_hub/src/upgrade_errors.rs
@@ -1,0 +1,43 @@
+//! Upgrade-related error types for the ManageHub contract.
+//!
+//! A dedicated `UpgradeError` enum is used because the main `Error` enum is
+//! already at the 50-variant XDR limit imposed by `#[contracterror]`.
+//!
+//! The [`From`] impl bridges `UpgradeError` into `Error` (reusing existing
+//! numeric codes) so that `?` propagation works in functions returning
+//! `Result<_, Error>`.
+
+use crate::errors::Error;
+
+/// Upgrade-specific errors.
+#[derive(Debug)]
+pub enum UpgradeError {
+    /// Token upgrades are currently disabled by the admin.
+    UpgradesDisabled,
+    /// The specified token does not exist.
+    TokenNotFound,
+    /// Caller is not authorized to perform this upgrade.
+    Unauthorized,
+    /// Upgrade configuration has not been initialised.
+    UpgradeNotConfigured,
+    /// No upgrade history found; cannot rollback.
+    NoUpgradeHistory,
+    /// Maximum rollback limit has been reached for this token.
+    RollbackLimitExceeded,
+    /// Arithmetic overflow during upgrade processing.
+    Overflow,
+}
+
+impl From<UpgradeError> for Error {
+    fn from(e: UpgradeError) -> Self {
+        match e {
+            UpgradeError::UpgradesDisabled => Error::SubscriptionNotActive,
+            UpgradeError::TokenNotFound => Error::TokenNotFound,
+            UpgradeError::Unauthorized => Error::Unauthorized,
+            UpgradeError::UpgradeNotConfigured => Error::AdminNotSet,
+            UpgradeError::NoUpgradeHistory => Error::MetadataNotFound,
+            UpgradeError::RollbackLimitExceeded => Error::PauseCountExceeded,
+            UpgradeError::Overflow => Error::TimestampOverflow,
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the token upgrade mechanism for issue #507. Tokens can now be versioned, upgraded, rolled back, and batch-processed with a full audit trail.

- **`upgrade.rs`** — `UpgradeModule` with all upgrade/rollback logic and admin configuration
- **`migration.rs`** — `MigrationModule` with snapshot capture, field migration helpers, and history recording
- **`upgrade_errors.rs`** — dedicated error enum (main `Error` is at the XDR 50-variant limit; follows the `staking_errors.rs` pattern)
- **`types.rs`** — new `UpgradeConfig`, `TokenVersionSnapshot`, `UpgradeRecord`, `BatchUpgradeResult` structs
- **`membership_token.rs`** — new `DataKey` variants (`UpgradeConfig`, `UpgradeHistory`, `VersionSnapshot`); `current_version: u32` field added to `MembershipToken` (default `0`)
- **`lib.rs`** — 7 new public endpoints wired up
- **`test.rs`** — 12 new tests (111 total, all passing)

## New endpoints

| Endpoint | Auth | Description |
|---|---|---|
| `set_upgrade_config` | Admin | Enable/disable upgrades, set admin-only flag and rollback limit |
| `upgrade_token` | Admin or owner | Upgrade a single token to the next version |
| `batch_upgrade_tokens` | Admin | Upgrade multiple tokens; individual failures don't abort the batch |
| `get_token_version` | Public | Query a token's current version number |
| `get_upgrade_history` | Public | Full upgrade audit trail for a token |
| `rollback_token_upgrade` | Admin | Restore state from a prior version snapshot; version keeps incrementing |
| `get_upgrade_config` | Public | Query current upgrade configuration |

## Design decisions

- **Version number never decreases** — rollback restores state from a snapshot but the version counter keeps incrementing so the history is never lost
- **Snapshot-before-upgrade** — a `TokenVersionSnapshot` is captured before every upgrade, enabling rollback to any previous version
- **Separate error file** — main `Error` enum is full (50 variants = XDR limit); `UpgradeError` bridges into existing codes via `From`
- **Batch partial-failure** — individual token failures in batch upgrades are recorded as `success: false` rather than aborting the whole call
- **90-day TTL** — upgrade history and version snapshots use `1_555_200` ledger TTL (~90 days)

## Test plan

- [x] `test_upgrade_config_set_and_retrieved`
- [x] `test_token_starts_at_version_zero`
- [x] `test_upgrade_token_increments_version`
- [x] `test_upgrade_token_updates_expiry_date`
- [x] `test_upgrade_history_recorded`
- [x] `test_get_upgrade_history_empty_for_fresh_token`
- [x] `test_batch_upgrade_tokens`
- [x] `test_rollback_token_upgrade`
- [x] `test_rollback_recorded_in_history`
- [x] `test_upgrade_fails_when_disabled`
- [x] `test_upgrade_fails_without_config`
- [x] `test_rollback_fails_without_snapshot`
- [x] All 99 pre-existing tests still pass
- [x] `cargo fmt` — clean
- [x] `cargo clippy -- -D warnings` — clean

Closes #507