### PR TITLE
feat: sandbox implementations for BE-14, BE-15, BE-16, BE-17

### DIFF
--- a/backend/sandbox/booking-extension.ts
+++ b/backend/sandbox/booking-extension.ts
@@ -1,0 +1,63 @@
+import {
+  Controller, Post, Patch, Body, Param, UseGuards,
+  NotFoundException, ConflictException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn } from 'typeorm';
+import { RolesGuard } from '../src/auth/guard/roles.guard';
+import { Roles } from '../src/auth/decorators/roles.decorators';
+import { UserRole } from '../src/users/enums/userRoles.enum';
+
+export type ExtensionStatus = 'pending' | 'approved' | 'rejected';
+
+@Entity()
+export class BookingExtensionRequest {
+  @PrimaryGeneratedColumn('uuid') id: string;
+  @Column() bookingId: string;
+  @Column() userId: string;
+  @Column({ type: 'date' }) newEndDate: string;
+  @Column({ default: 'pending' }) status: ExtensionStatus;
+  @CreateDateColumn() createdAt: Date;
+}
+
+@Controller('sandbox/bookings')
+@UseGuards(RolesGuard)
+export class BookingExtensionController {
+  constructor(
+    @InjectRepository(BookingExtensionRequest)
+    private readonly extRepo: Repository<BookingExtensionRequest>,
+  ) {}
+
+  @Post(':id/extend')
+  async requestExtension(
+    @Param('id') bookingId: string,
+    @Body() dto: { newEndDate: string; userId: string },
+  ) {
+    const pending = await this.extRepo.findOne({ where: { bookingId, status: 'pending' } });
+    if (pending) throw new ConflictException('Extension request already pending');
+
+    const req = this.extRepo.create({ bookingId, userId: dto.userId, newEndDate: dto.newEndDate });
+    return this.extRepo.save(req);
+  }
+
+  @Patch('extensions/:id/approve')
+  @Roles(UserRole.ADMIN)
+  async approve(@Param('id') id: string) {
+    const ext = await this.extRepo.findOneOrFail({ where: { id } }).catch(() => {
+      throw new NotFoundException('Extension request not found');
+    });
+    ext.status = 'approved';
+    return this.extRepo.save(ext);
+  }
+
+  @Patch('extensions/:id/reject')
+  @Roles(UserRole.ADMIN)
+  async reject(@Param('id') id: string) {
+    const ext = await this.extRepo.findOneOrFail({ where: { id } }).catch(() => {
+      throw new NotFoundException('Extension request not found');
+    });
+    ext.status = 'rejected';
+    return this.extRepo.save(ext);
+  }
+}

--- a/backend/sandbox/newsletter-unsubscribe.ts
+++ b/backend/sandbox/newsletter-unsubscribe.ts
@@ -1,0 +1,52 @@
+import { Controller, Get, Query, BadRequestException, Res } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Response } from 'express';
+import * as jwt from 'jsonwebtoken';
+
+// Minimal subscriber shape
+interface Subscriber { email: string; unsubscribed: boolean; }
+
+const HTML_OK = `<!DOCTYPE html><html><body>
+  <h2>You have been unsubscribed.</h2>
+  <p>You will no longer receive newsletters from us.</p>
+</body></html>`;
+
+const HTML_ERR = `<!DOCTYPE html><html><body>
+  <h2>Invalid or expired link.</h2>
+  <p>Please request a new unsubscribe link.</p>
+</body></html>`;
+
+@Controller('sandbox/newsletter')
+export class NewsletterUnsubscribeController {
+  constructor(
+    @InjectRepository('Subscriber')
+    private readonly subRepo: Repository<Subscriber>,
+  ) {}
+
+  @Get('unsubscribe')
+  async unsubscribe(@Query('token') token: string, @Res() res: Response) {
+    if (!token) {
+      return res.status(400).type('html').send(HTML_ERR);
+    }
+
+    let email: string;
+    try {
+      const secret = process.env.JWT_SECRET;
+      const payload = jwt.verify(token, secret) as { email: string };
+      email = payload.email;
+    } catch {
+      return res.status(400).type('html').send(HTML_ERR);
+    }
+
+    const subscriber = await this.subRepo.findOne({ where: { email } } as any);
+    if (!subscriber) {
+      return res.status(400).type('html').send(HTML_ERR);
+    }
+
+    subscriber.unsubscribed = true;
+    await (this.subRepo as any).save(subscriber);
+
+    return res.type('html').send(HTML_OK);
+  }
+}

