### PR TITLE
feat(sandbox): resolve BE-01, BE-04, BE-06, BE-07 — streak, booking reminder, activity score, amenity filter

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { SandboxAnalyticsModule } from './sandbox/analytics/analytics.module';
 import { SandboxBookingsModule } from './sandbox/bookings/bookings.module';
 import { SandboxReportsModule } from './sandbox/reports/reports.module';
 import { WaitlistModule } from './sandbox/waitlist/waitlist.module';
+import { SandboxModule } from './sandbox/sandbox.module';
 
 @Module({
   imports: [
@@ -107,6 +108,7 @@ import { WaitlistModule } from './sandbox/waitlist/waitlist.module';
     SandboxBookingsModule,
     SandboxReportsModule,
     WaitlistModule,
+    SandboxModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/bookings/entities/booking.entity.ts
+++ b/backend/src/bookings/entities/booking.entity.ts
@@ -63,6 +63,9 @@ export class Booking {
   @Column({ nullable: true })
   sorobanEscrowId: string;
 
+  @Column({ default: false })
+  reminderSent: boolean;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/src/sandbox/activity-score.controller.ts
+++ b/backend/src/sandbox/activity-score.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Param, ForbiddenException } from '@nestjs/common';
+import { ActivityScoreService } from './activity-score.service';
+import { CurrentUser } from '../auth/decorators/current.user.decorators';
+import { User } from '../users/entities/user.entity';
+import { UserRole } from '../users/enums/userRoles.enum';
+
+@Controller('sandbox/members')
+export class ActivityScoreController {
+  constructor(private readonly activityScoreService: ActivityScoreService) {}
+
+  /** GET /sandbox/members/activity-score — current user's score */
+  @Get('activity-score')
+  getMyScore(@CurrentUser() user: User) {
+    return this.activityScoreService.getActivityScore(user.id);
+  }
+
+  /** GET /sandbox/members/:userId/activity-score — admin only */
+  @Get(':userId/activity-score')
+  getScoreForUser(@Param('userId') userId: string, @CurrentUser() user: User) {
+    if (user.role !== UserRole.ADMIN && user.role !== UserRole.SUPER_ADMIN) {
+      throw new ForbiddenException('Admin access required');
+    }
+    return this.activityScoreService.getActivityScore(userId);
+  }
+}

--- a/backend/src/sandbox/activity-score.service.ts
+++ b/backend/src/sandbox/activity-score.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThanOrEqual } from 'typeorm';
+import { WorkspaceLog } from '../workspace-tracking/entities/workspace-log.entity';
+import { Booking } from '../bookings/entities/booking.entity';
+import { BookingStatus } from '../bookings/enums/booking-status.enum';
+import { StreakService } from './streak.service';
+
+export interface ActivityScoreResult {
+  score: number;
+  breakdown: { checkins: number; bookings: number; streak: number };
+}
+
+@Injectable()
+export class ActivityScoreService {
+  constructor(
+    @InjectRepository(WorkspaceLog)
+    private readonly logRepo: Repository<WorkspaceLog>,
+    @InjectRepository(Booking)
+    private readonly bookingRepo: Repository<Booking>,
+    private readonly streakService: StreakService,
+  ) {}
+
+  /**
+   * Score formula:
+   *   check-ins in last 30 days × 2
+   *   + confirmed bookings in last 30 days × 5
+   *   + current streak × 3
+   */
+  async getActivityScore(userId: string): Promise<ActivityScoreResult> {
+    const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+    const [checkins, bookings, { streak }] = await Promise.all([
+      this.logRepo.count({
+        where: { userId, checkedInAt: MoreThanOrEqual(since) },
+      }),
+      this.bookingRepo.count({
+        where: {
+          userId,
+          status: BookingStatus.CONFIRMED,
+          createdAt: MoreThanOrEqual(since),
+        },
+      }),
+      this.streakService.getStreakForUser(userId),
+    ]);
+
+    const score = checkins * 2 + bookings * 5 + streak * 3;
+    return { score, breakdown: { checkins, bookings, streak } };
+  }
+}

--- a/backend/src/sandbox/booking-reminder.service.ts
+++ b/backend/src/sandbox/booking-reminder.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between } from 'typeorm';
+import { Booking } from '../bookings/entities/booking.entity';
+import { BookingStatus } from '../bookings/enums/booking-status.enum';
+import { EmailService } from '../email/email.service';
+
+@Injectable()
+export class BookingReminderService {
+  private readonly logger = new Logger(BookingReminderService.name);
+
+  constructor(
+    @InjectRepository(Booking)
+    private readonly bookingRepo: Repository<Booking>,
+    private readonly emailService: EmailService,
+  ) {}
+
+  /**
+   * Runs every hour. Finds confirmed bookings whose startDate falls within
+   * the next 24–25 hours and sends a reminder email to each user.
+   * Uses a `reminderSent` flag on the booking to avoid duplicates.
+   */
+  @Cron(CronExpression.EVERY_HOUR)
+  async sendBookingReminders(): Promise<void> {
+    const now = new Date();
+    const windowStart = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    const windowEnd = new Date(now.getTime() + 25 * 60 * 60 * 1000);
+
+    // startDate is stored as 'YYYY-MM-DD'; compare as date strings
+    const startStr = windowStart.toISOString().slice(0, 10);
+    const endStr = windowEnd.toISOString().slice(0, 10);
+
+    const bookings = await this.bookingRepo.find({
+      where: {
+        status: BookingStatus.CONFIRMED,
+        startDate: Between(startStr, endStr),
+        reminderSent: false,
+      },
+      relations: ['user', 'workspace'],
+    });
+
+    let sent = 0;
+    for (const booking of bookings) {
+      if (!booking.user?.email) continue;
+
+      const fullName =
+        `${booking.user.firstname} ${booking.user.lastname}`.trim();
+      await this.emailService.sendBookingCreatedEmail(
+        booking.user.email,
+        fullName,
+        {
+          bookingId: booking.id,
+          workspaceName: booking.workspace?.name ?? '',
+          planType: booking.planType,
+          startDate: booking.startDate,
+          endDate: booking.endDate,
+          seatCount: booking.seatCount,
+          totalAmountNaira: (Number(booking.totalAmount) / 100).toFixed(2),
+        },
+      );
+
+      await this.bookingRepo.update(booking.id, { reminderSent: true });
+      sent++;
+    }
+
+    this.logger.log(`Booking reminder job: ${sent} reminder(s) sent.`);
+  }
+}

--- a/backend/src/sandbox/sandbox.module.ts
+++ b/backend/src/sandbox/sandbox.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WorkspaceLog } from '../workspace-tracking/entities/workspace-log.entity';
+import { Booking } from '../bookings/entities/booking.entity';
+import { Workspace } from '../workspaces/entities/workspace.entity';
+
+import { StreakService } from './streak.service';
+import { StreakController } from './streak.controller';
+import { BookingReminderService } from './booking-reminder.service';
+import { ActivityScoreService } from './activity-score.service';
+import { ActivityScoreController } from './activity-score.controller';
+import { WorkspaceFilterService } from './workspace-filter.service';
+import { WorkspaceFilterController } from './workspace-filter.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WorkspaceLog, Booking, Workspace])],
+  controllers: [
+    StreakController,
+    ActivityScoreController,
+    WorkspaceFilterController,
+  ],
+  providers: [
+    StreakService,
+    BookingReminderService,
+    ActivityScoreService,
+    WorkspaceFilterService,
+  ],
+})
+export class SandboxModule {}

