### PR TITLE
feat: implement referral contract (CT-34 → CT-37)

### DIFF
--- a/contracts/sandbox/referral/referral.register.ts
+++ b/contracts/sandbox/referral/referral.register.ts
@@ -1,0 +1,56 @@
+// CT-35: Referral code registration — register_code logic
+
+import { ReferralCode, Referral, DataKey, ContractError } from './referral.types';
+
+export interface ReferralStore {
+  codes: Map<string, ReferralCode>;
+  addressCodes: Map<string, string>;
+  referrals: Map<string, Referral>;
+}
+
+export function createStore(): ReferralStore {
+  return { codes: new Map(), addressCodes: new Map(), referrals: new Map() };
+}
+
+/**
+ * Register a unique referral code for a referrer address.
+ * Emits a 'code_registered' event on success.
+ */
+export function registerCode(
+  store: ReferralStore,
+  referrer: string,
+  code: string,
+  emit: (event: string, data: Record<string, unknown>) => void,
+): ReferralCode {
+  if (!referrer) throw new Error(ContractError.Unauthorized);
+
+  if (store.codes.has(code)) {
+    throw new Error(ContractError.CodeAlreadyExists);
+  }
+
+  if (store.addressCodes.has(referrer)) {
+    throw new Error(ContractError.CodeAlreadyExists);
+  }
+
+  const record: ReferralCode = {
+    code,
+    referrer,
+    createdAt: Date.now(),
+    totalUses: 0,
+  };
+
+  store.codes.set(code, record);
+  store.addressCodes.set(referrer, code);
+
+  emit('code_registered', { referrer, code, createdAt: record.createdAt });
+
+  return record;
+}
+
+export function getCodeByAddress(store: ReferralStore, referrer: string): string | null {
+  return store.addressCodes.get(referrer) ?? null;
+}
+
+export function getCode(store: ReferralStore, code: string): ReferralCode | null {
+  return store.codes.get(code) ?? null;
+}

--- a/contracts/sandbox/referral/referral.rewards.ts
+++ b/contracts/sandbox/referral/referral.rewards.ts
@@ -1,0 +1,51 @@
+// CT-37: Referral reward distribution — pay_referral_reward and set_reward_amount
+
+import { ContractError, ContractState } from './referral.types';
+import { ReferralStore } from './referral.register';
+
+/**
+ * Admin-only: transfer reward_amount of payment token to the referrer
+ * for a given referee's completed qualifying action.
+ * Emits a 'reward_paid' event on success.
+ */
+export function payReferralReward(
+  store: ReferralStore,
+  state: ContractState,
+  caller: string,
+  referee: string,
+  transfer: (token: string, to: string, amount: bigint) => void,
+  emit: (event: string, data: Record<string, unknown>) => void,
+): void {
+  if (caller !== state.admin) throw new Error(ContractError.Unauthorized);
+
+  const referral = store.referrals.get(referee);
+  if (!referral) throw new Error(ContractError.CodeNotFound);
+
+  if (referral.rewardPaid) return;
+
+  if (state.rewardAmount <= 0n) throw new Error(ContractError.InvalidReward);
+
+  transfer(state.paymentToken, referral.referrer, state.rewardAmount);
+
+  referral.rewardPaid = true;
+
+  emit('reward_paid', {
+    referee,
+    referrer: referral.referrer,
+    amount: state.rewardAmount.toString(),
+    token: state.paymentToken,
+  });
+}
+
+/**
+ * Admin-only: update the reward amount for future distributions.
+ */
+export function setRewardAmount(
+  state: ContractState,
+  caller: string,
+  amount: bigint,
+): ContractState {
+  if (caller !== state.admin) throw new Error(ContractError.Unauthorized);
+  if (amount <= 0n) throw new Error(ContractError.InvalidReward);
+  return { ...state, rewardAmount: amount };
+}