--- a/backend/sandbox/seat-booking.ts
+++ b/backend/sandbox/seat-booking.ts
@@ -1,0 +1,59 @@
+import {
+  Controller, Post, Get, Body, Param, Query,
+  BadRequestException, ConflictException, NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class SeatBooking {
+  @PrimaryGeneratedColumn('uuid') id: string;
+  @Column() workspaceId: string;
+  @Column() seatNumber: number;
+  @Column() bookingId: string;
+  @Column({ type: 'date' }) date: string;
+}
+
+// Minimal workspace shape expected from DB
+interface Workspace { id: string; totalSeats: number; }
+
+@Controller('sandbox')
+export class SeatBookingController {
+  constructor(
+    @InjectRepository(SeatBooking)
+    private readonly seatRepo: Repository<SeatBooking>,
+    @InjectRepository('Workspace')
+    private readonly wsRepo: Repository<Workspace>,
+  ) {}
+
+  @Post('seat-bookings')
+  async book(@Body() dto: { workspaceId: string; seatNumber: number; bookingId: string; date: string }) {
+    const ws = await this.wsRepo.findOne({ where: { id: dto.workspaceId } });
+    if (!ws) throw new NotFoundException('Workspace not found');
+    if (dto.seatNumber < 1 || dto.seatNumber > ws.totalSeats)
+      throw new BadRequestException(`Seat must be between 1 and ${ws.totalSeats}`);
+
+    const taken = await this.seatRepo.findOne({
+      where: { workspaceId: dto.workspaceId, seatNumber: dto.seatNumber, date: dto.date },
+    });
+    if (taken) throw new ConflictException('Seat already booked for this date');
+
+    return this.seatRepo.save(this.seatRepo.create(dto));
+  }
+
+  @Get('workspaces/:id/seats')
+  async availability(@Param('id') workspaceId: string, @Query('date') date: string) {
+    if (!date) throw new BadRequestException('date query param required');
+    const ws = await this.wsRepo.findOne({ where: { id: workspaceId } });
+    if (!ws) throw new NotFoundException('Workspace not found');
+
+    const booked = await this.seatRepo.find({ where: { workspaceId, date } });
+    const bookedNums = new Set(booked.map((b) => b.seatNumber));
+
+    return Array.from({ length: ws.totalSeats }, (_, i) => ({
+      seatNumber: i + 1,
+      available: !bookedNums.has(i + 1),
+    }));
+  }
+}

--- a/backend/sandbox/workspace-image-upload.ts
+++ b/backend/sandbox/workspace-image-upload.ts
@@ -1,0 +1,46 @@
+import {
+  Controller, Post, Param, UseGuards, UseInterceptors,
+  UploadedFile, BadRequestException,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { memoryStorage } from 'multer';
+import { RolesGuard } from '../src/auth/guard/roles.guard';
+import { Roles } from '../src/auth/decorators/roles.decorators';
+import { UserRole } from '../src/users/enums/userRoles.enum';
+import { CloudinaryService } from '../src/cloudinary/cloudinary.service';
+
+const ALLOWED_MIME = ['image/jpeg', 'image/png', 'image/webp'];
+const MAX_SIZE = 5 * 1024 * 1024; // 5 MB
+
+@Controller('sandbox/workspaces')
+@UseGuards(RolesGuard)
+@Roles(UserRole.ADMIN)
+export class WorkspaceImageUploadController {
+  constructor(private readonly cloudinary: CloudinaryService) {}
+
+  @Post(':id/images')
+  @UseInterceptors(
+    FileInterceptor('image', {
+      storage: memoryStorage(),
+      limits: { fileSize: MAX_SIZE },
+    }),
+  )
+  async uploadImage(
+    @Param('id') workspaceId: string,
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    if (!file) throw new BadRequestException('Image file is required');
+
+    if (!ALLOWED_MIME.includes(file.mimetype))
+      throw new BadRequestException('Only jpg, png, and webp files are allowed');
+
+    if (file.size > MAX_SIZE)
+      throw new BadRequestException('File size must not exceed 5MB');
+
+    const result = await this.cloudinary.uploadImage(file, `workspaces/${workspaceId}`);
+
+    if ('error' in result) throw new BadRequestException('Upload failed');
+
+    return { url: (result as any).secure_url };
+  }
+}


### PR DESCRIPTION
Closes #818, Closes #819, Closes #820, Closes #821

- **BE-14** (#818): `booking-extension.ts` — POST to submit extension requests, PATCH admin approve/reject endpoints with conflict guard
- **BE-15** (#819): `newsletter-unsubscribe.ts` — Public GET endpoint, verifies JWT-signed token, marks subscriber unsubscribed, returns HTML confirmation
- **BE-16** (#820): `seat-booking.ts` — POST to book a specific seat with availability validation, GET to list seat availability by date
- **BE-17** (#821): `workspace-image-upload.ts` — Admin POST to upload workspace images to Cloudinary, validates mime type (jpg/png/webp) and 5MB size limit

All files in `backend/sandbox/`.