### PR TITLE
feat: add AdminMemberTable and PaymentMethodCard components

### DIFF
--- a/frontend/cntr/AdminMemberTable/AdminMemberTable.test.tsx
+++ b/frontend/cntr/AdminMemberTable/AdminMemberTable.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AdminMemberTable } from './AdminMemberTable';
+
+const members = [{ id: '1', name: 'Alice', email: 'a@test.com', role: 'USER' as const, status: 'ACTIVE' as const, joinedAt: '2024-01-01' }];
+const props = { members, onRoleChange: vi.fn(), onBan: vi.fn(), onUnban: vi.fn() };
+
+describe('AdminMemberTable', () => {
+  it('renders member name', () => { render(<AdminMemberTable {...props} />); expect(screen.getByText('Alice')).toBeInTheDocument(); });
+  it('requires confirmation before ban', () => { render(<AdminMemberTable {...props} />); fireEvent.click(screen.getByText('Ban')); expect(screen.getByText('Confirm Ban')).toBeInTheDocument(); expect(props.onBan).not.toHaveBeenCalled(); });
+  it('calls onBan after confirmation', () => { render(<AdminMemberTable {...props} />); fireEvent.click(screen.getByText('Ban')); fireEvent.click(screen.getByText('Confirm Ban')); expect(props.onBan).toHaveBeenCalledWith('1'); });
+});

--- a/frontend/cntr/AdminMemberTable/AdminMemberTable.tsx
+++ b/frontend/cntr/AdminMemberTable/AdminMemberTable.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+
+interface MemberRow { id: string; name: string; email: string; role: 'USER' | 'ADMIN'; status: 'ACTIVE' | 'BANNED'; joinedAt: string; }
+interface Props { members: MemberRow[]; onRoleChange: (id: string, role: 'USER' | 'ADMIN') => void; onBan: (id: string) => void; onUnban: (id: string) => void; }
+
+export function AdminMemberTable({ members, onRoleChange, onBan, onUnban }: Props) {
+  const [confirmBan, setConfirmBan] = useState<string | null>(null);
+  return (
+    <table className="w-full text-sm">
+      <thead><tr className="border-b"><th className="text-left py-2">Name</th><th>Email</th><th>Role</th><th>Status</th><th>Joined</th><th>Actions</th></tr></thead>
+      <tbody>
+        {members.map((m) => (
+          <tr key={m.id} className="border-b">
+            <td className="py-2">{m.name}</td>
+            <td>{m.email}</td>
+            <td><select value={m.role} onChange={(e) => onRoleChange(m.id, e.target.value as 'USER' | 'ADMIN')}><option value="USER">USER</option><option value="ADMIN">ADMIN</option></select></td>
+            <td><span className={m.status === 'BANNED' ? 'text-red-600 font-bold' : ''}>{m.status}</span></td>
+            <td>{new Date(m.joinedAt).toLocaleDateString()}</td>
+            <td>
+              {m.status === 'BANNED' ? (
+                <button onClick={() => onUnban(m.id)}>Unban</button>
+              ) : confirmBan === m.id ? (
+                <button className="text-red-600" onClick={() => { onBan(m.id); setConfirmBan(null); }}>Confirm Ban</button>
+              ) : (
+                <button onClick={() => setConfirmBan(m.id)}>Ban</button>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/frontend/cntr/PaymentMethodCard/PaymentMethodCard.test.tsx
+++ b/frontend/cntr/PaymentMethodCard/PaymentMethodCard.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { PaymentMethodCard } from './PaymentMethodCard';
+
+const method = { type: 'card' as const, last4: '4242', brand: 'Visa', expiryMonth: 9, expiryYear: 2027 };
+const props = { method, onRemove: vi.fn(), onUpdate: vi.fn() };
+
+describe('PaymentMethodCard', () => {
+  it('shows masked card number', () => { render(<PaymentMethodCard {...props} />); expect(screen.getByText(/•••• •••• •••• 4242/)).toBeInTheDocument(); });
+  it('shows expiry as MM/YY', () => { render(<PaymentMethodCard {...props} />); expect(screen.getByText('Expires 09/27')).toBeInTheDocument(); });
+  it('requires confirmation before remove', () => { render(<PaymentMethodCard {...props} />); fireEvent.click(screen.getByText('Remove')); expect(screen.getByText('Confirm Remove')).toBeInTheDocument(); expect(props.onRemove).not.toHaveBeenCalled(); });
+  it('calls onUpdate immediately', () => { render(<PaymentMethodCard {...props} />); fireEvent.click(screen.getByText('Update')); expect(props.onUpdate).toHaveBeenCalled(); });
+});

--- a/frontend/cntr/PaymentMethodCard/PaymentMethodCard.tsx
+++ b/frontend/cntr/PaymentMethodCard/PaymentMethodCard.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { CreditCard } from 'lucide-react';
+
+interface PaymentMethod { type: 'card' | 'bank'; last4: string; brand?: string; expiryMonth?: number; expiryYear?: number; }
+interface Props { method: PaymentMethod; onRemove: () => void; onUpdate: () => void; }
+
+export function PaymentMethodCard({ method, onRemove, onUpdate }: Props) {
+  const [confirmRemove, setConfirmRemove] = useState(false);
+  const expiry = method.expiryMonth && method.expiryYear
+    ? `${String(method.expiryMonth).padStart(2, '0')}/${String(method.expiryYear).slice(-2)}`
+    : null;
+
+  return (
+    <div className="border rounded-lg p-4 flex items-center justify-between">
+      <div className="flex items-center gap-3">
+        <CreditCard size={20} />
+        <div>
+          <p className="font-medium text-sm">{method.brand ?? method.type.toUpperCase()} •••• •••• •••• {method.last4}</p>
+          {expiry && <p className="text-xs text-muted-foreground">Expires {expiry}</p>}
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <button onClick={onUpdate} className="text-sm text-blue-600">Update</button>
+        {confirmRemove ? (
+          <button onClick={onRemove} className="text-sm text-red-600 font-semibold">Confirm Remove</button>
+        ) : (
+          <button onClick={() => setConfirmRemove(true)} className="text-sm text-red-500">Remove</button>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Adds AdminMemberTable with inline role dropdown, ban confirmation flow, and unban support, and PaymentMethodCard with masked card number, MM/YY expiry, and inline remove confirmation.

closes #1014
closes #1017