### PR TITLE
feat: sandbox pages for FE-13, FE-14, FE-15, FE-16

### DIFF
--- a/frontend/sandbox/admin/workspaces/new/page.tsx
+++ b/frontend/sandbox/admin/workspaces/new/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+
+const TYPES = ["Hot Desk", "Private Office", "Meeting Room", "Event Space"];
+const AMENITIES = ["WiFi", "Projector", "Whiteboard", "Coffee", "Parking", "AC", "Locker"];
+
+interface FormData {
+  name: string; type: string; seats: number; rate: number;
+  description: string; amenities: string[]; active: boolean;
+}
+
+const defaults: FormData = { name: "", type: "", seats: 1, rate: 0, description: "", amenities: [], active: true };
+
+export default function NewWorkspacePage({ initial }: { initial?: Partial<FormData> }) {
+  const [form, setForm] = useState<FormData>({ ...defaults, ...initial });
+  const [errors, setErrors] = useState<Partial<Record<keyof FormData, string>>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [toast, setToast] = useState("");
+
+  const set = (k: keyof FormData, v: unknown) => setForm((f) => ({ ...f, [k]: v }));
+
+  const toggleAmenity = (a: string) =>
+    set("amenities", form.amenities.includes(a) ? form.amenities.filter((x) => x !== a) : [...form.amenities, a]);
+
+  const validate = () => {
+    const e: typeof errors = {};
+    if (!form.name.trim()) e.name = "Name is required";
+    if (!form.type) e.type = "Type is required";
+    if (form.seats < 1) e.seats = "Must be at least 1";
+    if (form.rate <= 0) e.rate = "Must be greater than 0";
+    setErrors(e);
+    return !Object.keys(e).length;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+    setSubmitting(true);
+    await new Promise((r) => setTimeout(r, 800)); // mock API
+    setSubmitting(false);
+    setToast(initial ? "Workspace updated!" : "Workspace created!");
+    setTimeout(() => setToast(""), 3000);
+  };
+
+  const field = "w-full px-3.5 py-2.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-gray-200";
+  const err = (k: keyof FormData) => errors[k] && <p className="text-red-500 text-xs mt-1">{errors[k]}</p>;
+
+  return (
+    <div className="max-w-xl mx-auto py-10 px-4">
+      <h1 className="text-xl font-bold text-gray-900 mb-6">{initial ? "Edit Workspace" : "New Workspace"}</h1>
+
+      {toast && <div className="mb-4 px-4 py-3 bg-emerald-50 text-emerald-700 text-sm rounded-lg">{toast}</div>}
+
+      <form onSubmit={handleSubmit} className="space-y-4 bg-white rounded-xl border border-gray-100 p-6">
+        <div>
+          <label className="block text-xs font-medium text-gray-500 mb-1.5">Name</label>
+          <input className={field} value={form.name} onChange={(e) => set("name", e.target.value)} />
+          {err("name")}
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-500 mb-1.5">Type</label>
+          <select className={field} value={form.type} onChange={(e) => set("type", e.target.value)}>
+            <option value="">Select type</option>
+            {TYPES.map((t) => <option key={t}>{t}</option>)}
+          </select>
+          {err("type")}
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1.5">Total Seats</label>
+            <input type="number" className={field} value={form.seats} onChange={(e) => set("seats", +e.target.value)} />
+            {err("seats")}
+          </div>
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1.5">Hourly Rate (₦)</label>
+            <input type="number" className={field} value={form.rate} onChange={(e) => set("rate", +e.target.value)} />
+            {err("rate")}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-500 mb-1.5">Description</label>
+          <textarea className={`${field} resize-none`} rows={3} value={form.description} onChange={(e) => set("description", e.target.value)} />
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-500 mb-2">Amenities</label>
+          <div className="flex flex-wrap gap-2">
+            {AMENITIES.map((a) => (
+              <button key={a} type="button" onClick={() => toggleAmenity(a)}
+                className={`px-3 py-1 text-xs rounded-full border transition-colors ${form.amenities.includes(a) ? "bg-gray-900 text-white border-gray-900" : "border-gray-200 text-gray-600 hover:border-gray-400"}`}>
+                {a}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between py-2">
+          <span className="text-sm text-gray-700">Active</span>
+          <button type="button" role="switch" aria-checked={form.active} onClick={() => set("active", !form.active)}
+            className={`relative inline-flex h-6 w-11 rounded-full transition-colors ${form.active ? "bg-gray-900" : "bg-gray-200"}`}>
+            <span className={`inline-block h-5 w-5 rounded-full bg-white shadow transform transition-transform mt-0.5 ${form.active ? "translate-x-[22px]" : "translate-x-0.5"}`} />
+          </button>
+        </div>
+
+        <button type="submit" disabled={submitting}
+          className="w-full py-2.5 text-sm font-medium rounded-lg bg-gray-900 text-white hover:bg-gray-800 disabled:opacity-50 transition-colors">
+          {submitting ? "Saving..." : initial ? "Save changes" : "Create workspace"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/sandbox/components/EmptyState.tsx
+++ b/frontend/sandbox/components/EmptyState.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { CalendarX, BellOff, ReceiptText, Building2 } from "lucide-react";
+import { ReactNode } from "react";
+
+interface EmptyStateProps {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  action?: { label: string; href: string };
+}
+
+export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+      <div className="w-14 h-14 rounded-full bg-gray-100 flex items-center justify-center mb-4 text-gray-400">
+        {icon}
+      </div>
+      <h3 className="text-base font-semibold text-gray-900 mb-1">{title}</h3>
+      <p className="text-sm text-gray-400 max-w-xs">{description}</p>
+      {action && (
+        <Link
+          href={action.href}
+          className="mt-5 px-5 py-2.5 text-sm font-medium rounded-lg bg-gray-900 text-white hover:bg-gray-800 transition-colors"
+        >
+          {action.label}
+        </Link>
+      )}
+    </div>
+  );
+}
+
+export function EmptyBookings() {
+  return (
+    <EmptyState
+      icon={<CalendarX className="w-6 h-6" />}
+      title="No bookings yet"
+      description="You haven't made any bookings. Reserve a workspace to get started."
+      action={{ label: "Browse workspaces", href: "/workspaces" }}
+    />
+  );
+}
+
+export function EmptyNotifications() {
+  return (
+    <EmptyState
+      icon={<BellOff className="w-6 h-6" />}
+      title="All caught up"
+      description="You have no notifications right now. Check back later."
+    />
+  );
+}
+
+export function EmptyInvoices() {
+  return (
+    <EmptyState
+      icon={<ReceiptText className="w-6 h-6" />}
+      title="No invoices"
+      description="Invoices for your bookings will appear here once generated."
+    />
+  );
+}
+
+export function EmptyWorkspaces() {
+  return (
+    <EmptyState
+      icon={<Building2 className="w-6 h-6" />}
+      title="No workspaces found"
+      description="No workspaces match your search. Try adjusting your filters."
+      action={{ label: "Clear filters", href: "/workspaces" }}
+    />
+  );
+}

--- a/frontend/sandbox/components/MobileNavDrawer.tsx
+++ b/frontend/sandbox/components/MobileNavDrawer.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { X, LayoutDashboard, Building2, CalendarCheck, Fingerprint, FileText, Bell, Settings, User } from "lucide-react";
+
+const LINKS = [
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/workspaces", label: "Workspaces", icon: Building2 },
+  { href: "/bookings", label: "Bookings", icon: CalendarCheck },
+  { href: "/check-in", label: "Check-in", icon: Fingerprint },
+  { href: "/invoices", label: "Invoices", icon: FileText },
+  { href: "/notifications", label: "Notifications", icon: Bell },
+  { href: "/settings", label: "Settings", icon: Settings },
+  { href: "/profile", label: "Profile", icon: User },
+];
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function MobileNavDrawer({ open, onClose }: Props) {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (open) document.body.style.overflow = "hidden";
+    else document.body.style.overflow = "";
+    return () => { document.body.style.overflow = ""; };
+  }, [open]);
+
+  return (
+    <>
+      {/* Overlay */}
+      <div
+        onClick={onClose}
+        className={`fixed inset-0 bg-black/40 z-40 transition-opacity duration-300 ${
+          open ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+        }`}
+      />
+
+      {/* Drawer */}
+      <aside
+        className={`fixed top-0 left-0 h-full w-64 bg-white z-50 shadow-xl flex flex-col transform transition-transform duration-300 ${
+          open ? "translate-x-0" : "-translate-x-full"
+        }`}
+      >
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+          <span className="font-bold text-gray-900">ManageHub</span>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <nav className="flex-1 overflow-y-auto py-3">
+          {LINKS.map(({ href, label, icon: Icon }) => {
+            const active = pathname === href;
+            return (
+              <Link
+                key={href}
+                href={href}
+                onClick={onClose}
+                className={`flex items-center gap-3 px-5 py-3 text-sm transition-colors ${
+                  active
+                    ? "bg-gray-900 text-white font-medium"
+                    : "text-gray-600 hover:bg-gray-50"
+                }`}
+              >
+                <Icon className="w-4 h-4 shrink-0" />
+                {label}
+              </Link>
+            );
+          })}
+        </nav>
+      </aside>
+    </>
+  );
+}

--- a/frontend/sandbox/settings/notifications/page.tsx
+++ b/frontend/sandbox/settings/notifications/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Bell } from "lucide-react";
+
+type Pref = { email: boolean; inApp: boolean };
+type Prefs = Record<string, Pref>;
+
+const ITEMS = [
+  "Booking confirmations",
+  "Check-in reminders",
+  "Payment receipts",
+  "Newsletter",
+  "New feature announcements",
+];
+
+const defaultPrefs = (): Prefs =>
+  Object.fromEntries(ITEMS.map((k) => [k, { email: true, inApp: true }]));
+
+function Toggle({ checked, onChange }: { checked: boolean; onChange: () => void }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={onChange}
+      className={`relative inline-flex h-6 w-11 shrink-0 rounded-full transition-colors ${
+        checked ? "bg-gray-900" : "bg-gray-200"
+      }`}
+    >
+      <span
+        className={`inline-block h-5 w-5 rounded-full bg-white shadow transform transition-transform mt-0.5 ${
+          checked ? "translate-x-[22px]" : "translate-x-0.5"
+        }`}
+      />
+    </button>
+  );
+}
+
+export default function NotificationPreferencesPage() {
+  const [prefs, setPrefs] = useState<Prefs>(defaultPrefs);
+  const [saving, setSaving] = useState(false);
+
+  const toggle = useCallback((item: string, channel: "email" | "inApp") => {
+    setPrefs((p) => {
+      const next = { ...p, [item]: { ...p[item], [channel]: !p[item][channel] } };
+      setSaving(true);
+      // debounced mock save
+      setTimeout(() => setSaving(false), 800);
+      return next;
+    });
+  }, []);
+
+  return (
+    <div className="max-w-2xl mx-auto py-10 px-4">
+      <div className="flex items-center gap-2 mb-6">
+        <Bell className="w-5 h-5 text-gray-500" />
+        <h1 className="text-xl font-bold text-gray-900">Notification Preferences</h1>
+        {saving && <span className="ml-auto text-xs text-gray-400">Saving...</span>}
+      </div>
+
+      <div className="bg-white rounded-xl border border-gray-100 divide-y divide-gray-50">
+        <div className="grid grid-cols-[1fr_80px_80px] px-5 py-2 text-xs font-medium text-gray-400">
+          <span />
+          <span className="text-center">Email</span>
+          <span className="text-center">In-app</span>
+        </div>
+        {ITEMS.map((item) => (
+          <div key={item} className="grid grid-cols-[1fr_80px_80px] items-center px-5 py-4">
+            <span className="text-sm text-gray-800">{item}</span>
+            <div className="flex justify-center">
+              <Toggle checked={prefs[item].email} onChange={() => toggle(item, "email")} />
+            </div>
+            <div className="flex justify-center">
+              <Toggle checked={prefs[item].inApp} onChange={() => toggle(item, "inApp")} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #847, closes #848, closes #849, closes #850

- **FE-13** — Notification preferences page with per-category Email/In-app toggles and a debounced save indicator
- **FE-14** — Mobile nav drawer that slides in from the left, highlights the active route, and closes on overlay click
- **FE-15** — Reusable `EmptyState` component plus four presets (Bookings, Notifications, Invoices, Workspaces)
- **FE-16** — Admin workspace creation/edit form with validation, amenity tag picker, and a mock submit handler