### PR TITLE
feat: add MemberTierBadge and WorkspaceUtilizationCard components

### DIFF
--- a/frontend/cntr/MemberTierBadge/MemberTierBadge.test.tsx
+++ b/frontend/cntr/MemberTierBadge/MemberTierBadge.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { MemberTierBadge } from './MemberTierBadge';
+
+describe('MemberTierBadge', () => {
+  it('renders Bronze', () => { render(<MemberTierBadge tier="BRONZE" />); expect(screen.getByText('Bronze')).toBeInTheDocument(); });
+  it('renders Silver', () => { render(<MemberTierBadge tier="SILVER" />); expect(screen.getByText('Silver')).toBeInTheDocument(); });
+  it('renders Gold', () => { render(<MemberTierBadge tier="GOLD" />); expect(screen.getByText('Gold')).toBeInTheDocument(); });
+  it('renders Platinum', () => { render(<MemberTierBadge tier="PLATINUM" />); expect(screen.getByText('Platinum')).toBeInTheDocument(); });
+});

--- a/frontend/cntr/MemberTierBadge/MemberTierBadge.tsx
+++ b/frontend/cntr/MemberTierBadge/MemberTierBadge.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Award } from 'lucide-react';
+
+export type MemberTier = 'BRONZE' | 'SILVER' | 'GOLD' | 'PLATINUM';
+
+const tierConfig: Record<MemberTier, { color: string; label: string }> = {
+  BRONZE:   { color: '#CD7F32', label: 'Bronze' },
+  SILVER:   { color: '#C0C0C0', label: 'Silver' },
+  GOLD:     { color: '#FFD700', label: 'Gold' },
+  PLATINUM: { color: '#E5E4E2', label: 'Platinum' },
+};
+
+export function MemberTierBadge({ tier }: { tier: MemberTier }) {
+  const { color, label } = tierConfig[tier];
+  return (
+    <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium text-white" style={{ backgroundColor: color }}>
+      <Award size={12} />
+      {label}
+    </span>
+  );
+}

--- a/frontend/cntr/UtilizationCard/WorkspaceUtilizationCard.test.tsx
+++ b/frontend/cntr/UtilizationCard/WorkspaceUtilizationCard.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { WorkspaceUtilizationCard } from './WorkspaceUtilizationCard';
+
+const stats = { utilizationPercent: 75, totalBookedHours: 120, peakDate: '2024-01-01', quietDate: '2024-01-07' };
+
+describe('WorkspaceUtilizationCard', () => {
+  it('renders workspace name', () => { render(<WorkspaceUtilizationCard workspaceName="Hub A" capacity={10} stats={stats} />); expect(screen.getByText(/Hub A/)).toBeInTheDocument(); });
+  it('renders utilization percent', () => { render(<WorkspaceUtilizationCard workspaceName="Hub A" capacity={10} stats={stats} />); expect(screen.getByText('75%')).toBeInTheDocument(); });
+});

--- a/frontend/cntr/UtilizationCard/WorkspaceUtilizationCard.tsx
+++ b/frontend/cntr/UtilizationCard/WorkspaceUtilizationCard.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface UtilizationStats { utilizationPercent: number; totalBookedHours: number; peakDate: string; quietDate: string; }
+interface Props { workspaceName: string; capacity: number; stats: UtilizationStats; }
+
+function ringColor(pct: number) { return pct >= 80 ? '#ef4444' : pct >= 50 ? '#eab308' : '#22c55e'; }
+function fmtDay(d: string) { return new Intl.DateTimeFormat('en', { weekday: 'long' }).format(new Date(d)); }
+
+export function WorkspaceUtilizationCard({ workspaceName, capacity, stats }: Props) {
+  const { utilizationPercent: pct, totalBookedHours, peakDate, quietDate } = stats;
+  const r = 40; const circ = 2 * Math.PI * r; const dash = (pct / 100) * circ;
+  return (
+    <div className="rounded-lg border p-4 space-y-3">
+      <h3 className="font-semibold text-sm">{workspaceName} <span className="text-muted-foreground">(cap: {capacity})</span></h3>
+      <div className="flex justify-center">
+        <svg width="100" height="100" viewBox="0 0 100 100">
+          <circle cx="50" cy="50" r={r} fill="none" stroke="#e5e7eb" strokeWidth="10" />
+          <circle cx="50" cy="50" r={r} fill="none" stroke={ringColor(pct)} strokeWidth="10"
+            strokeDasharray={`${dash} ${circ}`} strokeLinecap="round" transform="rotate(-90 50 50)" />
+          <text x="50" y="55" textAnchor="middle" fontSize="14" fontWeight="bold">{pct}%</text>
+        </svg>
+      </div>
+      <div className="text-xs space-y-1">
+        <p>Booked hours: <strong>{totalBookedHours}</strong></p>
+        <p>Peak day: <strong>{fmtDay(peakDate)}</strong></p>
+        <p>Quiet day: <strong>{fmtDay(quietDate)}</strong></p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds MemberTierBadge component for Bronze/Silver/Gold/Platinum tiers with lucide-react icon, and WorkspaceUtilizationCard with SVG circular progress ring and three colour bands.

closes #1015
closes #1016