### PR TITLE
feat(contracts): Soroban event_ticketing contract (CT-10 to CT-13)

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -5,8 +5,9 @@ members = [
     "manage_hub",
     "membership_token",
     "common_types",
-     "workspace_booking",
-    "payment_escrow"
+    "workspace_booking",
+    "payment_escrow",
+    "sandbox/event_ticketing"
 ]
 
 [workspace.dependencies]

--- a/contracts/sandbox/event_ticketing/Cargo.toml
+++ b/contracts/sandbox/event_ticketing/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "event_ticketing"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/sandbox/event_ticketing/src/errors.rs
+++ b/contracts/sandbox/event_ticketing/src/errors.rs
@@ -1,0 +1,35 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    /// No admin has been set yet.
+    AdminNotSet = 1,
+    /// Caller is not authorized.
+    Unauthorized = 2,
+    /// Contract already initialized.
+    AlreadyInitialized = 3,
+    /// Payment token not configured.
+    PaymentTokenNotSet = 4,
+
+    // Event errors (100–199)
+    /// Event ID not found.
+    EventNotFound = 100,
+    /// Event already exists.
+    EventAlreadyExists = 101,
+    /// Event is not in Active status.
+    EventNotActive = 102,
+    /// Event has no remaining capacity.
+    EventSoldOut = 103,
+
+    // Ticket errors (200–299)
+    /// Ticket ID not found.
+    TicketNotFound = 200,
+    /// Ticket already exists.
+    TicketAlreadyExists = 201,
+    /// Ticket cannot be transferred after event start.
+    TicketNotTransferable = 202,
+    /// Ticket cannot be cancelled after event start.
+    TicketNotCancellable = 203,
+}