--- a/backend/src/sandbox/streak.controller.ts
+++ b/backend/src/sandbox/streak.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, Get } from '@nestjs/common';
+import { StreakService } from './streak.service';
+import { CurrentUser } from '../auth/decorators/current.user.decorators';
+import { User } from '../users/entities/user.entity';
+
+@Controller('sandbox/streaks')
+export class StreakController {
+  constructor(private readonly streakService: StreakService) {}
+
+  /** GET /sandbox/streaks/me — returns the current user's check-in streak */
+  @Get('me')
+  getMyStreak(@CurrentUser() user: User) {
+    return this.streakService.getStreakForUser(user.id);
+  }
+}

--- a/backend/src/sandbox/streak.service.spec.ts
+++ b/backend/src/sandbox/streak.service.spec.ts
@@ -1,0 +1,61 @@
+import { StreakService } from './streak.service';
+
+describe('StreakService.calculateStreak', () => {
+  let service: StreakService;
+
+  beforeEach(() => {
+    // Instantiate without DB dependency — only testing pure calculation
+    service = new StreakService(null as any);
+  });
+
+  const day = (offsetDays: number): Date => {
+    const d = new Date();
+    d.setUTCHours(0, 0, 0, 0);
+    d.setUTCDate(d.getUTCDate() - offsetDays);
+    return d;
+  };
+
+  it('returns 0 streak for empty logs', () => {
+    expect(service.calculateStreak([])).toEqual({
+      streak: 0,
+      lastCheckinDate: null,
+    });
+  });
+
+  it('returns streak of 1 for a single check-in today', () => {
+    const { streak } = service.calculateStreak([day(0)]);
+    expect(streak).toBe(1);
+  });
+
+  it('returns streak of 1 for a single check-in yesterday', () => {
+    const { streak } = service.calculateStreak([day(1)]);
+    expect(streak).toBe(1);
+  });
+
+  it('returns 0 when last check-in was 2+ days ago', () => {
+    const { streak } = service.calculateStreak([day(2), day(3)]);
+    expect(streak).toBe(0);
+  });
+
+  it('counts consecutive days correctly', () => {
+    const { streak } = service.calculateStreak([
+      day(0),
+      day(1),
+      day(2),
+      day(3),
+    ]);
+    expect(streak).toBe(4);
+  });
+
+  it('stops streak at a gap', () => {
+    // today, yesterday, then a gap (skip day(2)), day(3)
+    const { streak } = service.calculateStreak([day(0), day(1), day(3)]);
+    expect(streak).toBe(2);
+  });
+
+  it('deduplicates multiple check-ins on the same day', () => {
+    const today = day(0);
+    const { streak } = service.calculateStreak([today, today, day(1)]);
+    expect(streak).toBe(2);
+  });
+});

