### PR TITLE
feat: add initialize, admin, and payment_token entry points

### DIFF
--- a/contracts/workspace_booking/src/lib.rs
+++ b/contracts/workspace_booking/src/lib.rs
@@ -1,2 +1,126 @@
+// contracts/workspace_booking/src/lib.rs
 #![no_std]
+// The env.events().publish() API is deprecated in favour of #[contractevent],
+// but kept here for consistency with the rest of the ManageHub contracts.
 #![allow(deprecated)]
+
+mod errors;
+mod types;
+
+// #[cfg(test)]
+// mod test;
+
+pub use errors::Error;
+pub use types::{Booking, BookingStatus, Workspace, WorkspaceType};
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, String, Vec};
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    /// Contract administrator address.
+    Admin,
+    /// Address of the USDC / payment token contract.
+    PaymentToken,
+    /// Workspace record keyed by workspace ID.
+    Workspace(String),
+    /// Ordered list of all registered workspace IDs.
+    WorkspaceList,
+    /// Booking record keyed by booking ID.
+    Booking(String),
+    /// List of booking IDs associated with a member.
+    MemberBookings(Address),
+    /// List of booking IDs associated with a workspace.
+    WorkspaceBookings(String),
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+#[contract]
+pub struct WorkspaceBookingContract;
+
+#[contractimpl]
+impl WorkspaceBookingContract {
+    // ── Internal helpers ──────────────────────────────────────────────────────
+
+    fn get_admin(env: &Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)
+    }
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+        let admin = Self::get_admin(env)?;
+        if caller != &admin {
+            return Err(Error::Unauthorized);
+        }
+        caller.require_auth();
+        Ok(())
+    }
+
+    fn get_payment_token(env: &Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::PaymentToken)
+            .ok_or(Error::PaymentTokenNotSet)
+    }
+
+    /// Returns `true` if no active booking for `workspace_id` overlaps
+    /// [`start_time`, `end_time`).
+    fn is_slot_available(env: &Env, workspace_id: &String, start_time: u64, end_time: u64) -> bool {
+        let booking_ids: Vec<String> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::WorkspaceBookings(workspace_id.clone()))
+            .unwrap_or(Vec::new(env));
+
+        for i in 0..booking_ids.len() {
+            let bid = booking_ids.get(i).unwrap();
+            let booking: Booking = match env.storage().persistent().get(&DataKey::Booking(bid)) {
+                Some(b) => b,
+                None => continue,
+            };
+
+            if booking.status != BookingStatus::Active {
+                continue;
+            }
+
+            // Overlap: existing booking starts before new slot ends AND ends after new slot starts.
+            if booking.start_time < end_time && booking.end_time > start_time {
+                return false;
+            }
+        }
+        true
+    }
+
+    // ── Initialisation ────────────────────────────────────────────────────────
+
+    /// One-time setup. Sets the admin and the payment token address.
+    pub fn initialize(env: Env, admin: Address, payment_token: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::PaymentToken, &payment_token);
+
+        env.events().publish(
+            (symbol_short!("init"),),
+            (admin, payment_token),
+        );
+        Ok(())
+    }
+
+    // ── Queries ───────────────────────────────────────────────────────────────
+
+    /// Return the current admin address.
+    pub fn admin(env: Env) -> Result<Address, Error> {
+        Self::get_admin(&env)
+    }
+
+    /// Return the payment token address.
+    pub fn payment_token(env: Env) -> Result<Address, Error> {
+        Self::get_payment_token(&env)
+    }
+}


### PR DESCRIPTION
Closes #599 
## Summary
Implements the one-time `initialize` entry point and two public query
functions on top of the Issue #598 scaffold.

## Changes
- `initialize(env, admin, payment_token)` — guards against double-init,
  requires admin auth, writes both addresses to instance storage, and
  emits an `init` event
- `admin(env)` — delegates to `Self::get_admin(&env)`
- `payment_token(env)` — delegates to `Self::get_payment_token(&env)`

## Acceptance Criteria
- [ ] `cargo check -p workspace_booking` passes
- [ ] `cargo clippy -p workspace_booking -- -D warnings` passes
- [ ] Double `initialize` panics with `Error(Contract, #3)`
- [ ] `admin()` returns the address passed to `initialize`
- [ ] `payment_token()` returns the token address passed to `initialize`
- [ ] `init` event is emitted on successful initialization