--- a/contracts/sandbox/event_ticketing/src/lib.rs
+++ b/contracts/sandbox/event_ticketing/src/lib.rs
@@ -1,0 +1,344 @@
+#![no_std]
+#![allow(deprecated)]
+
+mod errors;
+mod types;
+
+pub use errors::Error;
+pub use types::{Event, EventStatus, Ticket, TicketStatus};
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, String, Vec};
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    PaymentToken,
+    Event(String),
+    EventList,
+    Ticket(String),
+    /// All ticket IDs for an event.
+    EventTickets(String),
+    /// All ticket IDs owned by an address.
+    OwnerTickets(Address),
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct EventTicketingContract;
+
+#[contractimpl]
+impl EventTicketingContract {
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn get_admin(env: &Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)
+    }
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+        let admin = Self::get_admin(env)?;
+        if caller != &admin {
+            return Err(Error::Unauthorized);
+        }
+        caller.require_auth();
+        Ok(())
+    }
+
+    fn get_payment_token(env: &Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::PaymentToken)
+            .ok_or(Error::PaymentTokenNotSet)
+    }
+
+    // ── Initialisation ────────────────────────────────────────────────────────
+
+    pub fn initialize(env: Env, admin: Address, payment_token: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::PaymentToken, &payment_token);
+        env.events().publish((symbol_short!("init"),), (admin, payment_token));
+        Ok(())
+    }
+
+    // ── Event management (admin-only) ─────────────────────────────────────────
+
+    pub fn create_event(
+        env: Env,
+        caller: Address,
+        event_id: String,
+        name: String,
+        start_time: u64,
+        ticket_price: u128,
+        capacity: u32,
+    ) -> Result<(), Error> {
+        Self::require_admin(&env, &caller)?;
+
+        if env.storage().persistent().has(&DataKey::Event(event_id.clone())) {
+            return Err(Error::EventAlreadyExists);
+        }
+
+        let event = Event {
+            id: event_id.clone(),
+            name: name.clone(),
+            start_time,
+            ticket_price,
+            capacity,
+            remaining_capacity: capacity,
+            status: EventStatus::Active,
+            created_at: env.ledger().timestamp(),
+        };
+
+        env.storage().persistent().set(&DataKey::Event(event_id.clone()), &event);
+
+        let mut list: Vec<String> = env
+            .storage()
+            .instance()
+            .get(&DataKey::EventList)
+            .unwrap_or(Vec::new(&env));
+        list.push_back(event_id.clone());
+        env.storage().instance().set(&DataKey::EventList, &list);
+
+        env.events().publish((symbol_short!("ev_create"), event_id), (name, start_time, ticket_price, capacity));
+        Ok(())
+    }
+
+    // ── CT-10: Buy ticket ─────────────────────────────────────────────────────
+
+    pub fn buy_ticket(
+        env: Env,
+        buyer: Address,
+        ticket_id: String,
+        event_id: String,
+    ) -> Result<(), Error> {
+        buyer.require_auth();
+
+        if env.storage().persistent().has(&DataKey::Ticket(ticket_id.clone())) {
+            return Err(Error::TicketAlreadyExists);
+        }
+
+        let mut event: Event = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Event(event_id.clone()))
+            .ok_or(Error::EventNotFound)?;
+
+        if event.status != EventStatus::Active {
+            return Err(Error::EventNotActive);
+        }
+        if event.remaining_capacity == 0 {
+            return Err(Error::EventSoldOut);
+        }
+
+        // Transfer ticket_price from buyer to contract.
+        let payment_token = Self::get_payment_token(&env)?;
+        token::Client::new(&env, &payment_token).transfer(
+            &buyer,
+            &env.current_contract_address(),
+            &(event.ticket_price as i128),
+        );
+
+        // Decrement capacity.
+        event.remaining_capacity -= 1;
+        env.storage().persistent().set(&DataKey::Event(event_id.clone()), &event);
+
+        // Store ticket.
+        let ticket = Ticket {
+            id: ticket_id.clone(),
+            event_id: event_id.clone(),
+            owner: buyer.clone(),
+            price_paid: event.ticket_price,
+            status: TicketStatus::Active,
+            purchased_at: env.ledger().timestamp(),
+        };
+        env.storage().persistent().set(&DataKey::Ticket(ticket_id.clone()), &ticket);
+
+        // Index: event → tickets.
+        let mut ev_tickets: Vec<String> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EventTickets(event_id.clone()))
+            .unwrap_or(Vec::new(&env));
+        ev_tickets.push_back(ticket_id.clone());
+        env.storage().persistent().set(&DataKey::EventTickets(event_id.clone()), &ev_tickets);
+
+        // Index: owner → tickets.
+        let mut owner_tickets: Vec<String> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OwnerTickets(buyer.clone()))
+            .unwrap_or(Vec::new(&env));
+        owner_tickets.push_back(ticket_id.clone());
+        env.storage().persistent().set(&DataKey::OwnerTickets(buyer.clone()), &owner_tickets);
+
+        env.events().publish(
+            (symbol_short!("purchase"), ticket_id),
+            (buyer, event_id, event.ticket_price),
+        );
+        Ok(())
+    }
+
+    // ── CT-11: Transfer ticket ────────────────────────────────────────────────
+
+    pub fn transfer_ticket(
+        env: Env,
+        from: Address,
+        to: Address,
+        ticket_id: String,
+    ) -> Result<(), Error> {
+        from.require_auth();
+
+        let mut ticket: Ticket = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Ticket(ticket_id.clone()))
+            .ok_or(Error::TicketNotFound)?;
+
+        if ticket.owner != from {
+            return Err(Error::Unauthorized);
+        }
+
+        let event: Event = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Event(ticket.event_id.clone()))
+            .ok_or(Error::EventNotFound)?;
+
+        if env.ledger().timestamp() >= event.start_time {
+            return Err(Error::TicketNotTransferable);
+        }
+
+        // Re-index: remove from old owner, add to new owner.
+        let mut from_tickets: Vec<String> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OwnerTickets(from.clone()))
+            .unwrap_or(Vec::new(&env));
+        let mut new_from: Vec<String> = Vec::new(&env);
+        for i in 0..from_tickets.len() {
+            let t = from_tickets.get(i).unwrap();
+            if t != ticket_id {
+                new_from.push_back(t);
+            }
+        }
+        env.storage().persistent().set(&DataKey::OwnerTickets(from.clone()), &new_from);
+
+        let mut to_tickets: Vec<String> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::OwnerTickets(to.clone()))
+            .unwrap_or(Vec::new(&env));
+        to_tickets.push_back(ticket_id.clone());
+        env.storage().persistent().set(&DataKey::OwnerTickets(to.clone()), &to_tickets);
+
+        ticket.owner = to.clone();
+        env.storage().persistent().set(&DataKey::Ticket(ticket_id.clone()), &ticket);
+
+        env.events().publish(
+            (symbol_short!("transfer"), ticket_id),
+            (from, to, ticket.event_id),
+        );
+        Ok(())
+    }
+
+    // ── CT-12: Cancel ticket ──────────────────────────────────────────────────
+
+    pub fn cancel_ticket(env: Env, caller: Address, ticket_id: String) -> Result<(), Error> {
+        caller.require_auth();
+
+        let mut ticket: Ticket = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Ticket(ticket_id.clone()))
+            .ok_or(Error::TicketNotFound)?;
+
+        let admin = Self::get_admin(&env)?;
+        if caller != ticket.owner && caller != admin {
+            return Err(Error::Unauthorized);
+        }
+
+        let mut event: Event = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Event(ticket.event_id.clone()))
+            .ok_or(Error::EventNotFound)?;
+
+        if env.ledger().timestamp() >= event.start_time {
+            return Err(Error::TicketNotCancellable);
+        }
+
+        // Refund ticket_price from contract to ticket owner.
+        let payment_token = Self::get_payment_token(&env)?;
+        token::Client::new(&env, &payment_token).transfer(
+            &env.current_contract_address(),
+            &ticket.owner,
+            &(ticket.price_paid as i128),
+        );
+
+        // Restore capacity.
+        event.remaining_capacity += 1;
+        env.storage().persistent().set(&DataKey::Event(ticket.event_id.clone()), &event);
+
+        ticket.status = TicketStatus::Cancelled;
+        env.storage().persistent().set(&DataKey::Ticket(ticket_id.clone()), &ticket);
+
+        env.events().publish(
+            (symbol_short!("cancel"), ticket_id),
+            (caller, ticket.event_id, ticket.price_paid),
+        );
+        Ok(())
+    }
+
+    // ── CT-13: Query functions ────────────────────────────────────────────────
+
+    pub fn get_event(env: Env, event_id: String) -> Result<Event, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Event(event_id))
+            .ok_or(Error::EventNotFound)
+    }
+
+    pub fn get_all_events(env: Env) -> Vec<String> {
+        env.storage()
+            .instance()
+            .get(&DataKey::EventList)
+            .unwrap_or(Vec::new(&env))
+    }
+
+    pub fn get_ticket(env: Env, ticket_id: String) -> Result<Ticket, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Ticket(ticket_id))
+            .ok_or(Error::TicketNotFound)
+    }
+
+    pub fn get_event_tickets(env: Env, event_id: String) -> Vec<String> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::EventTickets(event_id))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    pub fn get_owner_tickets(env: Env, owner: Address) -> Vec<String> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::OwnerTickets(owner))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    pub fn check_event_availability(env: Env, event_id: String) -> bool {
+        let event: Event = match env.storage().persistent().get(&DataKey::Event(event_id)) {
+            Some(e) => e,
+            None => return false,
+        };
+        event.status == EventStatus::Active && event.remaining_capacity > 0
+    }
+}

