### PR TITLE
Add MIME type validator/filter and URL slug generator utilities

### DIFF
--- a/backend/cntr/file-mime.validator.ts
+++ b/backend/cntr/file-mime.validator.ts
@@ -1,0 +1,50 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+  ValidationArguments,
+} from 'class-validator';
+import type { Request } from 'express';
+
+@ValidatorConstraint({ name: 'isAllowedMimeType', async: false })
+class IsAllowedMimeTypeConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: ValidationArguments): boolean {
+    const [allowedTypes] = args.constraints as [string[]];
+    return typeof value === 'string' && allowedTypes.includes(value);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const [allowedTypes] = args.constraints as [string[]];
+    return `${args.property} must be one of: ${allowedTypes.join(', ')}.`;
+  }
+}
+
+export function IsAllowedMimeType(allowedTypes: string[], options?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options,
+      constraints: [allowedTypes],
+      validator: IsAllowedMimeTypeConstraint,
+    });
+  };
+}
+
+type MulterFile = Express.Multer.File;
+type MulterCallback = (error: Error | null, acceptFile: boolean) => void;
+
+export function createMimeTypeFilter(allowedTypes: string[]) {
+  return function fileFilter(
+    _req: Request,
+    file: MulterFile,
+    cb: MulterCallback,
+  ): void {
+    if (allowedTypes.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error(`Unsupported file type: ${file.mimetype}. Allowed: ${allowedTypes.join(', ')}.`), false);
+    }
+  };
+}

--- a/backend/cntr/slug.util.ts
+++ b/backend/cntr/slug.util.ts
@@ -1,0 +1,17 @@
+export function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function generateUniqueSlug(name: string, existingSlugs: string[]): string {
+  const base = generateSlug(name);
+  if (!existingSlugs.includes(base)) return base;
+
+  let counter = 2;
+  while (existingSlugs.includes(`${base}-${counter}`)) {
+    counter++;
+  }
+  return `${base}-${counter}`;
+}


### PR DESCRIPTION
File upload endpoints only enforced file size, not MIME type, allowing unsupported or potentially malicious files through. IsAllowedMimeType is a class-validator decorator for DTO validation; createMimeTypeFilter returns a Multer fileFilter function — both accept the same allowedTypes array so permitted types are declared once.

Workspace names were stored as plain strings with no URL-safe identifier. generateSlug converts a name to lowercase hyphen-separated form; generateUniqueSlug appends -2, -3, etc. on collision with an existing slug list. No external packages required. Both utilities live in backend/cntr/ as specified.

Closes #946
Closes #947