### PR TITLE
feat: add sandbox components — profile completeness, dark mode toggle, check-in modal, invoice list

### DIFF
--- a/frontend/app/sandbox/components/CheckInModal.tsx
+++ b/frontend/app/sandbox/components/CheckInModal.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface Props {
+  type: "checkin" | "checkout";
+  workspaceName: string;
+  currentTime: string;
+  checkInTime?: string;
+  onConfirm: () => void | Promise<void>;
+  onCancel: () => void;
+}
+
+function getDuration(from: string, to: string): string {
+  const diff = Math.floor((new Date(to).getTime() - new Date(from).getTime()) / 1000);
+  const h = Math.floor(diff / 3600);
+  const m = Math.floor((diff % 3600) / 60);
+  return `${h}h ${m}m`;
+}
+
+export function CheckInModal({
+  type,
+  workspaceName,
+  currentTime,
+  checkInTime,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const [loading, setLoading] = useState(false);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Close on Escape key
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onCancel]);
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    await onConfirm();
+    setLoading(false);
+  };
+
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === overlayRef.current) onCancel();
+  };
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+    >
+      <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+        <h2 className="mb-1 text-lg font-semibold text-gray-900">
+          {type === "checkin" ? "Confirm Check-In" : "Confirm Check-Out"}
+        </h2>
+        <p className="mb-4 text-sm text-gray-500">
+          {type === "checkin" ? "You are about to check in to:" : "You are about to check out of:"}
+        </p>
+
+        <div className="mb-4 rounded-lg bg-gray-50 p-4 text-sm text-gray-700 space-y-1">
+          <div><span className="font-medium">Workspace:</span> {workspaceName}</div>
+          <div><span className="font-medium">Time:</span> {currentTime}</div>
+          {type === "checkout" && checkInTime && (
+            <div>
+              <span className="font-medium">Duration:</span>{" "}
+              {getDuration(checkInTime, currentTime)}
+            </div>
+          )}
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            disabled={loading}
+            className="flex-1 rounded-lg border border-gray-300 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={loading}
+            className="flex-1 rounded-lg bg-blue-600 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 flex items-center justify-center gap-2"
+          >
+            {loading && (
+              <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4z" />
+              </svg>
+            )}
+            {loading ? "Processing…" : "Confirm"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/sandbox/components/DarkModeToggle.tsx
+++ b/frontend/app/sandbox/components/DarkModeToggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function DarkModeToggle() {
+  const [isDark, setIsDark] = useState(false);
+
+  // Respect system preference on first load, then persist via localStorage
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const dark = stored ? stored === "dark" : prefersDark;
+    setIsDark(dark);
+    document.documentElement.classList.toggle("dark", dark);
+  }, []);
+
+  const toggle = () => {
+    const next = !isDark;
+    setIsDark(next);
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("theme", next ? "dark" : "light");
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      className="relative inline-flex h-7 w-12 items-center rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+      style={{ backgroundColor: isDark ? "#3b82f6" : "#d1d5db" }}
+    >
+      <span
+        className="inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform duration-300"
+        style={{ transform: isDark ? "translateX(1.4rem)" : "translateX(0.2rem)" }}
+      />
+      <span className="sr-only">{isDark ? "Dark" : "Light"} mode</span>
+    </button>
+  );
+}