--- a/contracts/sandbox/event_ticketing/src/types.rs
+++ b/contracts/sandbox/event_ticketing/src/types.rs
@@ -1,0 +1,63 @@
+use soroban_sdk::{contracttype, Address, String};
+
+/// Lifecycle status of an event.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum EventStatus {
+    /// Event is open for ticket purchases.
+    Active,
+    /// Event has been cancelled.
+    Cancelled,
+    /// Event has concluded.
+    Completed,
+}
+
+/// An event that members can purchase tickets for.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Event {
+    /// Unique event identifier.
+    pub id: String,
+    /// Human-readable event name.
+    pub name: String,
+    /// Unix timestamp when the event starts.
+    pub start_time: u64,
+    /// Price per ticket in smallest payment-token units.
+    pub ticket_price: u128,
+    /// Total ticket capacity.
+    pub capacity: u32,
+    /// Remaining tickets available.
+    pub remaining_capacity: u32,
+    /// Current event status.
+    pub status: EventStatus,
+    /// Ledger timestamp when event was created.
+    pub created_at: u64,
+}
+
+/// Lifecycle status of a ticket.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum TicketStatus {
+    /// Ticket is valid and owned.
+    Active,
+    /// Ticket has been cancelled and refunded.
+    Cancelled,
+}
+
+/// A ticket purchased for an event.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Ticket {
+    /// Unique ticket identifier.
+    pub id: String,
+    /// ID of the event this ticket belongs to.
+    pub event_id: String,
+    /// Current owner of the ticket.
+    pub owner: Address,
+    /// Price paid for this ticket.
+    pub price_paid: u128,
+    /// Current ticket status.
+    pub status: TicketStatus,
+    /// Ledger timestamp when ticket was purchased.
+    pub purchased_at: u64,
+}


### PR DESCRIPTION
## Summary

Implements the `event_ticketing` Soroban smart contract under `contracts/sandbox/event_ticketing/`, resolving all four assigned issues.

## Changes

- **`Cargo.toml`** — new crate added to workspace members (`sandbox/event_ticketing`)
- **`src/errors.rs`** — `Error` enum covering admin, event, and ticket error codes
- **`src/types.rs`** — `Event`, `EventStatus`, `Ticket`, `TicketStatus` contract types
- **`src/lib.rs`** — full contract implementation:
  - `initialize` — sets admin and payment token
  - `create_event` — admin-only event registration
  - **CT-10** `buy_ticket` — auth check, event validation (Active/SoldOut), token transfer, capacity decrement, event+owner indexing, purchase event
  - **CT-11** `transfer_ticket` — auth check, ownership validation, pre-start-time guard, re-indexes owner lists, transfer event
  - **CT-12** `cancel_ticket` — owner/admin auth, pre-start-time guard, full refund, capacity restore, cancellation event
  - **CT-13** `get_event`, `get_all_events`, `get_ticket`, `get_event_tickets`, `get_owner_tickets`, `check_event_availability`

## Testing

CI will run `cargo build` to verify compilation. Code follows the same patterns as the existing `workspace_booking` contract.

Closes #774
Closes #775
Closes #776
Closes #777