--- a/contracts/sandbox/referral/referral.tracking.ts
+++ b/contracts/sandbox/referral/referral.tracking.ts
@@ -1,0 +1,53 @@
+// CT-36: Referral tracking and validation — use_referral_code logic
+
+import { Referral, ContractError } from './referral.types';
+import { ReferralStore } from './referral.register';
+
+/**
+ * Link a referee to a referrer via a referral code.
+ * Validates code existence, self-referral, and duplicate usage.
+ * Emits a 'referral_used' event on success.
+ */
+export function useReferralCode(
+  store: ReferralStore,
+  referee: string,
+  code: string,
+  emit: (event: string, data: Record<string, unknown>) => void,
+): Referral {
+  if (!referee) throw new Error(ContractError.Unauthorized);
+
+  const referralCode = store.codes.get(code);
+  if (!referralCode) throw new Error(ContractError.CodeNotFound);
+
+  if (referralCode.referrer === referee) {
+    throw new Error(ContractError.SelfReferral);
+  }
+
+  if (store.referrals.has(referee)) {
+    throw new Error(ContractError.AlreadyReferred);
+  }
+
+  const record: Referral = {
+    code,
+    referrer: referralCode.referrer,
+    referee,
+    registeredAt: Date.now(),
+    rewardPaid: false,
+  };
+
+  store.referrals.set(referee, record);
+  referralCode.totalUses += 1;
+
+  emit('referral_used', {
+    referee,
+    referrer: referralCode.referrer,
+    code,
+    totalUses: referralCode.totalUses,
+  });
+
+  return record;
+}
+
+export function getReferral(store: ReferralStore, referee: string): Referral | null {
+  return store.referrals.get(referee) ?? null;
+}

--- a/contracts/sandbox/referral/referral.types.ts
+++ b/contracts/sandbox/referral/referral.types.ts
@@ -1,0 +1,54 @@
+// CT-34: Referral contract types — ReferralCode, Referral, Reward, DataKey, errors
+
+export interface ReferralCode {
+  code: string;
+  referrer: string;
+  createdAt: number;
+  totalUses: number;
+}
+
+export interface Referral {
+  code: string;
+  referrer: string;
+  referee: string;
+  registeredAt: number;
+  rewardPaid: boolean;
+}
+
+export interface Reward {
+  amount: bigint;
+  token: string;
+}
+
+export enum DataKey {
+  Admin = 'Admin',
+  PaymentToken = 'PaymentToken',
+  ReferralReward = 'ReferralReward',
+  Code = 'Code',
+  AddressCode = 'AddressCode',
+  ReferralRecord = 'ReferralRecord',
+  ReferralList = 'ReferralList',
+}
+
+export enum ContractError {
+  AdminNotSet = 'AdminNotSet',
+  AlreadyInitialized = 'AlreadyInitialized',
+  Unauthorized = 'Unauthorized',
+  CodeNotFound = 'CodeNotFound',
+  CodeAlreadyExists = 'CodeAlreadyExists',
+  AlreadyReferred = 'AlreadyReferred',
+  InvalidReward = 'InvalidReward',
+  SelfReferral = 'SelfReferral',
+}
+
+export interface ContractState {
+  admin: string;
+  paymentToken: string;
+  rewardAmount: bigint;
+}
+
+/** Stub: initialize the referral contract */
+export function initialize(state: ContractState, rewardAmount: bigint): ContractState {
+  if (rewardAmount <= 0n) throw new Error(ContractError.InvalidReward);
+  return { ...state, rewardAmount };
+}


### PR DESCRIPTION
Implements the full referral contract TypeScript layer across four files:

- **referral.types.ts** — scaffolds `ReferralCode`, `Referral`, `Reward`, `DataKey` enum, all error variants, and `initialize` stub (CT-34)
- **referral.register.ts** — `registerCode` with auth check, duplicate-code and duplicate-address guards, and event emission (CT-35)
- **referral.tracking.ts** — `useReferralCode` with `CodeNotFound`, `SelfReferral`, and `AlreadyReferred` validation plus `totalUses` increment (CT-36)
- **referral.rewards.ts** — admin-gated `payReferralReward` (token transfer, marks `rewardPaid`) and `setRewardAmount` (CT-37)

Closes #798, Closes #799, Closes #800, Closes #801