### PR TITLE
feat: FE-31/32/33/34 - wallet connect, workspace search, error pages, audit logs

### DIFF
--- a/frontend/sandbox/admin/audit-logs/page.tsx
+++ b/frontend/sandbox/admin/audit-logs/page.tsx
@@ -1,0 +1,73 @@
+"use client";
+import { useState } from "react";
+
+const MOCK = Array.from({ length: 60 }, (_, i) => ({
+  id: i + 1, timestamp: new Date(Date.now() - i * 3e6).toISOString(),
+  actor: `user${i % 5}@hub.com`, action: ["CREATE", "UPDATE", "DELETE", "LOGIN"][i % 4],
+  targetType: ["Workspace", "Member", "Booking"][i % 3], targetId: `${100 + i}`,
+  details: JSON.stringify({ field: "status", from: "active", to: "inactive", reason: "admin action" }),
+}));
+
+const PAGE_SIZE = 25;
+
+export default function AuditLogsPage() {
+  const [action, setAction] = useState("");
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [page, setPage] = useState(1);
+  const [modal, setModal] = useState<string | null>(null);
+
+  const filtered = MOCK.filter((l) =>
+    (!action || l.action === action) &&
+    (!from || l.timestamp >= from) &&
+    (!to || l.timestamp <= to + "T23:59:59Z")
+  );
+  const paged = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+
+  return (
+    <div className="p-6">
+      <h1 className="text-xl font-bold mb-4">Audit Logs</h1>
+      <div className="flex gap-3 mb-4 flex-wrap">
+        <select value={action} onChange={(e) => { setAction(e.target.value); setPage(1); }}
+          className="border rounded px-3 py-1.5 text-sm">
+          <option value="">All Actions</option>
+          {["CREATE","UPDATE","DELETE","LOGIN"].map((a) => <option key={a}>{a}</option>)}
+        </select>
+        <input type="date" value={from} onChange={(e) => setFrom(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
+        <input type="date" value={to} onChange={(e) => setTo(e.target.value)} className="border rounded px-3 py-1.5 text-sm" />
+      </div>
+      {paged.length === 0 ? <p className="text-gray-500 text-center mt-12">No logs match the current filters.</p> : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead><tr className="bg-gray-50 text-left">{["Timestamp","Actor","Action","Target Type","Target ID","Details"].map((h) => <th key={h} className="px-3 py-2 border-b font-medium">{h}</th>)}</tr></thead>
+            <tbody>{paged.map((l) => (
+              <tr key={l.id} className="border-b hover:bg-gray-50">
+                <td className="px-3 py-2 whitespace-nowrap">{new Date(l.timestamp).toLocaleString()}</td>
+                <td className="px-3 py-2">{l.actor}</td>
+                <td className="px-3 py-2"><span className="bg-blue-50 text-blue-700 px-2 py-0.5 rounded text-xs">{l.action}</span></td>
+                <td className="px-3 py-2">{l.targetType}</td>
+                <td className="px-3 py-2">{l.targetId}</td>
+                <td className="px-3 py-2 cursor-pointer text-blue-600 hover:underline" onClick={() => setModal(l.details)}>{l.details.slice(0, 30)}…</td>
+              </tr>
+            ))}</tbody>
+          </table>
+        </div>
+      )}
+      <div className="flex gap-2 mt-4 justify-end text-sm">
+        <button disabled={page === 1} onClick={() => setPage(page - 1)} className="px-3 py-1 border rounded disabled:opacity-40">Prev</button>
+        <span className="px-2 py-1">{page} / {totalPages || 1}</span>
+        <button disabled={page >= totalPages} onClick={() => setPage(page + 1)} className="px-3 py-1 border rounded disabled:opacity-40">Next</button>
+      </div>
+      {modal && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50" onClick={() => setModal(null)}>
+          <div className="bg-white rounded-lg p-6 max-w-lg w-full shadow-xl" onClick={(e) => e.stopPropagation()}>
+            <h2 className="font-semibold mb-3">Log Details</h2>
+            <pre className="text-xs bg-gray-50 p-3 rounded overflow-auto max-h-64">{JSON.stringify(JSON.parse(modal), null, 2)}</pre>
+            <button onClick={() => setModal(null)} className="mt-4 px-4 py-1.5 bg-gray-800 text-white rounded text-sm">Close</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/sandbox/components/FreighterConnectButton.tsx
+++ b/frontend/sandbox/components/FreighterConnectButton.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { useEffect, useState } from "react";
+
+const FREIGHTER_URL = "https://www.freighter.app/";
+const LS_KEY = "freighter_pubkey";
+
+function truncate(key: string) {
+  return `${key.slice(0, 4)}...${key.slice(-4)}`;
+}
+
+export default function FreighterConnectButton() {
+  const [pubkey, setPubkey] = useState<string | null>(null);
+  const [installed, setInstalled] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(LS_KEY);
+    if (stored) setPubkey(stored);
+    setInstalled(typeof window !== "undefined" && !!(window as any).freighter);
+  }, []);
+
+  async function connect() {
+    try {
+      const { getPublicKey } = await import("@stellar/freighter-api");
+      const key = await getPublicKey();
+      localStorage.setItem(LS_KEY, key);
+      setPubkey(key);
+    } catch (e) {
+      console.error("Freighter connect failed", e);
+    }
+  }
+
+  function disconnect() {
+    localStorage.removeItem(LS_KEY);
+    setPubkey(null);
+  }
+
+  if (!installed) {
+    return (
+      <a
+        href={FREIGHTER_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="px-4 py-2 rounded bg-blue-600 text-white text-sm hover:bg-blue-700"
+      >
+        Install Freighter
+      </a>
+    );
+  }
+
+  return pubkey ? (
+    <div className="flex items-center gap-3">
+      <span className="text-sm font-mono bg-gray-100 px-3 py-1 rounded">{truncate(pubkey)}</span>
+      <button onClick={disconnect} className="px-3 py-1 text-sm rounded border border-red-400 text-red-500 hover:bg-red-50">
+        Disconnect
+      </button>
+    </div>
+  ) : (
+    <button onClick={connect} className="px-4 py-2 rounded bg-blue-600 text-white text-sm hover:bg-blue-700">
+      Connect Wallet
+    </button>
+  );
+}

--- a/frontend/sandbox/error.tsx
+++ b/frontend/sandbox/error.tsx
@@ -1,0 +1,24 @@
+"use client";
+import Link from "next/link";
+
+export default function ErrorPage({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center text-center px-4">
+      <svg className="w-24 h-24 text-red-400 mb-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+          d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+      </svg>
+      <h1 className="text-4xl font-bold text-gray-800 mb-2">Something went wrong</h1>
+      <p className="text-gray-500 mb-2">{error?.message ?? "An unexpected error occurred."}</p>
+      <p className="text-sm text-gray-400 mb-8">Please try again or return home.</p>
+      <div className="flex gap-4">
+        <button onClick={reset} className="px-5 py-2 bg-red-500 text-white rounded hover:bg-red-600 transition">
+          Try again
+        </button>
+        <Link href="/" className="px-5 py-2 border border-gray-300 rounded hover:bg-gray-50 transition">
+          Go home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/sandbox/not-found.tsx
+++ b/frontend/sandbox/not-found.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center text-center px-4">
+      <svg className="w-24 h-24 text-blue-400 mb-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5}
+          d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <h1 className="text-5xl font-bold text-gray-800 mb-2">404</h1>
+      <p className="text-lg text-gray-500 mb-8">Oops! The page you're looking for doesn't exist.</p>
+      <Link href="/dashboard" className="px-6 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition">
+        Go to Dashboard
+      </Link>
+    </div>
+  );
+}

--- a/frontend/sandbox/workspaces/page.tsx
+++ b/frontend/sandbox/workspaces/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+const MOCK = [
+  { id: 1, name: "The Hive", type: "Hot Desk", rate: 5, seats: 12, amenities: ["WiFi", "Coffee"] },
+  { id: 2, name: "Focus Pod", type: "Private Office", rate: 20, seats: 1, amenities: ["WiFi", "AC"] },
+  { id: 3, name: "Collab Room", type: "Meeting Room", rate: 15, seats: 8, amenities: ["Projector", "WiFi"] },
+  { id: 4, name: "Quiet Zone", type: "Hot Desk", rate: 4, seats: 6, amenities: ["WiFi"] },
+];
+
+export default function WorkspacesPage() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [query, setQuery] = useState(params.get("q") ?? "");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const t = setTimeout(() => setLoading(false), 500);
+    return () => clearTimeout(t);
+  }, []);
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      const url = query ? `?q=${encodeURIComponent(query)}` : "?";
+      router.replace(url);
+    }, 350);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const results = MOCK.filter(
+    (w) => w.name.toLowerCase().includes(query.toLowerCase()) || w.type.toLowerCase().includes(query.toLowerCase())
+  );
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <div className="relative mb-6">
+        <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Search workspaces…"
+          className="w-full border rounded px-4 py-2 pr-10 focus:outline-none focus:ring-2 focus:ring-blue-500" />
+        {query && <button onClick={() => setQuery("")} className="absolute right-3 top-2.5 text-gray-400 hover:text-gray-600">×</button>}
+      </div>
+      {loading ? (
+        <div className="space-y-3">{[...Array(3)].map((_, i) => <div key={i} className="h-20 bg-gray-100 rounded animate-pulse" />)}</div>
+      ) : results.length === 0 ? (
+        <p className="text-center text-gray-500 mt-12">No workspaces match your search.</p>
+      ) : (
+        <div className="space-y-3">
+          {results.map((w) => (
+            <div key={w.id} className="border rounded p-4 flex justify-between items-start">
+              <div>
+                <p className="font-semibold">{w.name}</p>
+                <p className="text-sm text-gray-500">{w.type} · ${w.rate}/hr · {w.seats} seats</p>
+                <div className="flex gap-1 mt-1">{w.amenities.map((a) => <span key={a} className="text-xs bg-blue-50 text-blue-600 px-2 py-0.5 rounded-full">{a}</span>)}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #894, closes #895, closes #896, closes #897

- **FE-31**: `FreighterConnectButton` detects Freighter extension, connects wallet via `getPublicKey()`, persists address in localStorage, and shows disconnect option.
- **FE-32**: Workspace search page with 350ms debounced input, live filtering by name/type, URL `?q=` sync, empty state, and loading skeleton.
- **FE-33**: Custom `not-found.tsx` (404) and `error.tsx` (500) pages with Heroicons, Tailwind styling, and reset/navigation actions.
- **FE-34**: Admin audit log table with action-type filter, date range pickers, paginated 25 rows/page, and a modal for prettified JSON details.