### PR TITLE
feat(contracts): governance contract — finalize, cancel, queries, tests (CT-18–21)

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -5,8 +5,9 @@ members = [
     "manage_hub",
     "membership_token",
     "common_types",
-     "workspace_booking",
-    "payment_escrow"
+    "workspace_booking",
+    "payment_escrow",
+    "sandbox/governance"
 ]
 
 [workspace.dependencies]

--- a/contracts/sandbox/governance/Cargo.toml
+++ b/contracts/sandbox/governance/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "governance"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/sandbox/governance/src/errors.rs
+++ b/contracts/sandbox/governance/src/errors.rs
@@ -1,0 +1,29 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u32)]
+pub enum Error {
+    /// Contract already initialized.
+    AlreadyInitialized = 1,
+    /// No admin set.
+    AdminNotSet = 2,
+    /// Caller is not the admin.
+    Unauthorized = 3,
+    /// Proposal ID already exists.
+    ProposalAlreadyExists = 4,
+    /// Proposal not found.
+    ProposalNotFound = 5,
+    /// Proposal is not in Active status.
+    ProposalNotActive = 6,
+    /// Voting period has not started yet.
+    VotingNotStarted = 7,
+    /// Voting period has already ended.
+    VotingPeriodEnded = 8,
+    /// Voting period has not ended yet.
+    VotingPeriodNotEnded = 9,
+    /// Member has already voted on this proposal.
+    AlreadyVoted = 10,
+    /// Invalid time range (start >= end).
+    InvalidTimeRange = 11,
+}

