### PR TITLE
feat: add Correlation ID middleware and Response Transformer interceptor

### DIFF
--- a/backend/cntr/correlation-id.middleware.spec.ts
+++ b/backend/cntr/correlation-id.middleware.spec.ts
@@ -1,0 +1,21 @@
+import { CorrelationIdMiddleware } from './correlation-id.middleware';
+
+describe('CorrelationIdMiddleware', () => {
+  let middleware: CorrelationIdMiddleware;
+  beforeEach(() => { middleware = new CorrelationIdMiddleware(); });
+
+  it('generates a correlation ID when none present', () => {
+    const req: any = { headers: {} };
+    const res: any = { setHeader: jest.fn() };
+    middleware.use(req, res, jest.fn());
+    expect(req.headers['x-correlation-id']).toMatch(/^[0-9a-f-]{36}$/);
+    expect(res.setHeader).toHaveBeenCalledWith('X-Correlation-ID', req.headers['x-correlation-id']);
+  });
+
+  it('preserves existing correlation ID', () => {
+    const req: any = { headers: { 'x-correlation-id': 'existing-id' } };
+    const res: any = { setHeader: jest.fn() };
+    middleware.use(req, res, jest.fn());
+    expect(req.headers['x-correlation-id']).toBe('existing-id');
+  });
+});

--- a/backend/cntr/correlation-id.middleware.ts
+++ b/backend/cntr/correlation-id.middleware.ts
@@ -1,0 +1,14 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+
+@Injectable()
+export class CorrelationIdMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction): void {
+    const existing = req.headers['x-correlation-id'] as string | undefined;
+    const correlationId = existing ?? randomUUID();
+    req.headers['x-correlation-id'] = correlationId;
+    res.setHeader('X-Correlation-ID', correlationId);
+    next();
+  }
+}

--- a/backend/cntr/response-transformer.interceptor.spec.ts
+++ b/backend/cntr/response-transformer.interceptor.spec.ts
@@ -1,0 +1,15 @@
+import { ResponseTransformerInterceptor } from './response-transformer.interceptor';
+import { of } from 'rxjs';
+
+describe('ResponseTransformerInterceptor', () => {
+  it('wraps response in success envelope', (done) => {
+    const interceptor = new ResponseTransformerInterceptor();
+    const next = { handle: () => of({ id: 1 }) };
+    interceptor.intercept({} as any, next as any).subscribe((result: any) => {
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ id: 1 });
+      expect(typeof result.timestamp).toBe('string');
+      done();
+    });
+  });
+});

--- a/backend/cntr/response-transformer.interceptor.ts
+++ b/backend/cntr/response-transformer.interceptor.ts
@@ -1,0 +1,16 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler } from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable()
+export class ResponseTransformerInterceptor implements NestInterceptor {
+  intercept(_ctx: ExecutionContext, next: CallHandler): Observable<unknown> {
+    return next.handle().pipe(
+      map((data) => ({
+        success: true,
+        data,
+        timestamp: new Date().toISOString(),
+      })),
+    );
+  }
+}


### PR DESCRIPTION
Adds CorrelationIdMiddleware that generates/preserves a UUID v4 per request and echoes it in the response header, and ResponseTransformerInterceptor that wraps all successful responses in a consistent envelope.

closes #940
closes #942