--- a/backend/src/sandbox/streak.service.ts
+++ b/backend/src/sandbox/streak.service.ts
@@ -1,0 +1,75 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WorkspaceLog } from '../workspace-tracking/entities/workspace-log.entity';
+
+export interface StreakResult {
+  streak: number;
+  lastCheckinDate: string | null;
+}
+
+@Injectable()
+export class StreakService {
+  constructor(
+    @InjectRepository(WorkspaceLog)
+    private readonly logRepo: Repository<WorkspaceLog>,
+  ) {}
+
+  /**
+   * Calculates the current consecutive check-in streak for a user.
+   * A streak is the number of calendar days in a row (ending today or yesterday)
+   * where the user had at least one check-in. A gap > 1 day resets the streak to 0.
+   */
+  calculateStreak(dates: Date[]): {
+    streak: number;
+    lastCheckinDate: Date | null;
+  } {
+    if (!dates.length) return { streak: 0, lastCheckinDate: null };
+
+    // Deduplicate to calendar-day strings (UTC), then sort descending
+    const daySet = new Set(dates.map((d) => d.toISOString().slice(0, 10)));
+    const days = Array.from(daySet).sort((a, b) => (a > b ? -1 : 1));
+
+    const today = new Date().toISOString().slice(0, 10);
+    const yesterday = new Date(Date.now() - 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+
+    // Streak must start from today or yesterday
+    if (days[0] !== today && days[0] !== yesterday) {
+      return { streak: 0, lastCheckinDate: new Date(days[0]) };
+    }
+
+    let streak = 1;
+    for (let i = 1; i < days.length; i++) {
+      const prev = new Date(days[i - 1]);
+      const curr = new Date(days[i]);
+      const diffDays = Math.round(
+        (prev.getTime() - curr.getTime()) / 86_400_000,
+      );
+      if (diffDays === 1) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+
+    return { streak, lastCheckinDate: new Date(days[0]) };
+  }
+
+  async getStreakForUser(userId: string): Promise<StreakResult> {
+    const logs = await this.logRepo.find({
+      where: { userId },
+      select: ['checkedInAt'],
+    });
+
+    const { streak, lastCheckinDate } = this.calculateStreak(
+      logs.map((l) => l.checkedInAt),
+    );
+
+    return {
+      streak,
+      lastCheckinDate: lastCheckinDate ? lastCheckinDate.toISOString() : null,
+    };
+  }
+}

--- a/backend/src/sandbox/workspace-filter.controller.ts
+++ b/backend/src/sandbox/workspace-filter.controller.ts
@@ -1,0 +1,32 @@
+import {
+  Controller,
+  Get,
+  Query,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
+import { WorkspaceFilterService } from './workspace-filter.service';
+
+@Controller('sandbox/workspaces')
+export class WorkspaceFilterController {
+  constructor(
+    private readonly workspaceFilterService: WorkspaceFilterService,
+  ) {}
+
+  /**
+   * GET /sandbox/workspaces?amenities=wifi,standing-desk&page=1&limit=10
+   * Filters workspaces by amenities (AND logic, case-insensitive).
+   */
+  @Get()
+  filterWorkspaces(
+    @Query('amenities') amenities: string | undefined,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number,
+  ) {
+    return this.workspaceFilterService.filterByAmenities(
+      amenities,
+      page,
+      limit,
+    );
+  }
+}

--- a/backend/src/sandbox/workspace-filter.service.ts
+++ b/backend/src/sandbox/workspace-filter.service.ts
@@ -1,0 +1,75 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Workspace } from '../workspaces/entities/workspace.entity';
+
+export interface WorkspaceFilterResult {
+  total: number;
+  page: number;
+  limit: number;
+  data: Workspace[];
+}
+
+@Injectable()
+export class WorkspaceFilterService {
+  constructor(
+    @InjectRepository(Workspace)
+    private readonly workspaceRepo: Repository<Workspace>,
+  ) {}
+
+  /**
+   * Filters workspaces by amenities (AND logic, case-insensitive).
+   * amenities is a comma-separated string e.g. "wifi,standing-desk".
+   */
+  async filterByAmenities(
+    amenitiesParam: string | undefined,
+    page = 1,
+    limit = 10,
+  ): Promise<WorkspaceFilterResult> {
+    if (
+      page < 1 ||
+      limit < 1 ||
+      !Number.isInteger(page) ||
+      !Number.isInteger(limit)
+    ) {
+      throw new BadRequestException('page and limit must be positive integers');
+    }
+
+    const qb = this.workspaceRepo
+      .createQueryBuilder('w')
+      .where('w.isActive = :active', { active: true });
+
+    if (amenitiesParam !== undefined && amenitiesParam.trim() !== '') {
+      // Validate: only allow alphanumeric, hyphens, underscores, spaces, commas
+      if (!/^[\w\s,\-]+$/.test(amenitiesParam)) {
+        throw new BadRequestException('amenities param is malformed');
+      }
+
+      const requested = amenitiesParam
+        .split(',')
+        .map((a) => a.trim().toLowerCase())
+        .filter(Boolean);
+
+      if (!requested.length) {
+        throw new BadRequestException('amenities param is malformed');
+      }
+
+      // simple-array stores values as comma-separated; use LOWER + LIKE for each
+      for (const amenity of requested) {
+        qb.andWhere(
+          `LOWER(w.amenities) LIKE :am_${amenity.replace(/-/g, '_')}`,
+          {
+            [`am_${amenity.replace(/-/g, '_')}`]: `%${amenity}%`,
+          },
+        );
+      }
+    }
+
+    const [data, total] = await qb
+      .skip((page - 1) * limit)
+      .take(limit)
+      .getManyAndCount();
+
+    return { total, page, limit, data };
+  }
+}


### PR DESCRIPTION
## Summary

Resolves all 4 issues assigned to @Xhristin3 in a single PR. All implementation lives in `backend/src/sandbox/` as required.

---

### BE-01 — Member check-in streak tracking (#805)
- `GET /sandbox/streaks/me` — returns `{ streak, lastCheckinDate }` for the current user
- Calculates consecutive calendar-day streak from `workspace_logs.checkedInAt`
- A gap > 1 day resets streak to 0
- 7 unit tests covering edge cases (empty, today, yesterday, gap, dedup)

### BE-04 — Booking reminder scheduled job (#808)
- `@Cron(EVERY_HOUR)` job in `BookingReminderService`
- Queries `confirmed` bookings with `startDate` in the next 24–25 hours
- Sends reminder email via existing `EmailService`
- Adds `reminderSent: boolean` flag to `Booking` entity to prevent duplicates
- Logs count of reminders sent each run

### BE-06 — Member activity score (#810)
- `GET /sandbox/members/activity-score` — current user's score
- `GET /sandbox/members/:userId/activity-score` — admin/super_admin only
- Formula: `checkins_30d × 2 + confirmed_bookings_30d × 5 + streak × 3`
- Returns `{ score, breakdown: { checkins, bookings, streak } }`

### BE-07 — Workspace amenity filtering (#811)
- `GET /sandbox/workspaces?amenities=wifi,standing-desk&page=1&limit=10`
- AND logic, case-insensitive matching against `Workspace.amenities` (simple-array)
- Returns `{ total, page, limit, data }`
- Returns 400 for malformed amenities param

---

Closes #805
Closes #808
Closes #810
Closes #811