### PR TITLE
feat: sandbox booking timeline, members table, workspace detail, and cancel flow

### DIFF
--- a/frontend/app/sandbox/admin/members/page.tsx
+++ b/frontend/app/sandbox/admin/members/page.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState } from "react";
+
+interface Member {
+  id: number;
+  name: string;
+  email: string;
+  role: string;
+  status: "active" | "inactive";
+  joined: string;
+}
+
+const SAMPLE_MEMBERS: Member[] = [
+  { id: 1, name: "Alice Johnson", email: "alice@example.com", role: "Admin", status: "active", joined: "2024-01-10" },
+  { id: 2, name: "Bob Smith", email: "bob@example.com", role: "Member", status: "active", joined: "2024-02-15" },
+  { id: 3, name: "Carol White", email: "carol@example.com", role: "Member", status: "inactive", joined: "2024-03-01" },
+  { id: 4, name: "David Lee", email: "david@example.com", role: "Moderator", status: "active", joined: "2024-03-20" },
+  { id: 5, name: "Eve Martinez", email: "eve@example.com", role: "Member", status: "active", joined: "2024-04-05" },
+  { id: 6, name: "Frank Brown", email: "frank@example.com", role: "Member", status: "inactive", joined: "2024-04-18" },
+  { id: 7, name: "Grace Kim", email: "grace@example.com", role: "Admin", status: "active", joined: "2024-05-02" },
+  { id: 8, name: "Henry Davis", email: "henry@example.com", role: "Member", status: "active", joined: "2024-05-14" },
+];
+
+const PAGE_SIZE = 5;
+
+type SortKey = keyof Pick<Member, "name" | "role" | "status" | "joined">;
+
+export default function MembersPage() {
+  const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("name");
+  const [sortAsc, setSortAsc] = useState(true);
+  const [page, setPage] = useState(1);
+
+  const filtered = SAMPLE_MEMBERS.filter(
+    (m) =>
+      m.name.toLowerCase().includes(search.toLowerCase()) ||
+      m.email.toLowerCase().includes(search.toLowerCase()) ||
+      m.role.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const sorted = [...filtered].sort((a, b) => {
+    const av = a[sortKey];
+    const bv = b[sortKey];
+    return sortAsc ? av.localeCompare(bv) : bv.localeCompare(av);
+  });
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const paginated = sorted.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  function toggleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortAsc(!sortAsc);
+    } else {
+      setSortKey(key);
+      setSortAsc(true);
+    }
+    setPage(1);
+  }
+
+  function SortIcon({ col }: { col: SortKey }) {
+    if (sortKey !== col) return <span className="ml-1 text-gray-400">↕</span>;
+    return <span className="ml-1">{sortAsc ? "↑" : "↓"}</span>;
+  }
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold mb-6">Members</h1>
+
+      <input
+        type="text"
+        placeholder="Search by name, email or role..."
+        value={search}
+        onChange={(e) => { setSearch(e.target.value); setPage(1); }}
+        className="w-full mb-4 px-4 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+      />
+
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 text-left">
+            <tr>
+              <th className="px-4 py-3 cursor-pointer" onClick={() => toggleSort("name")}>
+                Name <SortIcon col="name" />
+              </th>
+              <th className="px-4 py-3">Email</th>
+              <th className="px-4 py-3 cursor-pointer" onClick={() => toggleSort("role")}>
+                Role <SortIcon col="role" />
+              </th>
+              <th className="px-4 py-3 cursor-pointer" onClick={() => toggleSort("status")}>
+                Status <SortIcon col="status" />
+              </th>
+              <th className="px-4 py-3 cursor-pointer" onClick={() => toggleSort("joined")}>
+                Joined <SortIcon col="joined" />
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {paginated.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="px-4 py-6 text-center text-gray-500">No members found.</td>
+              </tr>
+            ) : (
+              paginated.map((m) => (
+                <tr key={m.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 font-medium">{m.name}</td>
+                  <td className="px-4 py-3 text-gray-600">{m.email}</td>
+                  <td className="px-4 py-3">{m.role}</td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`px-2 py-0.5 rounded-full text-xs font-semibold ${
+                        m.status === "active"
+                          ? "bg-green-100 text-green-700"
+                          : "bg-gray-100 text-gray-500"
+                      }`}
+                    >
+                      {m.status}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-gray-600">{m.joined}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between mt-4 text-sm text-gray-600">
+        <span>
+          Showing {paginated.length} of {sorted.length} members
+        </span>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+            className="px-3 py-1 border rounded disabled:opacity-40 hover:bg-gray-50"
+          >
+            Prev
+          </button>
+          <span className="px-3 py-1">
+            {page} / {totalPages}
+          </span>
+          <button
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+            disabled={page === totalPages}
+            className="px-3 py-1 border rounded disabled:opacity-40 hover:bg-gray-50"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/sandbox/components/BookingTimeline.tsx
+++ b/frontend/app/sandbox/components/BookingTimeline.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+const STAGES = [
+  "Created",
+  "Payment Received",
+  "Confirmed",
+  "Checked In",
+  "Completed",
+] as const;
+
+type Stage = (typeof STAGES)[number] | "Cancelled";
+
+interface Props {
+  currentStatus: Stage;
+  timestamps: Partial<Record<Stage, string | null>>;
+}
+
+export function BookingTimeline({ currentStatus, timestamps }: Props) {
+  const stages = currentStatus === "Cancelled"
+    ? [...STAGES.slice(0, STAGES.indexOf("Completed")), "Cancelled" as Stage]
+    : [...STAGES];
+
+  const currentIdx = stages.indexOf(currentStatus);
+
+  return (
+    <ol className="relative border-l border-gray-200 space-y-6 pl-6">
+      {stages.map((stage, idx) => {
+        const done = idx < currentIdx;
+        const active = idx === currentIdx;
+        const cancelled = stage === "Cancelled";
+
+        return (
+          <li key={stage} className="relative">
+            {/* Circle indicator */}
+            <span
+              className={[
+                "absolute -left-[1.65rem] flex h-5 w-5 items-center justify-center rounded-full border-2",
+                done
+                  ? "border-green-500 bg-green-500"
+                  : active && cancelled
+                  ? "border-red-500 bg-red-500"
+                  : active
+                  ? "border-blue-500 bg-white"
+                  : "border-gray-300 bg-white",
+              ].join(" ")}
+            >
+              {done && (
+                <svg className="h-3 w-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+              {active && !cancelled && (
+                <span className="h-2 w-2 rounded-full bg-blue-500 animate-pulse" />
+              )}
+            </span>
+
+            {/* Label + timestamp */}
+            <div className="ml-1">
+              <p className={[
+                "text-sm font-medium",
+                done ? "text-green-700" : active && cancelled ? "text-red-600" : active ? "text-blue-700" : "text-gray-400",
+              ].join(" ")}>
+                {stage}
+              </p>
+              {timestamps[stage] && (
+                <p className="text-xs text-gray-400">{timestamps[stage]}</p>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/frontend/app/sandbox/components/BookingTimeline.tsx
+++ b/frontend/app/sandbox/components/BookingTimeline.tsx
@@ -72,3 +72,5 @@ export function BookingTimeline({ currentStatus, timestamps }: Props) {
     </ol>
   );
 }
+
+export default BookingTimeline;

--- a/frontend/app/sandbox/components/CancelBookingFlow.tsx
+++ b/frontend/app/sandbox/components/CancelBookingFlow.tsx
@@ -116,3 +116,5 @@ export function CancelBookingFlow({ booking, onSuccess, onClose }: Props) {
     </div>
   );
 }
+
+export default CancelBookingFlow;

--- a/frontend/app/sandbox/components/CancelBookingFlow.tsx
+++ b/frontend/app/sandbox/components/CancelBookingFlow.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+
+interface Booking {
+  id: string;
+  workspaceName: string;
+  date: string;
+  amount: string;
+}
+
+interface Props {
+  booking: Booking;
+  onSuccess: () => void;
+  onClose: () => void;
+}
+
+type Step = "confirm" | "success" | "error";
+
+export function CancelBookingFlow({ booking, onSuccess, onClose }: Props) {
+  const [step, setStep] = useState<Step>("confirm");
+  const [loading, setLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    setErrorMsg("");
+    try {
+      // Replace with real API call
+      await new Promise((res) => setTimeout(res, 1000));
+      setStep("success");
+      onSuccess();
+    } catch {
+      setErrorMsg("Cancellation failed. Please try again.");
+      setStep("error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="w-full max-w-sm rounded-xl bg-white p-6 shadow-xl">
+
+        {step === "confirm" && (
+          <>
+            <h2 className="mb-1 text-lg font-semibold text-gray-900">Cancel Booking?</h2>
+            <p className="mb-4 text-sm text-gray-500">
+              This action cannot be undone. Please review your booking details.
+            </p>
+            <div className="mb-4 rounded-lg bg-gray-50 p-4 text-sm text-gray-700 space-y-1">
+              <div><span className="font-medium">Workspace:</span> {booking.workspaceName}</div>
+              <div><span className="font-medium">Date:</span> {booking.date}</div>
+              <div><span className="font-medium">Amount:</span> {booking.amount}</div>
+            </div>
+            <p className="mb-5 text-xs text-amber-600 font-medium">
+              ⚠ A refund will be processed within 5–7 business days.
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={onClose}
+                disabled={loading}
+                className="flex-1 rounded-lg border border-gray-300 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+              >
+                Keep Booking
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={loading}
+                className="flex-1 rounded-lg bg-red-600 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50 flex items-center justify-center gap-2"
+              >
+                {loading && (
+                  <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4l3-3-3-3v4a8 8 0 00-8 8h4z" />
+                  </svg>
+                )}
+                {loading ? "Cancelling…" : "Yes, Cancel"}
+              </button>
+            </div>
+          </>
+        )}
+
+        {step === "success" && (
+          <div className="text-center space-y-4">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+              <svg className="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <h2 className="text-lg font-semibold text-gray-900">Booking Cancelled</h2>
+            <p className="text-sm text-gray-500">
+              Your refund of {booking.amount} will be processed within 5–7 business days.
+            </p>
+            <a href="/bookings" className="inline-block mt-2 text-sm font-medium text-blue-600 hover:underline">
+              ← Back to bookings
+            </a>
+          </div>
+        )}
+
+        {step === "error" && (
+          <div className="space-y-4">
+            <p className="text-sm text-red-600 font-medium">{errorMsg}</p>
+            <div className="flex gap-3">
+              <button onClick={() => setStep("confirm")} className="flex-1 rounded-lg border border-gray-300 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
+                Try Again
+              </button>
+              <button onClick={onClose} className="flex-1 rounded-lg bg-gray-800 py-2 text-sm font-medium text-white hover:bg-gray-900">
+                Close
+              </button>
+            </div>
+          </div>
+        )}
+
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/sandbox/page.tsx
+++ b/frontend/app/sandbox/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+import BookingTimeline from "./components/BookingTimeline";
+import CancelBookingFlow from "./components/CancelBookingFlow";
+
+const DEMO_BOOKING = {
+  id: "BK-1042",
+  workspace: "The Innovation Hub",
+  date: "2024-06-15",
+  time: "10:00 AM – 12:00 PM",
+  total: 50,
+};
+
+export default function SandboxPage() {
+  const [showCancel, setShowCancel] = useState(false);
+  const [cancelled, setCancelled] = useState(false);
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto space-y-10">
+      <h1 className="text-2xl font-bold">Sandbox</h1>
+
+      {/* BookingTimeline demo */}
+      <section>
+        <h2 className="text-lg font-semibold mb-4">Booking Timeline</h2>
+        <BookingTimeline
+          currentStatus="confirmed"
+          timestamps={{
+            created: "2024-06-10 09:00",
+            paymentReceived: "2024-06-10 09:05",
+            confirmed: "2024-06-10 09:10",
+          }}
+        />
+      </section>
+
+      {/* CancelBookingFlow demo */}
+      <section>
+        <h2 className="text-lg font-semibold mb-4">Cancel Booking Flow</h2>
+        {cancelled ? (
+          <p className="text-green-600 font-medium">Booking was successfully cancelled.</p>
+        ) : (
+          <button
+            onClick={() => setShowCancel(true)}
+            className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700"
+          >
+            Cancel Booking
+          </button>
+        )}
+
+        {showCancel && (
+          <CancelBookingFlow
+            booking={DEMO_BOOKING}
+            onSuccess={() => { setCancelled(true); setShowCancel(false); }}
+            onClose={() => setShowCancel(false)}
+          />
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/app/sandbox/page.tsx
+++ b/frontend/app/sandbox/page.tsx
@@ -24,11 +24,11 @@ export default function SandboxPage() {
       <section>
         <h2 className="text-lg font-semibold mb-4">Booking Timeline</h2>
         <BookingTimeline
-          currentStatus="confirmed"
+          currentStatus="Confirmed"
           timestamps={{
-            created: "2024-06-10 09:00",
-            paymentReceived: "2024-06-10 09:05",
-            confirmed: "2024-06-10 09:10",
+            "Created": "2024-06-10 09:00",
+            "Payment Received": "2024-06-10 09:05",
+            "Confirmed": "2024-06-10 09:10",
           }}
         />
       </section>

--- a/frontend/app/sandbox/page.tsx
+++ b/frontend/app/sandbox/page.tsx
@@ -6,10 +6,9 @@ import CancelBookingFlow from "./components/CancelBookingFlow";
 
 const DEMO_BOOKING = {
   id: "BK-1042",
-  workspace: "The Innovation Hub",
+  workspaceName: "The Innovation Hub",
   date: "2024-06-15",
-  time: "10:00 AM – 12:00 PM",
-  total: 50,
+  amount: "$50.00",
 };
 
 export default function SandboxPage() {

--- a/frontend/app/sandbox/workspaces/[id]/page.tsx
+++ b/frontend/app/sandbox/workspaces/[id]/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useState } from "react";
+
+interface Workspace {
+  id: string;
+  name: string;
+  description: string;
+  capacity: number;
+  pricePerHour: number;
+  amenities: string[];
+  images: string[];
+  available: boolean;
+}
+
+const WORKSPACE: Workspace = {
+  id: "ws-001",
+  name: "The Innovation Hub",
+  description:
+    "A bright, open workspace designed for collaboration and deep focus. Floor-to-ceiling windows, standing desks, and high-speed fibre make it the perfect home for your team.",
+  capacity: 12,
+  pricePerHour: 25,
+  amenities: ["Wi-Fi", "Whiteboards", "Projector", "Coffee & Tea", "24/7 Access", "Printing"],
+  images: [
+    "https://images.unsplash.com/photo-1497366216548-37526070297c?w=800&q=80",
+    "https://images.unsplash.com/photo-1497366754035-f200968a6e72?w=800&q=80",
+    "https://images.unsplash.com/photo-1524758631624-e2822e304c36?w=800&q=80",
+  ],
+  available: true,
+};
+
+export default function WorkspaceDetailPage() {
+  const [activeImage, setActiveImage] = useState(0);
+  const [showBooking, setShowBooking] = useState(false);
+  const [hours, setHours] = useState(2);
+  const [booked, setBooked] = useState(false);
+
+  const workspace = WORKSPACE;
+  const total = workspace.pricePerHour * hours;
+
+  function handleBook() {
+    setBooked(true);
+    setShowBooking(false);
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      {/* Image Gallery */}
+      <div className="mb-6">
+        <div className="relative w-full h-72 bg-gray-200 rounded-xl overflow-hidden mb-2">
+          <img
+            src={workspace.images[activeImage]}
+            alt={workspace.name}
+            className="w-full h-full object-cover"
+          />
+        </div>
+        <div className="flex gap-2">
+          {workspace.images.map((src, i) => (
+            <button
+              key={i}
+              onClick={() => setActiveImage(i)}
+              className={`w-20 h-14 rounded-lg overflow-hidden border-2 ${
+                activeImage === i ? "border-blue-500" : "border-transparent"
+              }`}
+            >
+              <img src={src} alt="" className="w-full h-full object-cover" />
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Header */}
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <h1 className="text-2xl font-bold">{workspace.name}</h1>
+          <p className="text-gray-500 mt-1">Capacity: {workspace.capacity} people</p>
+        </div>
+        <div className="text-right">
+          <p className="text-2xl font-bold text-blue-600">${workspace.pricePerHour}/hr</p>
+          <span
+            className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
+              workspace.available
+                ? "bg-green-100 text-green-700"
+                : "bg-red-100 text-red-600"
+            }`}
+          >
+            {workspace.available ? "Available" : "Unavailable"}
+          </span>
+        </div>
+      </div>
+
+      <p className="text-gray-600 mb-6">{workspace.description}</p>
+
+      {/* Amenities */}
+      <div className="mb-6">
+        <h2 className="font-semibold mb-2">Amenities</h2>
+        <div className="flex flex-wrap gap-2">
+          {workspace.amenities.map((a) => (
+            <span key={a} className="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm">
+              {a}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      {/* Book button */}
+      {booked ? (
+        <div className="p-4 bg-green-50 border border-green-200 rounded-lg text-green-700 font-medium">
+          Booking confirmed! Check your email for details.
+        </div>
+      ) : (
+        <button
+          onClick={() => setShowBooking(true)}
+          disabled={!workspace.available}
+          className="w-full py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 disabled:opacity-40"
+        >
+          Book This Space
+        </button>
+      )}
+
+      {/* Booking modal */}
+      {showBooking && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-xl p-6 w-full max-w-sm shadow-lg">
+            <h2 className="text-lg font-bold mb-4">Book {workspace.name}</h2>
+            <label className="block text-sm font-medium mb-1">Duration (hours)</label>
+            <input
+              type="number"
+              min={1}
+              max={8}
+              value={hours}
+              onChange={(e) => setHours(Math.max(1, Number(e.target.value)))}
+              className="w-full border rounded-lg px-3 py-2 mb-4 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <div className="flex justify-between text-sm mb-6">
+              <span className="text-gray-500">Total</span>
+              <span className="font-bold">${total}</span>
+            </div>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowBooking(false)}
+                className="flex-1 py-2 border rounded-lg hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleBook}
+                className="flex-1 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+              >
+                Confirm
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

This PR adds four new sandbox UI components and pages for the ManageHub frontend.

### Changes

- **BookingTimeline** (`sandbox/components/BookingTimeline.tsx`) — vertical stage-based timeline showing booking progress with filled/pulsing/gray indicators for each state
- **Admin Members page** (`sandbox/admin/members/page.tsx`) — searchable and sortable members table with pagination, status badges, and role columns
- **Workspace Detail page** (`sandbox/workspaces/[id]/page.tsx`) — workspace info with image gallery thumbnails, amenities list, capacity/pricing, and a booking modal with duration input
- **CancelBookingFlow** (`sandbox/components/CancelBookingFlow.tsx`) — 3-step modal: confirm (with refund warning) → success/error feedback
- **Sandbox demo page** (`sandbox/page.tsx`) — wires up BookingTimeline and CancelBookingFlow with sample data

closes #843
closes #844
closes #845
closes #846