### PR TITLE
feat: lazy image with blur placeholder

### DIFF
--- a/frontend/sandbox/components/LazyImage.tsx
+++ b/frontend/sandbox/components/LazyImage.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+
+interface LazyImageProps {
+  src: string;
+  alt: string;
+  width: number;
+  height: number;
+  blurDataUrl?: string;
+}
+
+export function LazyImage({ src, alt, width, height, blurDataUrl }: LazyImageProps) {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <div className="relative overflow-hidden" style={{ width, height }}>
+      {!loaded && (
+        blurDataUrl ? (
+          <img
+            src={blurDataUrl}
+            alt=""
+            aria-hidden
+            className="absolute inset-0 w-full h-full object-cover"
+            style={{ filter: "blur(10px)", transform: "scale(1.05)" }}
+          />
+        ) : (
+          <div className="absolute inset-0 bg-gray-200 animate-pulse" />
+        )
+      )}
+      <img
+        src={src}
+        alt={alt}
+        width={width}
+        height={height}
+        loading="lazy"
+        onLoad={() => setLoaded(true)}
+        className="absolute inset-0 w-full h-full object-cover transition-opacity duration-500"
+        style={{ opacity: loaded ? 1 : 0 }}
+      />
+    </div>
+  );
+}

--- a/frontend/sandbox/page.tsx
+++ b/frontend/sandbox/page.tsx
@@ -1,0 +1,23 @@
+import { LazyImage } from "./components/LazyImage";
+
+const images = [
+  { src: "https://picsum.photos/seed/a/600/400", alt: "Office space A" },
+  { src: "https://picsum.photos/seed/b/600/400", alt: "Office space B" },
+  { src: "https://picsum.photos/seed/c/600/400", alt: "Office space C" },
+  { src: "https://picsum.photos/seed/d/600/400", alt: "Office space D" },
+  { src: "https://picsum.photos/seed/e/600/400", alt: "Office space E" },
+  { src: "https://picsum.photos/seed/f/600/400", alt: "Office space F" },
+];
+
+export default function SandboxPage() {
+  return (
+    <main className="p-8">
+      <h1 className="text-2xl font-semibold mb-6">LazyImage Demo</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {images.map((img) => (
+          <LazyImage key={img.src} src={img.src} alt={img.alt} width={600} height={400} />
+        ))}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Adds a `LazyImage` component that shows a blurred placeholder while the full image loads, falling back to an animated shimmer when no blur URL is provided. Includes a 6-image grid demo page in `frontend/sandbox/`.

Closes #898