### PR TITLE
feat:Booking Creation with Payment #601

### DIFF
--- a/contracts/workspace_booking/src/lib.rs
+++ b/contracts/workspace_booking/src/lib.rs
@@ -224,6 +224,103 @@ impl WorkspaceBookingContract {
         Ok(())
     }
 
+    // ── Booking ───────────────────────────────────────────────────────────────
+
+    /// Reserve a workspace for a time slot.
+    ///
+    /// The caller must have pre-approved the contract to spend `amount` of the
+    /// payment token (or the caller's auth tree must cover the sub-invocation).
+    /// Cost is rounded **up** to the nearest full hour.
+    ///
+    /// * `booking_id`   – unique ID chosen by the caller (e.g. a UUID).
+    /// * `workspace_id` – workspace to book.
+    /// * `start_time`   – Unix timestamp (seconds) for start of reservation.
+    /// * `end_time`     – Unix timestamp (seconds) for end of reservation.
+    pub fn book_workspace(
+        env: Env,
+        member: Address,
+        booking_id: String,
+        workspace_id: String,
+        start_time: u64,
+        end_time: u64,
+    ) -> Result<(), Error> {
+        member.require_auth();
+
+        if env.storage().persistent().has(&DataKey::Booking(booking_id.clone())) {
+            return Err(Error::BookingAlreadyExists);
+        }
+
+        let now = env.ledger().timestamp();
+
+        if start_time >= end_time || end_time <= now {
+            return Err(Error::InvalidTimeRange);
+        }
+
+        let workspace: Workspace = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Workspace(workspace_id.clone()))
+            .ok_or(Error::WorkspaceNotFound)?;
+
+        if !workspace.is_available {
+            return Err(Error::WorkspaceUnavailable);
+        }
+
+        if !Self::is_slot_available(&env, &workspace_id, start_time, end_time) {
+            return Err(Error::BookingConflict);
+        }
+
+        // Cost = hourly_rate × ⌈duration_seconds / 3600⌉
+        let duration_secs = end_time - start_time;
+        let duration_hours = duration_secs.div_ceil(3600);
+        let amount: i128 = workspace.hourly_rate * duration_hours as i128;
+
+        // Collect payment from member → contract
+        let payment_token = Self::get_payment_token(&env)?;
+        token::Client::new(&env, &payment_token).transfer(
+            &member,
+            env.current_contract_address(),
+            &amount,
+        );
+
+        let booking = Booking {
+            id: booking_id.clone(),
+            workspace_id: workspace_id.clone(),
+            member: member.clone(),
+            start_time,
+            end_time,
+            status: BookingStatus::Active,
+            amount_paid: amount,
+            created_at: now,
+        };
+
+        env.storage().persistent().set(&DataKey::Booking(booking_id.clone()), &booking);
+
+        // Index: workspace → bookings
+        let mut ws_bookings: Vec<String> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::WorkspaceBookings(workspace_id.clone()))
+            .unwrap_or(Vec::new(&env));
+        ws_bookings.push_back(booking_id.clone());
+        env.storage().persistent().set(&DataKey::WorkspaceBookings(workspace_id.clone()), &ws_bookings);
+
+        // Index: member → bookings
+        let mut member_bookings: Vec<String> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MemberBookings(member.clone()))
+            .unwrap_or(Vec::new(&env));
+        member_bookings.push_back(booking_id.clone());
+        env.storage().persistent().set(&DataKey::MemberBookings(member.clone()), &member_bookings);
+
+        env.events().publish(
+            (symbol_short!("booked"), booking_id),
+            (member, workspace_id, start_time, end_time, amount),
+        );
+        Ok(())
+    }
+
     // ── Queries ───────────────────────────────────────────────────────────────
 
     /// Fetch a workspace record by ID.
@@ -234,11 +331,35 @@ impl WorkspaceBookingContract {
             .ok_or(Error::WorkspaceNotFound)
     }
 
+    /// Fetch a booking record by ID.
+    pub fn get_booking(env: Env, booking_id: String) -> Result<Booking, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Booking(booking_id))
+            .ok_or(Error::BookingNotFound)
+    }
+
     /// Return all registered workspace IDs (in registration order).
     pub fn get_all_workspaces(env: Env) -> Vec<String> {
         env.storage()
             .instance()
             .get(&DataKey::WorkspaceList)
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Return all booking IDs made by a specific member.
+    pub fn get_member_bookings(env: Env, member: Address) -> Vec<String> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MemberBookings(member))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    /// Return all booking IDs associated with a specific workspace.
+    pub fn get_workspace_bookings(env: Env, workspace_id: String) -> Vec<String> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::WorkspaceBookings(workspace_id))
             .unwrap_or(Vec::new(&env))
     }
 


### PR DESCRIPTION
PR Description

This PR implements the book_workspace core booking functionality and adds booking query helpers.

Changes

Implemented book_workspace to allow members to book a workspace, validate time ranges, check availability, compute cost (rounded up hourly), transfer payment, and store booking records.

Added booking query functions:

get_booking

get_member_bookings

get_workspace_bookings

Prevents duplicate bookings and detects booking conflicts.

Emits a booked event when a booking is successfully created.

Ensures cost calculation uses div_ceil(3600) to satisfy clippy lint rules.

Result

Successful bookings transfer tokens from the member to the contract.

Overlapping bookings and unavailable workspaces are rejected.

Member and workspace booking lists update correctly.

All checks pass:

cargo check -p workspace_booking
cargo clippy -p workspace_booking -- -D warnings

Closes #601