### PR TITLE
feat: ActivityFeed, StatCard, WorkspaceImageManager, notifications infinite scroll

### DIFF
--- a/frontend/sandbox/components/ActivityFeed.tsx
+++ b/frontend/sandbox/components/ActivityFeed.tsx
@@ -1,0 +1,86 @@
+"use client";
+import { useState } from "react";
+import { ReactNode } from "react";
+import { CalendarPlus, LogIn, LogOut, Receipt, CalendarX } from "lucide-react";
+
+export type ActivityType =
+  | "booking_created"
+  | "checkin"
+  | "checkout"
+  | "invoice_paid"
+  | "booking_cancelled";
+
+export interface Activity {
+  id: string;
+  type: ActivityType;
+  description: string;
+  timestamp: string | Date;
+  icon?: ReactNode;
+}
+
+const TYPE_ICONS: Record<ActivityType, ReactNode> = {
+  booking_created: <CalendarPlus className="w-4 h-4" />,
+  checkin: <LogIn className="w-4 h-4" />,
+  checkout: <LogOut className="w-4 h-4" />,
+  invoice_paid: <Receipt className="w-4 h-4" />,
+  booking_cancelled: <CalendarX className="w-4 h-4" />,
+};
+
+const TYPE_COLORS: Record<ActivityType, string> = {
+  booking_created: "bg-blue-100 text-blue-600",
+  checkin: "bg-green-100 text-green-600",
+  checkout: "bg-gray-100 text-gray-600",
+  invoice_paid: "bg-purple-100 text-purple-600",
+  booking_cancelled: "bg-red-100 text-red-600",
+};
+
+function relativeTime(ts: string | Date): string {
+  const diff = (Date.now() - new Date(ts).getTime()) / 1000;
+  if (diff < 60) return "just now";
+  if (diff < 3600) return `${Math.floor(diff / 60)} minutes ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)} hours ago`;
+  return `${Math.floor(diff / 86400)} days ago`;
+}
+
+const PAGE_SIZE = 5;
+
+interface ActivityFeedProps {
+  activities: Activity[];
+}
+
+export default function ActivityFeed({ activities }: ActivityFeedProps) {
+  const [visible, setVisible] = useState(PAGE_SIZE);
+
+  if (activities.length === 0) {
+    return (
+      <div className="flex flex-col items-center py-12 text-gray-400">
+        <CalendarX className="w-8 h-8 mb-2" />
+        <p className="text-sm">No activity yet</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {activities.slice(0, visible).map((a) => (
+        <div key={a.id} className="flex items-start gap-3 p-3 rounded-lg hover:bg-gray-50 transition-colors">
+          <span className={`mt-0.5 flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center ${TYPE_COLORS[a.type]}`}>
+            {a.icon ?? TYPE_ICONS[a.type]}
+          </span>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm text-gray-800">{a.description}</p>
+            <p className="text-xs text-gray-400 mt-0.5">{relativeTime(a.timestamp)}</p>
+          </div>
+        </div>
+      ))}
+      {visible < activities.length && (
+        <button
+          onClick={() => setVisible((v) => v + PAGE_SIZE)}
+          className="w-full mt-2 py-2 text-sm text-blue-600 hover:text-blue-700 font-medium"
+        >
+          Load more
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/sandbox/components/StatCard.tsx
+++ b/frontend/sandbox/components/StatCard.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { useEffect, useRef, useState, ReactNode } from "react";
+import { TrendingUp, TrendingDown } from "lucide-react";
+
+interface Trend {
+  direction: "up" | "down";
+  percent: number;
+}
+
+interface StatCardProps {
+  label: string;
+  value: number;
+  unit?: string;
+  icon: ReactNode;
+  iconBg?: string;
+  trend?: Trend;
+}
+
+function useCountUp(target: number, duration = 1200) {
+  const [count, setCount] = useState(0);
+  const raf = useRef<number>(0);
+
+  useEffect(() => {
+    const start = performance.now();
+    const tick = (now: number) => {
+      const progress = Math.min((now - start) / duration, 1);
+      setCount(Math.floor(progress * target));
+      if (progress < 1) raf.current = requestAnimationFrame(tick);
+    };
+    raf.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf.current);
+  }, [target, duration]);
+
+  return count;
+}
+
+export default function StatCard({ label, value, unit, icon, iconBg = "bg-blue-100 text-blue-600", trend }: StatCardProps) {
+  const count = useCountUp(value);
+
+  return (
+    <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-5 flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-500">{label}</span>
+        <span className={`w-9 h-9 rounded-full flex items-center justify-center ${iconBg}`}>{icon}</span>
+      </div>
+      <div className="flex items-end gap-2">
+        <span className="text-3xl font-bold text-gray-900">
+          {unit && <span className="text-xl mr-0.5">{unit}</span>}
+          {count.toLocaleString()}
+        </span>
+        {trend && (
+          <span className={`flex items-center gap-0.5 text-sm font-medium mb-0.5 ${trend.direction === "up" ? "text-green-600" : "text-red-500"}`}>
+            {trend.direction === "up" ? <TrendingUp className="w-4 h-4" /> : <TrendingDown className="w-4 h-4" />}
+            {trend.percent}%
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/sandbox/components/WorkspaceImageManager.tsx
+++ b/frontend/sandbox/components/WorkspaceImageManager.tsx
@@ -1,0 +1,113 @@
+"use client";
+import { useRef, useState, DragEvent, ChangeEvent } from "react";
+import { UploadCloud, X } from "lucide-react";
+
+const ALLOWED = ["image/jpeg", "image/png", "image/webp"];
+const MAX_SIZE = 5 * 1024 * 1024;
+
+interface UploadingFile {
+  name: string;
+  progress: number;
+  error?: string;
+}
+
+interface WorkspaceImageManagerProps {
+  images: string[];
+  onUpload: (file: File) => Promise<void>;
+  onDelete: (url: string) => void;
+}
+
+export default function WorkspaceImageManager({ images, onUpload, onDelete }: WorkspaceImageManagerProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragging, setDragging] = useState(false);
+  const [uploading, setUploading] = useState<UploadingFile[]>([]);
+
+  function validate(file: File): string | null {
+    if (!ALLOWED.includes(file.type)) return "Only JPG, PNG, or WebP files are allowed.";
+    if (file.size > MAX_SIZE) return "File must be under 5MB.";
+    return null;
+  }
+
+  async function handleFiles(files: FileList | null) {
+    if (!files) return;
+    for (const file of Array.from(files)) {
+      const error = validate(file);
+      if (error) {
+        setUploading((u) => [...u, { name: file.name, progress: 0, error }]);
+        continue;
+      }
+      setUploading((u) => [...u, { name: file.name, progress: 0 }]);
+      // Simulate progress then call onUpload
+      for (let p = 20; p <= 80; p += 20) {
+        await new Promise((r) => setTimeout(r, 150));
+        setUploading((u) => u.map((f) => f.name === file.name ? { ...f, progress: p } : f));
+      }
+      try {
+        await onUpload(file);
+        setUploading((u) => u.map((f) => f.name === file.name ? { ...f, progress: 100 } : f));
+      } catch {
+        setUploading((u) => u.map((f) => f.name === file.name ? { ...f, error: "Upload failed." } : f));
+      }
+      setTimeout(() => setUploading((u) => u.filter((f) => f.name !== file.name)), 1200);
+    }
+  }
+
+  function onDrop(e: DragEvent) {
+    e.preventDefault();
+    setDragging(false);
+    handleFiles(e.dataTransfer.files);
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Drop zone */}
+      <div
+        onClick={() => inputRef.current?.click()}
+        onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={onDrop}
+        className={`border-2 border-dashed rounded-xl p-8 flex flex-col items-center gap-2 cursor-pointer transition-colors ${dragging ? "border-blue-500 bg-blue-50" : "border-gray-300 hover:border-gray-400"}`}
+      >
+        <UploadCloud className="w-8 h-8 text-gray-400" />
+        <p className="text-sm text-gray-500">Drag & drop images here, or <span className="text-blue-600 font-medium">browse</span></p>
+        <p className="text-xs text-gray-400">JPG, PNG, WebP · max 5MB</p>
+        <input ref={inputRef} type="file" accept=".jpg,.jpeg,.png,.webp" multiple className="hidden"
+          onChange={(e: ChangeEvent<HTMLInputElement>) => handleFiles(e.target.files)} />
+      </div>
+
+      {/* Upload progress */}
+      {uploading.map((f) => (
+        <div key={f.name} className="space-y-1">
+          <div className="flex justify-between text-xs text-gray-500">
+            <span className="truncate max-w-xs">{f.name}</span>
+            {f.error ? <span className="text-red-500">{f.error}</span> : <span>{f.progress}%</span>}
+          </div>
+          {!f.error && (
+            <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
+              <div className="h-full bg-blue-500 transition-all duration-200" style={{ width: `${f.progress}%` }} />
+            </div>
+          )}
+        </div>
+      ))}
+
+      {/* Image grid */}
+      {images.length > 0 && (
+        <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
+          {images.map((url) => (
+            <div key={url} className="relative group aspect-square rounded-lg overflow-hidden border border-gray-100">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={url} alt="" className="w-full h-full object-cover" />
+              <button
+                onClick={() => onDelete(url)}
+                className="absolute top-1 right-1 w-6 h-6 rounded-full bg-black/60 text-white flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                aria-label="Delete image"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/sandbox/notifications/page.tsx
+++ b/frontend/sandbox/notifications/page.tsx
@@ -1,0 +1,101 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+interface Notification {
+  id: number;
+  title: string;
+  body: string;
+  read: boolean;
+  timestamp: string;
+}
+
+const ALL_NOTIFICATIONS: Notification[] = Array.from({ length: 60 }, (_, i) => ({
+  id: i + 1,
+  title: ["Booking confirmed", "Invoice due", "Check-in reminder", "New message", "Workspace update"][i % 5],
+  body: `Notification #${i + 1} — ${["Your booking has been confirmed.", "An invoice is due for payment.", "Don't forget your check-in today.", "You have a new message.", "A workspace you follow was updated."][i % 5]}`,
+  read: i % 3 === 0,
+  timestamp: new Date(Date.now() - i * 3600_000).toISOString(),
+}));
+
+const PAGE_SIZE = 20;
+
+function fetchPage(page: number): Promise<Notification[]> {
+  return new Promise((resolve) =>
+    setTimeout(() => {
+      const start = page * PAGE_SIZE;
+      resolve(ALL_NOTIFICATIONS.slice(start, start + PAGE_SIZE));
+    }, 600)
+  );
+}
+
+export default function NotificationsPage() {
+  const [items, setItems] = useState<Notification[]>([]);
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  async function loadMore() {
+    if (loading || done) return;
+    setLoading(true);
+    const next = await fetchPage(page);
+    if (next.length < PAGE_SIZE) setDone(true);
+    setItems((prev) => [...prev, ...next]);
+    setPage((p) => p + 1);
+    setLoading(false);
+  }
+
+  // Initial load
+  useEffect(() => { loadMore(); }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // IntersectionObserver for infinite scroll
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) loadMore();
+    }, { threshold: 0.1 });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loading, done, page]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  function markRead(id: number) {
+    setItems((prev) => prev.map((n) => n.id === id ? { ...n, read: true } : n));
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <h1 className="text-xl font-semibold text-gray-900 mb-4">Notifications</h1>
+      <div className="space-y-2">
+        {items.map((n) => (
+          <div
+            key={n.id}
+            onClick={() => markRead(n.id)}
+            className={`p-4 rounded-lg border cursor-pointer transition-colors hover:bg-gray-50 ${!n.read ? "border-l-4 border-l-blue-500 border-gray-100 bg-blue-50/30" : "border-gray-100"}`}
+          >
+            <div className="flex justify-between items-start gap-2">
+              <p className={`text-sm font-medium ${!n.read ? "text-gray-900" : "text-gray-600"}`}>{n.title}</p>
+              <span className="text-xs text-gray-400 whitespace-nowrap">
+                {new Date(n.timestamp).toLocaleDateString()}
+              </span>
+            </div>
+            <p className="text-sm text-gray-500 mt-0.5">{n.body}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* Sentinel for IntersectionObserver */}
+      <div ref={sentinelRef} className="h-4" />
+
+      {loading && (
+        <div className="flex justify-center py-6">
+          <div className="w-6 h-6 border-2 border-blue-500 border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+
+      {done && !loading && (
+        <p className="text-center text-sm text-gray-400 py-6">You&apos;re all caught up 🎉</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/sandbox/page.tsx
+++ b/frontend/sandbox/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+import { useState } from "react";
+import { Users, CalendarCheck, DollarSign, Clock } from "lucide-react";
+import StatCard from "./components/StatCard";
+import ActivityFeed, { Activity } from "./components/ActivityFeed";
+import WorkspaceImageManager from "./components/WorkspaceImageManager";
+
+const MOCK_ACTIVITIES: Activity[] = [
+  { id: "1", type: "booking_created", description: "Booked The Hive for 3 hours", timestamp: new Date(Date.now() - 7200_000) },
+  { id: "2", type: "checkin", description: "Checked in to Focus Pod", timestamp: new Date(Date.now() - 14400_000) },
+  { id: "3", type: "invoice_paid", description: "Invoice #INV-042 paid — ₦12,000", timestamp: new Date(Date.now() - 86400_000) },
+  { id: "4", type: "checkout", description: "Checked out of Collab Room", timestamp: new Date(Date.now() - 90000_000) },
+  { id: "5", type: "booking_cancelled", description: "Cancelled booking for Quiet Zone", timestamp: new Date(Date.now() - 172800_000) },
+  { id: "6", type: "booking_created", description: "Booked Collab Room for a team meeting", timestamp: new Date(Date.now() - 259200_000) },
+  { id: "7", type: "checkin", description: "Checked in to The Hive", timestamp: new Date(Date.now() - 345600_000) },
+];
+
+const MOCK_IMAGES = [
+  "https://images.unsplash.com/photo-1497366216548-37526070297c?w=400&q=80",
+  "https://images.unsplash.com/photo-1497366811353-6870744d04b2?w=400&q=80",
+  "https://images.unsplash.com/photo-1524758631624-e2822e304c36?w=400&q=80",
+];
+
+export default function SandboxPage() {
+  const [images, setImages] = useState<string[]>(MOCK_IMAGES);
+
+  async function handleUpload(file: File) {
+    await new Promise((r) => setTimeout(r, 800));
+    const url = URL.createObjectURL(file);
+    setImages((prev) => [...prev, url]);
+  }
+
+  function handleDelete(url: string) {
+    setImages((prev) => prev.filter((u) => u !== url));
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-10">
+      <section>
+        <h2 className="text-lg font-semibold text-gray-800 mb-4">Dashboard Stats</h2>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <StatCard label="Total Members" value={1284} icon={<Users className="w-5 h-5" />} iconBg="bg-blue-100 text-blue-600" trend={{ direction: "up", percent: 12 }} />
+          <StatCard label="Bookings Today" value={47} icon={<CalendarCheck className="w-5 h-5" />} iconBg="bg-green-100 text-green-600" trend={{ direction: "up", percent: 5 }} />
+          <StatCard label="Revenue" value={284500} unit="₦" icon={<DollarSign className="w-5 h-5" />} iconBg="bg-purple-100 text-purple-600" trend={{ direction: "down", percent: 3 }} />
+          <StatCard label="Avg. Hours/Day" value={6} icon={<Clock className="w-5 h-5" />} iconBg="bg-orange-100 text-orange-600" />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-gray-800 mb-4">Recent Activity</h2>
+        <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-4">
+          <ActivityFeed activities={MOCK_ACTIVITIES} />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-gray-800 mb-4">Workspace Images</h2>
+        <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-4">
+          <WorkspaceImageManager images={images} onUpload={handleUpload} onDelete={handleDelete} />
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements four frontend sandbox components in a single PR.

### Changes

**`frontend/sandbox/components/ActivityFeed.tsx`** — closes #855
- Chronological activity feed with 5 typed activities (booking_created, checkin, checkout, invoice_paid, booking_cancelled)
- Distinct lucide icons per type, relative timestamps ("2 hours ago")
- Load-more button (5 items per page), empty state

**`frontend/sandbox/components/StatCard.tsx`** — closes #860
- Animated counter from 0 → value over 1.2s using `requestAnimationFrame`
- Props: `label`, `value`, `unit`, `icon`, `iconBg`, `trend`
- Trend shown as green/red arrow with percentage
- Icon rendered in a colored circle

**`frontend/sandbox/components/WorkspaceImageManager.tsx`** — closes #862
- Drag-and-drop upload zone (also click-to-browse)
- Per-file upload progress bar with simulated progress
- Validates jpg/png/webp and max 5MB before upload
- Preview grid with hover-reveal delete button
- Props: `images`, `onUpload`, `onDelete`

**`frontend/sandbox/notifications/page.tsx`** — closes #857
- Loads first 20 notifications on mount
- IntersectionObserver triggers next page load on scroll to bottom
- Loading spinner while fetching, "You're all caught up" when exhausted
- Unread notifications highlighted with blue left border
- Mark as read on click

**`frontend/sandbox/page.tsx`** — demo page rendering all three components with mock data

## Closes
Closes #855
Closes #857
Closes #860
Closes #862