--- a/contracts/sandbox/governance/src/lib.rs
+++ b/contracts/sandbox/governance/src/lib.rs
@@ -1,0 +1,292 @@
+#![no_std]
+#![allow(deprecated)]
+
+mod errors;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+pub use errors::Error;
+pub use types::{Proposal, ProposalStatus, Vote, VoteChoice};
+
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, String, Vec};
+
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    Proposal(String),
+    ProposalList,
+    Vote(String, Address),
+    MemberVotes(Address),
+}
+
+// ── Contract ──────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct GovernanceContract;
+
+#[contractimpl]
+impl GovernanceContract {
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn get_admin(env: &Env) -> Result<Address, Error> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .ok_or(Error::AdminNotSet)
+    }
+
+    fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
+        let admin = Self::get_admin(env)?;
+        if caller != &admin {
+            return Err(Error::Unauthorized);
+        }
+        caller.require_auth();
+        Ok(())
+    }
+
+    fn load_proposal(env: &Env, proposal_id: &String) -> Result<Proposal, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Proposal(proposal_id.clone()))
+            .ok_or(Error::ProposalNotFound)
+    }
+
+    // ── Initialisation ────────────────────────────────────────────────────────
+
+    pub fn initialize(env: Env, admin: Address) -> Result<(), Error> {
+        if env.storage().instance().has(&DataKey::Admin) {
+            return Err(Error::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.events().publish((symbol_short!("init"),), (admin,));
+        Ok(())
+    }
+
+    // ── Proposal creation ─────────────────────────────────────────────────────
+
+    pub fn create_proposal(
+        env: Env,
+        proposer: Address,
+        proposal_id: String,
+        title: String,
+        start_time: u64,
+        end_time: u64,
+    ) -> Result<(), Error> {
+        proposer.require_auth();
+
+        if start_time >= end_time {
+            return Err(Error::InvalidTimeRange);
+        }
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::Proposal(proposal_id.clone()))
+        {
+            return Err(Error::ProposalAlreadyExists);
+        }
+
+        let proposal = Proposal {
+            id: proposal_id.clone(),
+            title: title.clone(),
+            proposer: proposer.clone(),
+            start_time,
+            end_time,
+            yes_votes: 0,
+            no_votes: 0,
+            abstain_votes: 0,
+            status: ProposalStatus::Active,
+            created_at: env.ledger().timestamp(),
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id.clone()), &proposal);
+
+        let mut list: Vec<String> = env
+            .storage()
+            .instance()
+            .get(&DataKey::ProposalList)
+            .unwrap_or(Vec::new(&env));
+        list.push_back(proposal_id.clone());
+        env.storage()
+            .instance()
+            .set(&DataKey::ProposalList, &list);
+
+        env.events().publish(
+            (symbol_short!("created"), proposal_id),
+            (proposer, title, start_time, end_time),
+        );
+        Ok(())
+    }
+
+    // ── Voting ────────────────────────────────────────────────────────────────
+
+    pub fn cast_vote(
+        env: Env,
+        voter: Address,
+        proposal_id: String,
+        choice: VoteChoice,
+    ) -> Result<(), Error> {
+        voter.require_auth();
+
+        let mut proposal = Self::load_proposal(&env, &proposal_id)?;
+
+        if proposal.status != ProposalStatus::Active {
+            return Err(Error::ProposalNotActive);
+        }
+
+        let now = env.ledger().timestamp();
+        if now < proposal.start_time {
+            return Err(Error::VotingNotStarted);
+        }
+        if now >= proposal.end_time {
+            return Err(Error::VotingPeriodEnded);
+        }
+
+        let vote_key = DataKey::Vote(proposal_id.clone(), voter.clone());
+        if env.storage().persistent().has(&vote_key) {
+            return Err(Error::AlreadyVoted);
+        }
+
+        match choice {
+            VoteChoice::Yes => proposal.yes_votes += 1,
+            VoteChoice::No => proposal.no_votes += 1,
+            VoteChoice::Abstain => proposal.abstain_votes += 1,
+        }
+
+        let vote = Vote {
+            voter: voter.clone(),
+            proposal_id: proposal_id.clone(),
+            choice: choice.clone(),
+            voted_at: now,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&vote_key, &vote);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id.clone()), &proposal);
+
+        // Index: member → voted proposal IDs
+        let mut member_votes: Vec<String> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MemberVotes(voter.clone()))
+            .unwrap_or(Vec::new(&env));
+        member_votes.push_back(proposal_id.clone());
+        env.storage()
+            .persistent()
+            .set(&DataKey::MemberVotes(voter.clone()), &member_votes);
+
+        env.events()
+            .publish((symbol_short!("voted"), proposal_id), (voter, choice));
+        Ok(())
+    }
+
+    // ── CT-18: Finalization ───────────────────────────────────────────────────
+
+    pub fn finalize_proposal(
+        env: Env,
+        caller: Address,
+        proposal_id: String,
+    ) -> Result<(), Error> {
+        Self::require_admin(&env, &caller)?;
+
+        let mut proposal = Self::load_proposal(&env, &proposal_id)?;
+
+        if proposal.status != ProposalStatus::Active {
+            return Err(Error::ProposalNotActive);
+        }
+        if env.ledger().timestamp() < proposal.end_time {
+            return Err(Error::VotingPeriodNotEnded);
+        }
+
+        proposal.status = if proposal.yes_votes > proposal.no_votes {
+            ProposalStatus::Passed
+        } else {
+            ProposalStatus::Rejected
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id.clone()), &proposal);
+
+        env.events().publish(
+            (symbol_short!("final"), proposal_id),
+            (proposal.yes_votes, proposal.no_votes, proposal.status),
+        );
+        Ok(())
+    }
+
+    // ── CT-19: Cancellation ───────────────────────────────────────────────────
+
+    pub fn cancel_proposal(
+        env: Env,
+        caller: Address,
+        proposal_id: String,
+    ) -> Result<(), Error> {
+        Self::require_admin(&env, &caller)?;
+
+        let mut proposal = Self::load_proposal(&env, &proposal_id)?;
+
+        if proposal.status != ProposalStatus::Active {
+            return Err(Error::ProposalNotActive);
+        }
+
+        proposal.status = ProposalStatus::Cancelled;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Proposal(proposal_id.clone()), &proposal);
+
+        env.events()
+            .publish((symbol_short!("cancel"), proposal_id), (caller,));
+        Ok(())
+    }
+
+    // ── CT-20: Queries ────────────────────────────────────────────────────────
+
+    pub fn get_proposal(env: Env, proposal_id: String) -> Result<Proposal, Error> {
+        Self::load_proposal(&env, &proposal_id)
+    }
+
+    pub fn get_all_proposals(env: Env) -> Vec<String> {
+        env.storage()
+            .instance()
+            .get(&DataKey::ProposalList)
+            .unwrap_or(Vec::new(&env))
+    }
+
+    pub fn get_vote(env: Env, proposal_id: String, voter: Address) -> Option<Vote> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Vote(proposal_id, voter))
+    }
+
+    pub fn get_member_votes(env: Env, voter: Address) -> Vec<String> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::MemberVotes(voter))
+            .unwrap_or(Vec::new(&env))
+    }
+
+    pub fn has_voted(env: Env, proposal_id: String, voter: Address) -> bool {
+        env.storage()
+            .persistent()
+            .has(&DataKey::Vote(proposal_id, voter))
+    }
+
+    pub fn get_proposal_result(env: Env, proposal_id: String) -> Result<ProposalStatus, Error> {
+        let proposal = Self::load_proposal(&env, &proposal_id)?;
+        Ok(proposal.status)
+    }
+
+    pub fn admin(env: Env) -> Result<Address, Error> {
+        Self::get_admin(&env)
+    }
+}

