### PR TITLE
feat(contracts): implement resource_credits Soroban contract (CT-01 – CT-04)

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -5,8 +5,9 @@ members = [
     "manage_hub",
     "membership_token",
     "common_types",
-     "workspace_booking",
-    "payment_escrow"
+    "workspace_booking",
+    "payment_escrow",
+    "resource_credits"
 ]
 
 [workspace.dependencies]

--- a/contracts/resource_credits/Cargo.toml
+++ b/contracts/resource_credits/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "resource_credits"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/resource_credits/src/errors.rs
+++ b/contracts/resource_credits/src/errors.rs
@@ -1,0 +1,19 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    /// No admin has been set yet.
+    AdminNotSet = 1,
+    /// Contract already initialized.
+    AlreadyInitialized = 2,
+    /// Caller is not the admin.
+    Unauthorized = 3,
+    /// Member balance is too low.
+    InsufficientBalance = 4,
+    /// Amount must be greater than zero.
+    InvalidAmount = 5,
+    /// Account not found in storage.
+    AccountNotFound = 6,
+}

--- a/contracts/resource_credits/src/lib.rs
+++ b/contracts/resource_credits/src/lib.rs
@@ -1,0 +1,182 @@
+#![no_std]
+
+mod errors;
+mod types;
+
+use errors::Error;
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env};
+
+/// Storage keys for the contract.
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    PaymentToken,
+    Balance(Address),
+    TotalSupply,
+    TransactionHistory(Address),
+}
+
+#[contract]
+pub struct ResourceCreditsContract;
+
+#[contractimpl]
+impl ResourceCreditsContract {
+    /// Initialize the contract with an admin and payment token.
+    pub fn initialize(env: Env, admin: Address, payment_token: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::PaymentToken, &payment_token);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalSupply, &0u128);
+        Ok(())
+    }
+
+    /// Mint credits to a recipient (admin only).
+    ///
+    /// CT-02: increases recipient balance and TotalSupply.
+    pub fn mint_credits(
+        env: Env,
+        caller: Address,
+        recipient: Address,
+        amount: u128,
+    ) -> Result<(), Error> {
+        if amount == 0 {
+            return Err(Error::InvalidAmount);
+        }
+        let admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)?;
+        if caller != admin {
+            return Err(Error::Unauthorized);
+        }
+        caller.require_auth();
+
+        let bal: u128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(recipient.clone()))
+            .unwrap_or(0u128);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(recipient.clone()), &(bal + amount));
+
+        let supply: u128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0u128);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalSupply, &(supply + amount));
+
+        env.events().publish(
+            (symbol_short!("mint"), recipient),
+            amount,
+        );
+        Ok(())
+    }
+
+    /// Transfer credits from one member to another.
+    ///
+    /// CT-03: sender balance decremented, recipient balance incremented.
+    pub fn transfer_credits(
+        env: Env,
+        from: Address,
+        to: Address,
+        amount: u128,
+    ) -> Result<(), Error> {
+        if amount == 0 {
+            return Err(Error::InvalidAmount);
+        }
+        from.require_auth();
+
+        let from_bal: u128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(from.clone()))
+            .unwrap_or(0u128);
+        if from_bal < amount {
+            return Err(Error::InsufficientBalance);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(from.clone()), &(from_bal - amount));
+
+        let to_bal: u128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(to.clone()))
+            .unwrap_or(0u128);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(to.clone()), &(to_bal + amount));
+
+        env.events().publish(
+            (symbol_short!("transfer"), from, to),
+            amount,
+        );
+        Ok(())
+    }
+
+    /// Spend (burn) credits from a member's balance.
+    ///
+    /// CT-04: decrements member balance and TotalSupply.
+    pub fn spend_credits(env: Env, member: Address, amount: u128) -> Result<(), Error> {
+        if amount == 0 {
+            return Err(Error::InvalidAmount);
+        }
+        member.require_auth();
+
+        let bal: u128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Balance(member.clone()))
+            .unwrap_or(0u128);
+        if bal < amount {
+            return Err(Error::InsufficientBalance);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Balance(member.clone()), &(bal - amount));
+
+        let supply: u128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0u128);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalSupply, &(supply - amount));
+
+        env.events().publish(
+            (symbol_short!("spend"), member),
+            amount,
+        );
+        Ok(())
+    }
+
+    /// Get the credit balance of a member.
+    pub fn balance(env: Env, member: Address) -> u128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Balance(member))
+            .unwrap_or(0u128)
+    }
+
+    /// Get the total supply of credits.
+    pub fn total_supply(env: Env) -> u128 {
+        env.storage()
+            .instance()
+            .get(&DataKey::TotalSupply)
+            .unwrap_or(0u128)
+    }
+}

--- a/contracts/resource_credits/src/types.rs
+++ b/contracts/resource_credits/src/types.rs
@@ -1,0 +1,29 @@
+use soroban_sdk::{contracttype, Address};
+
+/// Type of credit transaction.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum TransactionType {
+    Mint,
+    Transfer,
+    Spend,
+}
+
+/// A single credit transaction record.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CreditTransaction {
+    pub tx_type: TransactionType,
+    pub from: Option<Address>,
+    pub to: Option<Address>,
+    pub amount: u128,
+    pub timestamp: u64,
+}
+
+/// Snapshot of a member's credit balance.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CreditBalance {
+    pub owner: Address,
+    pub amount: u128,
+}


### PR DESCRIPTION
## Summary

Implements the complete `resource_credits` Soroban contract inside `contracts/resource_credits/`, following the same conventions as `workspace_booking` and `payment_escrow`.

## Changes

### CT-01 — Scaffold
- `Cargo.toml` with `soroban-sdk` workspace dependency
- `src/errors.rs` — `Error` enum: `AdminNotSet`, `AlreadyInitialized`, `Unauthorized`, `InsufficientBalance`, `InvalidAmount`, `AccountNotFound`
- `src/types.rs` — `CreditBalance`, `CreditTransaction`, `TransactionType`
- `src/lib.rs` — `DataKey` enum (`Admin`, `PaymentToken`, `Balance(Address)`, `TotalSupply`, `TransactionHistory(Address)`) and `initialize(env, admin, payment_token)`
- Added `resource_credits` to workspace `Cargo.toml` members

### CT-02 — Mint
- `mint_credits(env, caller, recipient, amount)` — admin-gated, increments recipient balance and `TotalSupply`, emits `mint` event

### CT-03 — Transfer
- `transfer_credits(env, from, to, amount)` — requires `from.require_auth()`, atomic balance swap, emits `transfer` event

### CT-04 — Spend (burn)
- `spend_credits(env, member, amount)` — requires `member.require_auth()`, decrements balance and `TotalSupply`, emits `spend` event

## Closes

Closes #765
Closes #766
Closes #767
Closes #768