### PR TITLE
sandbox endpoints BE-22 to BE-25

### DIFF
--- a/backend/sandbox/checkin-history.ts
+++ b/backend/sandbox/checkin-history.ts
@@ -1,0 +1,55 @@
+import { Controller, Get, Param, Query, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, FindOptionsWhere, Repository } from 'typeorm';
+import { WorkspaceLog } from '../workspace/entities/workspace-log.entity';
+
+@Controller('sandbox/checkins')
+@UseGuards(JwtAuthGuard)
+export class CheckinHistoryController {
+  constructor(
+    @InjectRepository(WorkspaceLog)
+    private readonly logs: Repository<WorkspaceLog>,
+  ) {}
+
+  private async getHistory(
+    userId: string,
+    q: { from?: string; to?: string; workspaceId?: string; page?: string; limit?: string },
+  ) {
+    const page = Math.max(1, parseInt(q.page ?? '1'));
+    const limit = Math.min(100, parseInt(q.limit ?? '20'));
+
+    const where: FindOptionsWhere<WorkspaceLog> = { userId };
+    if (q.workspaceId) where.workspaceId = q.workspaceId;
+    if (q.from && q.to) where.checkedInAt = Between(new Date(q.from), new Date(q.to));
+
+    const [rows, total] = await this.logs.findAndCount({
+      where,
+      relations: ['workspace'],
+      order: { checkedInAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    const data = rows.map((r) => ({
+      workspaceName: r.workspace?.name,
+      checkedInAt: r.checkedInAt,
+      checkedOutAt: r.checkedOutAt,
+      durationMinutes: r.checkedOutAt
+        ? Math.round((r.checkedOutAt.getTime() - r.checkedInAt.getTime()) / 60000)
+        : null,
+    }));
+
+    return { data, total, page, limit };
+  }
+
+  @Get('history')
+  myHistory(@Req() req: any, @Query() q: any) {
+    return this.getHistory(req.user.id, q);
+  }
+
+  @Get('history/:userId')
+  userHistory(@Param('userId') userId: string, @Query() q: any) {
+    return this.getHistory(userId, q);
+  }
+}

--- a/backend/sandbox/invoice-search.ts
+++ b/backend/sandbox/invoice-search.ts
@@ -1,0 +1,50 @@
+import { Controller, Get, HttpException, HttpStatus, Query, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Between, FindOptionsWhere, Repository } from 'typeorm';
+import { Invoice } from '../invoices/entities/invoice.entity';
+
+@Controller('sandbox')
+@UseGuards(JwtAuthGuard)
+export class InvoiceSearchController {
+  constructor(
+    @InjectRepository(Invoice)
+    private readonly invoices: Repository<Invoice>,
+  ) {}
+
+  @Get('invoices')
+  async search(
+    @Req() req: any,
+    @Query() q: { status?: string; from?: string; to?: string; minAmount?: string; maxAmount?: string; page?: string; limit?: string },
+  ) {
+    const page = Math.max(1, parseInt(q.page ?? '1'));
+    const limit = Math.min(100, parseInt(q.limit ?? '20'));
+
+    const from = q.from ? new Date(q.from) : undefined;
+    const to = q.to ? new Date(q.to) : undefined;
+    if ((q.from && isNaN(from!.getTime())) || (q.to && isNaN(to!.getTime()))) {
+      throw new HttpException('Invalid date param', HttpStatus.BAD_REQUEST);
+    }
+
+    const minKobo = q.minAmount ? parseFloat(q.minAmount) * 100 : undefined;
+    const maxKobo = q.maxAmount ? parseFloat(q.maxAmount) * 100 : undefined;
+    if ((q.minAmount && isNaN(minKobo!)) || (q.maxAmount && isNaN(maxKobo!))) {
+      throw new HttpException('Invalid amount param', HttpStatus.BAD_REQUEST);
+    }
+
+    const where: FindOptionsWhere<Invoice> = {};
+    if (!req.user.isAdmin) where.userId = req.user.id;
+    if (q.status) where.status = q.status as any;
+    if (from && to) where.createdAt = Between(from, to);
+    if (minKobo && maxKobo) where.amountKobo = Between(minKobo, maxKobo);
+
+    const [data, total] = await this.invoices.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return { data, total, page, limit };
+  }
+}

--- a/backend/sandbox/notification-read-all.ts
+++ b/backend/sandbox/notification-read-all.ts
@@ -1,0 +1,41 @@
+import { Controller, HttpCode, HttpStatus, Patch, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Notification } from '../notifications/entities/notification.entity';
+import { WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Server } from 'socket.io';
+
+@WebSocketGateway({ cors: true })
+@Controller('sandbox')
+@UseGuards(JwtAuthGuard)
+export class NotificationReadAllController {
+  @WebSocketServer()
+  private server: Server;
+
+  constructor(
+    @InjectRepository(Notification)
+    private readonly notifications: Repository<Notification>,
+  ) {}
+
+  @Patch('notifications/read-all')
+  @HttpCode(HttpStatus.OK)
+  async markAllRead(@Req() req: any) {
+    const userId: string = req.user.id;
+
+    const unread = await this.notifications.find({
+      where: { userId, isRead: false },
+    });
+
+    if (unread.length === 0) return { updated: 0 };
+
+    await this.notifications.update(
+      { userId, isRead: false },
+      { isRead: true },
+    );
+
+    this.server?.to(userId).emit('notifications:all-read', { updated: unread.length });
+
+    return { updated: unread.length };
+  }
+}

--- a/backend/sandbox/profile-update.ts
+++ b/backend/sandbox/profile-update.ts
@@ -1,0 +1,51 @@
+import { Body, Controller, HttpCode, HttpException, HttpStatus, Patch, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../users/entities/user.entity';
+
+const NIGERIAN_PHONE = /^(\+234|0)[789]\d{9}$/;
+
+function profileCompleteness(user: Partial<User>): number {
+  const fields = ['firstname', 'lastname', 'username', 'phone', 'email'];
+  const filled = fields.filter((f) => !!(user as any)[f]).length;
+  return Math.round((filled / fields.length) * 100);
+}
+
+@Controller('sandbox')
+@UseGuards(JwtAuthGuard)
+export class ProfileUpdateController {
+  constructor(
+    @InjectRepository(User)
+    private readonly users: Repository<User>,
+  ) {}
+
+  @Patch('profile')
+  @HttpCode(HttpStatus.OK)
+  async updateProfile(
+    @Req() req: any,
+    @Body() body: { firstname?: string; lastname?: string; username?: string; phone?: string },
+  ) {
+    const { firstname, lastname, username, phone } = body;
+    const userId: string = req.user.id;
+
+    if (phone && !NIGERIAN_PHONE.test(phone)) {
+      throw new HttpException('Invalid Nigerian phone number', HttpStatus.BAD_REQUEST);
+    }
+
+    if (username) {
+      const taken = await this.users.findOne({ where: { username } });
+      if (taken && taken.id !== userId) {
+        throw new HttpException('Username already taken', HttpStatus.CONFLICT);
+      }
+    }
+
+    const user = await this.users.findOneOrFail({ where: { id: userId } });
+    Object.assign(user, { firstname, lastname, username, phone });
+    (user as any).profileCompleteness = profileCompleteness(user);
+    await this.users.save(user);
+
+    const { password, refreshToken, ...safe } = user as any;
+    return safe;
+  }
+}


### PR DESCRIPTION
Implements four sandbox endpoints:

- **BE-22** (#826): `PATCH /sandbox/profile` — update member profile fields with Nigerian phone validation, unique username check, and profileCompleteness recalculation.
- **BE-23** (#827): `GET /sandbox/invoices` — invoice listing with status, date range, amount (Naira→kobo), and pagination filters.
- **BE-24** (#828): `PATCH /sandbox/notifications/read-all` — marks all unread notifications as read, returns count, emits WebSocket event.
- **BE-25** (#829): `GET /sandbox/checkins/history` and `GET /sandbox/checkins/history/:userId` — paginated check-in/out history with date and workspace filters.

Closes #826, closes #827, closes #828, closes #829