--- a/contracts/sandbox/governance/src/test.rs
+++ b/contracts/sandbox/governance/src/test.rs
@@ -1,0 +1,250 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Env, String,
+};
+
+fn setup() -> (Env, GovernanceContractClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, GovernanceContract);
+    let client = GovernanceContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin).unwrap();
+    (env, client, admin)
+}
+
+fn make_proposal(
+    env: &Env,
+    client: &GovernanceContractClient,
+    proposer: &Address,
+    id: &str,
+    start: u64,
+    end: u64,
+) {
+    client
+        .create_proposal(
+            proposer,
+            &String::from_str(env, id),
+            &String::from_str(env, "Test Proposal"),
+            &start,
+            &end,
+        )
+        .unwrap();
+}
+
+// ── CT-21 tests ───────────────────────────────────────────────────────────────
+
+#[test]
+fn test_proposal_creation_succeeds() {
+    let (env, client, _admin) = setup();
+    let proposer = Address::generate(&env);
+    env.ledger().set_timestamp(100);
+    make_proposal(&env, &client, &proposer, "prop-1", 200, 400);
+    let p = client
+        .get_proposal(&String::from_str(&env, "prop-1"))
+        .unwrap();
+    assert_eq!(p.status, ProposalStatus::Active);
+}
+
+#[test]
+fn test_proposal_creation_rejects_duplicate() {
+    let (env, client, _admin) = setup();
+    let proposer = Address::generate(&env);
+    env.ledger().set_timestamp(100);
+    make_proposal(&env, &client, &proposer, "prop-dup", 200, 400);
+    let err = client
+        .try_create_proposal(
+            &proposer,
+            &String::from_str(&env, "prop-dup"),
+            &String::from_str(&env, "Dup"),
+            &200,
+            &400,
+        )
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::ProposalAlreadyExists);
+}
+
+#[test]
+fn test_cast_vote_records_vote() {
+    let (env, client, _admin) = setup();
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    env.ledger().set_timestamp(100);
+    make_proposal(&env, &client, &proposer, "prop-v", 50, 400);
+    client
+        .cast_vote(&voter, &String::from_str(&env, "prop-v"), &VoteChoice::Yes)
+        .unwrap();
+    assert!(client.has_voted(&String::from_str(&env, "prop-v"), &voter));
+    let vote = client
+        .get_vote(&String::from_str(&env, "prop-v"), &voter)
+        .unwrap();
+    assert_eq!(vote.choice, VoteChoice::Yes);
+}
+
+#[test]
+fn test_cast_vote_rejects_double_voting() {
+    let (env, client, _admin) = setup();
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    env.ledger().set_timestamp(100);
+    make_proposal(&env, &client, &proposer, "prop-dv", 50, 400);
+    client
+        .cast_vote(&voter, &String::from_str(&env, "prop-dv"), &VoteChoice::Yes)
+        .unwrap();
+    let err = client
+        .try_cast_vote(&voter, &String::from_str(&env, "prop-dv"), &VoteChoice::No)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::AlreadyVoted);
+}
+
+#[test]
+fn test_cast_vote_fails_outside_voting_period() {
+    let (env, client, _admin) = setup();
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    // Before start
+    env.ledger().set_timestamp(100);
+    make_proposal(&env, &client, &proposer, "prop-t1", 200, 400);
+    let err = client
+        .try_cast_vote(&voter, &String::from_str(&env, "prop-t1"), &VoteChoice::Yes)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::VotingNotStarted);
+
+    // After end
+    env.ledger().set_timestamp(500);
+    let err2 = client
+        .try_cast_vote(&voter, &String::from_str(&env, "prop-t1"), &VoteChoice::Yes)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err2, Error::VotingPeriodEnded);
+}
+
+#[test]
+fn test_finalize_proposal_passed() {
+    let (env, client, admin) = setup();
+    let proposer = Address::generate(&env);
+    let voter1 = Address::generate(&env);
+    let voter2 = Address::generate(&env);
+    env.ledger().set_timestamp(100);
+    make_proposal(&env, &client, &proposer, "prop-f", 50, 200);
+    client
+        .cast_vote(&voter1, &String::from_str(&env, "prop-f"), &VoteChoice::Yes)
+        .unwrap();
+    client
+        .cast_vote(&voter2, &String::from_str(&env, "prop-f"), &VoteChoice::Yes)
+        .unwrap();
+    env.ledger().set_timestamp(300);
+    client
+        .finalize_proposal(&admin, &String::from_str(&env, "prop-f"))
+        .unwrap();
+    let p = client
+        .get_proposal(&String::from_str(&env, "prop-f"))
+        .unwrap();
+    assert_eq!(p.status, ProposalStatus::Passed);
+}
+
+#[test]
+fn test_finalize_proposal_rejected() {
+    let (env, client, admin) = setup();
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    env.ledger().set_timestamp(100);
+    make_proposal(&env, &client, &proposer, "prop-r", 50, 200);
+    client
+        .cast_vote(&voter, &String::from_str(&env, "prop-r"), &VoteChoice::No)
+        .unwrap();
+    env.ledger().set_timestamp(300);
+    client
+        .finalize_proposal(&admin, &String::from_str(&env, "prop-r"))
+        .unwrap();
+    let p = client
+        .get_proposal(&String::from_str(&env, "prop-r"))
+        .unwrap();
+    assert_eq!(p.status, ProposalStatus::Rejected);
+}
+
+#[test]
+fn test_finalize_fails_before_voting_ends() {
+    let (env, client, admin) = setup();
+    let proposer = Address::generate(&env);
+    env.ledger().set_timestamp(100);
+    make_proposal(&env, &client, &proposer, "prop-fe", 50, 500);
+    let err = client
+        .try_finalize_proposal(&admin, &String::from_str(&env, "prop-fe"))
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::VotingPeriodNotEnded);
+}
+
+#[test]
+fn test_cancel_proposal_blocks_further_voting() {
+    let (env, client, admin) = setup();
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    env.ledger().set_timestamp(100);
+    make_proposal(&env, &client, &proposer, "prop-c", 50, 500);
+    client
+        .cancel_proposal(&admin, &String::from_str(&env, "prop-c"))
+        .unwrap();
+    let p = client
+        .get_proposal(&String::from_str(&env, "prop-c"))
+        .unwrap();
+    assert_eq!(p.status, ProposalStatus::Cancelled);
+    let err = client
+        .try_cast_vote(&voter, &String::from_str(&env, "prop-c"), &VoteChoice::Yes)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::ProposalNotActive);
+}
+
+#[test]
+fn test_non_admin_cannot_finalize() {
+    let (env, client, _admin) = setup();
+    let proposer = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    env.ledger().set_timestamp(100);
+    make_proposal(&env, &client, &proposer, "prop-na", 50, 200);
+    env.ledger().set_timestamp(300);
+    let err = client
+        .try_finalize_proposal(&non_admin, &String::from_str(&env, "prop-na"))
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::Unauthorized);
+}
+
+#[test]
+fn test_non_admin_cannot_cancel() {
+    let (env, client, _admin) = setup();
+    let proposer = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    env.ledger().set_timestamp(100);
+    make_proposal(&env, &client, &proposer, "prop-nc", 50, 500);
+    let err = client
+        .try_cancel_proposal(&non_admin, &String::from_str(&env, "prop-nc"))
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, Error::Unauthorized);
+}
+
+#[test]
+fn test_get_all_proposals_and_member_votes() {
+    let (env, client, _admin) = setup();
+    let proposer = Address::generate(&env);
+    let voter = Address::generate(&env);
+    env.ledger().set_timestamp(100);
+    make_proposal(&env, &client, &proposer, "p1", 50, 500);
+    make_proposal(&env, &client, &proposer, "p2", 50, 500);
+    let all = client.get_all_proposals();
+    assert_eq!(all.len(), 2);
+    client
+        .cast_vote(&voter, &String::from_str(&env, "p1"), &VoteChoice::Yes)
+        .unwrap();
+    let mv = client.get_member_votes(&voter);
+    assert_eq!(mv.len(), 1);
+}