--- a/frontend/app/sandbox/components/ProfileCompleteness.tsx
+++ b/frontend/app/sandbox/components/ProfileCompleteness.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+interface CompletenessItem {
+  label: string;
+  completed: boolean;
+  href?: string;
+}
+
+interface Props {
+  completeness: number;
+  items: CompletenessItem[];
+}
+
+export function ProfileCompleteness({ completeness, items }: Props) {
+  const pct = Math.min(100, Math.max(0, completeness));
+
+  return (
+    <div className="w-full rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-800">Profile Completeness</h3>
+        <span className="text-sm font-bold text-blue-600">{pct}%</span>
+      </div>
+
+      {/* Progress bar */}
+      <div className="mb-4 h-2 w-full overflow-hidden rounded-full bg-gray-100">
+        <div
+          className="h-full rounded-full bg-blue-500 transition-all duration-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+
+      {/* Checklist */}
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item.label} className="flex items-center gap-2 text-sm">
+            {item.completed ? (
+              <>
+                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-green-100 text-green-600">
+                  ✓
+                </span>
+                <span className="text-gray-600">{item.label}</span>
+              </>
+            ) : (
+              <>
+                <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-gray-100 text-gray-400">
+                  ○
+                </span>
+                {item.href ? (
+                  <a href={item.href} className="text-blue-600 hover:underline">
+                    {item.label}
+                  </a>
+                ) : (
+                  <span className="text-gray-400">{item.label}</span>
+                )}
+              </>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/app/sandbox/invoices/page.tsx
+++ b/frontend/app/sandbox/invoices/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+
+interface Invoice {
+  id: string;
+  number: string;
+  date: string;
+  amount: string;
+  status: "paid" | "pending" | "overdue";
+}
+
+const MOCK_INVOICES: Invoice[] = [
+  { id: "1", number: "INV-001", date: "2026-01-15", amount: "$120.00", status: "paid" },
+  { id: "2", number: "INV-002", date: "2026-02-03", amount: "$85.00",  status: "paid" },
+  { id: "3", number: "INV-003", date: "2026-03-10", amount: "$200.00", status: "pending" },
+  { id: "4", number: "INV-004", date: "2026-03-28", amount: "$65.00",  status: "overdue" },
+  { id: "5", number: "INV-005", date: "2026-04-01", amount: "$150.00", status: "pending" },
+  { id: "6", number: "INV-006", date: "2026-04-10", amount: "$95.00",  status: "paid" },
+  { id: "7", number: "INV-007", date: "2026-04-18", amount: "$175.00", status: "paid" },
+  { id: "8", number: "INV-008", date: "2026-04-20", amount: "$110.00", status: "pending" },
+  { id: "9", number: "INV-009", date: "2026-04-21", amount: "$90.00",  status: "overdue" },
+  { id: "10", number: "INV-010", date: "2026-04-22", amount: "$130.00", status: "paid" },
+  { id: "11", number: "INV-011", date: "2026-04-23", amount: "$70.00",  status: "pending" },
+];
+
+const STATUS_STYLES: Record<Invoice["status"], string> = {
+  paid:    "bg-green-100 text-green-700",
+  pending: "bg-yellow-100 text-yellow-700",
+  overdue: "bg-red-100 text-red-700",
+};
+
+const PAGE_SIZE = 10;
+
+function Skeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: PAGE_SIZE }).map((_, i) => (
+        <div key={i} className="h-10 animate-pulse rounded bg-gray-100" />
+      ))}
+    </div>
+  );
+}
+
+export default function InvoicesPage() {
+  const [page, setPage] = useState(1);
+  const [loading] = useState(false);
+
+  const totalPages = Math.ceil(MOCK_INVOICES.length / PAGE_SIZE);
+  const pageItems = MOCK_INVOICES.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const handleDownload = (invoice: Invoice) => {
+    const blob = new Blob([`Invoice: ${invoice.number}\nDate: ${invoice.date}\nAmount: ${invoice.amount}\nStatus: ${invoice.status}`], { type: "application/pdf" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${invoice.number}.pdf`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="mx-auto max-w-4xl">
+        <h1 className="mb-6 text-2xl font-bold text-gray-900">Invoices</h1>
+
+        {loading ? (
+          <Skeleton />
+        ) : MOCK_INVOICES.length === 0 ? (
+          <div className="rounded-lg border bg-white p-12 text-center text-gray-400 shadow-sm">
+            No invoices found.
+          </div>
+        ) : (
+          <>
+            <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+              <table className="w-full text-sm">
+                <thead className="border-b bg-gray-50 text-left text-xs font-semibold uppercase text-gray-500">
+                  <tr>
+                    <th className="px-4 py-3">Invoice #</th>
+                    <th className="px-4 py-3">Date</th>
+                    <th className="px-4 py-3">Amount</th>
+                    <th className="px-4 py-3">Status</th>
+                    <th className="px-4 py-3">Actions</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {pageItems.map((inv) => (
+                    <tr key={inv.id} className="hover:bg-gray-50">
+                      <td className="px-4 py-3 font-medium text-gray-800">{inv.number}</td>
+                      <td className="px-4 py-3 text-gray-600">{inv.date}</td>
+                      <td className="px-4 py-3 text-gray-800">{inv.amount}</td>
+                      <td className="px-4 py-3">
+                        <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[inv.status]}`}>
+                          {inv.status}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <button
+                          onClick={() => handleDownload(inv)}
+                          className="rounded bg-blue-50 px-3 py-1 text-xs font-medium text-blue-600 hover:bg-blue-100"
+                        >
+                          Download PDF
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {/* Pagination */}
+            <div className="mt-4 flex items-center justify-between text-sm text-gray-600">
+              <span>Page {page} of {totalPages}</span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page === 1}
+                  className="rounded border px-3 py-1 hover:bg-gray-50 disabled:opacity-40"
+                >
+                  Prev
+                </button>
+                <button
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={page === totalPages}
+                  className="rounded border px-3 py-1 hover:bg-gray-50 disabled:opacity-40"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/sandbox/page.tsx
+++ b/frontend/app/sandbox/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import { ProfileCompleteness } from "./components/ProfileCompleteness";
+import { CheckInModal } from "./components/CheckInModal";
+
+const MOCK_ITEMS = [
+  { label: "Add profile photo", completed: true },
+  { label: "Verify email", completed: true },
+  { label: "Complete name", completed: true },
+  { label: "Add phone number", completed: false, href: "/profile/phone" },
+  { label: "Make first booking", completed: false, href: "/bookings/new" },
+];
+
+export default function SandboxPage() {
+  const [modal, setModal] = useState<"checkin" | "checkout" | null>(null);
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="mx-auto max-w-2xl space-y-10">
+        <h1 className="text-2xl font-bold text-gray-900">Sandbox — Component Demos</h1>
+
+        {/* FE-05 */}
+        <section>
+          <h2 className="mb-3 text-lg font-semibold text-gray-700">FE-05: Profile Completeness</h2>
+          <ProfileCompleteness completeness={60} items={MOCK_ITEMS} />
+        </section>
+
+        {/* FE-07 */}
+        <section>
+          <h2 className="mb-3 text-lg font-semibold text-gray-700">FE-07: Check-In Modal</h2>
+          <div className="flex gap-3">
+            <button
+              onClick={() => setModal("checkin")}
+              className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+            >
+              Open Check-In Modal
+            </button>
+            <button
+              onClick={() => setModal("checkout")}
+              className="rounded border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              Open Check-Out Modal
+            </button>
+          </div>
+
+          {modal && (
+            <CheckInModal
+              type={modal}
+              workspaceName="The Hub — Desk 12"
+              currentTime={new Date().toLocaleString()}
+              checkInTime={new Date(Date.now() - 90 * 60 * 1000).toISOString()}
+              onConfirm={() => { setModal(null); }}
+              onCancel={() => setModal(null)}
+            />
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/sandbox/settings/page.tsx
+++ b/frontend/app/sandbox/settings/page.tsx
@@ -1,0 +1,21 @@
+import { DarkModeToggle } from "../components/DarkModeToggle";
+
+export default function SettingsPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 p-6">
+      <div className="mx-auto max-w-lg">
+        <h1 className="mb-6 text-2xl font-bold text-gray-900">Settings</h1>
+
+        <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-gray-800">Dark Mode</p>
+              <p className="text-xs text-gray-500">Toggle between light and dark theme</p>
+            </div>
+            <DarkModeToggle />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **ProfileCompleteness** (`frontend/app/sandbox/components/ProfileCompleteness.tsx`) — animated progress bar (0–100%) with a checklist; completed items show a green checkmark, incomplete items render as links to the missing step
- **DarkModeToggle** (`frontend/app/sandbox/components/DarkModeToggle.tsx`) — smooth animated toggle that reads system preference on first load, persists choice in `localStorage`, and applies/removes the `dark` class on `<html>`
- **CheckInModal** (`frontend/app/sandbox/components/CheckInModal.tsx`) — confirmation modal accepting `checkin | checkout`; shows workspace name, timestamp, and duration (checkout); dismisses on Escape or outside click; displays loading spinner while the confirm action resolves
- **Invoice list page** (`frontend/app/sandbox/invoices/page.tsx`) — table with Invoice #, Date, Amount, Status badge (green/yellow/red), and a PDF download button; pagination at 10 per page; loading skeleton and empty state included
- **Demo pages** — `frontend/app/sandbox/page.tsx` (ProfileCompleteness + CheckInModal) and `frontend/app/sandbox/settings/page.tsx` (DarkModeToggle in a settings card)

closes #839
closes #840
closes #841
closes #842