--- a/contracts/sandbox/governance/src/types.rs
+++ b/contracts/sandbox/governance/src/types.rs
@@ -1,0 +1,50 @@
+use soroban_sdk::{contracttype, Address, String};
+
+/// Vote choice cast by a member.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum VoteChoice {
+    Yes,
+    No,
+    Abstain,
+}
+
+/// Lifecycle status of a proposal.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum ProposalStatus {
+    /// Voting is open.
+    Active,
+    /// Voting ended; yes_votes > no_votes.
+    Passed,
+    /// Voting ended; yes_votes <= no_votes.
+    Rejected,
+    /// Cancelled by admin before finalization.
+    Cancelled,
+}
+
+/// A governance proposal.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Proposal {
+    pub id: String,
+    pub title: String,
+    pub proposer: Address,
+    pub start_time: u64,
+    pub end_time: u64,
+    pub yes_votes: u32,
+    pub no_votes: u32,
+    pub abstain_votes: u32,
+    pub status: ProposalStatus,
+    pub created_at: u64,
+}
+
+/// A single vote record.
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Vote {
+    pub voter: Address,
+    pub proposal_id: String,
+    pub choice: VoteChoice,
+    pub voted_at: u64,
+}


### PR DESCRIPTION
## Summary

Implements the full governance contract in `contracts/sandbox/governance/` addressing all four assigned issues.

## Changes

### `src/types.rs`
- `Proposal`, `ProposalStatus` (Active / Passed / Rejected / Cancelled), `Vote`, `VoteChoice`

### `src/errors.rs`
- All error variants required by the acceptance criteria

### `src/lib.rs`
- `initialize` — one-time admin setup
- `create_proposal` — any member can open a proposal with a voting window
- `cast_vote` — records Yes/No/Abstain, rejects double-votes and out-of-window votes
- **CT-18** `finalize_proposal` — admin-gated; fails if voting period hasn't ended; marks Passed/Rejected; emits event
- **CT-19** `cancel_proposal` — admin-gated; fails if not Active; sets Cancelled; emits event
- **CT-20** `get_proposal`, `get_all_proposals`, `get_vote`, `get_member_votes`, `has_voted`, `get_proposal_result`

### `src/test.rs` (CT-21)
- proposal creation succeeds and rejects duplicates
- `cast_vote` records vote and rejects double voting
- `cast_vote` fails outside voting period (before start and after end)
- `finalize_proposal` marks Passed / Rejected correctly
- `finalize_proposal` fails before voting period ends
- `cancel_proposal` works and blocks further voting
- non-admin cannot finalize or cancel
- `get_all_proposals` and `get_member_votes` return correct data

### `contracts/Cargo.toml`
- Added `sandbox/governance` to workspace members

## Closes
Closes #782
Closes #783
Closes #784
Closes #785