### PR TITLE
feat(cntr): add QR code check-in and PDF invoice generator services

### DIFF
--- a/backend/cntr/invoice-pdf.service.spec.ts
+++ b/backend/cntr/invoice-pdf.service.spec.ts
@@ -1,0 +1,52 @@
+import { generateInvoicePDF, InvoiceData } from './invoice-pdf.service';
+
+const sampleInvoice: InvoiceData = {
+  invoiceNumber: 'INV-2026-001',
+  issueDate: '2026-06-01',
+  memberName: 'Amina Bello',
+  memberEmail: 'amina.bello@example.com',
+  lineItems: [
+    { description: 'Hot Desk – May 2026', quantity: 1, unitPrice: 15000 },
+    { description: 'Meeting Room Booking (2 hrs)', quantity: 2, unitPrice: 5000 },
+    { description: 'Printing Credits', quantity: 10, unitPrice: 200 },
+  ],
+};
+
+describe('generateInvoicePDF', () => {
+  it('returns a non-empty Buffer', async () => {
+    const buffer = await generateInvoicePDF(sampleInvoice);
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect(buffer.length).toBeGreaterThan(0);
+  });
+
+  it('starts with %PDF bytes (valid PDF format)', async () => {
+    const buffer = await generateInvoicePDF(sampleInvoice);
+    const header = buffer.slice(0, 4).toString('ascii');
+    expect(header).toBe('%PDF');
+  });
+
+  it('produces a larger buffer when there are more line items', async () => {
+    const fewItems: InvoiceData = { ...sampleInvoice, lineItems: [sampleInvoice.lineItems[0]] };
+    const manyItems: InvoiceData = {
+      ...sampleInvoice,
+      lineItems: Array.from({ length: 20 }, (_, i) => ({
+        description: `Item ${i + 1}`,
+        quantity: i + 1,
+        unitPrice: 1000,
+      })),
+    };
+    const small = await generateInvoicePDF(fewItems);
+    const large = await generateInvoicePDF(manyItems);
+    expect(large.length).toBeGreaterThan(small.length);
+  });
+
+  it('handles an invoice with a single line item', async () => {
+    const single: InvoiceData = {
+      ...sampleInvoice,
+      lineItems: [{ description: 'Private Office – June 2026', quantity: 1, unitPrice: 80000 }],
+    };
+    const buffer = await generateInvoicePDF(single);
+    expect(buffer.slice(0, 4).toString('ascii')).toBe('%PDF');
+    expect(buffer.length).toBeGreaterThan(0);
+  });
+});

--- a/backend/cntr/invoice-pdf.service.ts
+++ b/backend/cntr/invoice-pdf.service.ts
@@ -1,0 +1,130 @@
+import PDFDocument from 'pdfkit';
+
+export interface LineItem {
+  description: string;
+  quantity: number;
+  unitPrice: number; // in base currency units (e.g. NGN)
+}
+
+export interface InvoiceData {
+  invoiceNumber: string;
+  issueDate: string; // ISO date string e.g. "2026-06-01"
+  memberName: string;
+  memberEmail: string;
+  lineItems: LineItem[];
+}
+
+const VAT_RATE = 0.075; // 7.5%
+
+export function generateInvoicePDF(invoice: InvoiceData): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+
+    const doc = new PDFDocument({ margin: 50, size: 'A4' });
+
+    doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+
+    doc
+      .fontSize(24)
+      .font('Helvetica-Bold')
+      .text('ManageHub', 50, 50);
+
+    doc
+      .fontSize(10)
+      .font('Helvetica')
+      .fillColor('#555555')
+      .text('Workspace Management Platform', 50, 80);
+
+    doc.moveTo(50, 100).lineTo(545, 100).strokeColor('#cccccc').stroke();
+    doc.fillColor('#000000').fontSize(20).font('Helvetica-Bold').text('INVOICE', 50, 120);
+
+    doc
+      .fontSize(10)
+      .font('Helvetica')
+      .text(`Invoice Number: ${invoice.invoiceNumber}`, 50, 150)
+      .text(`Issue Date:     ${invoice.issueDate}`, 50, 165);
+
+    doc
+      .fontSize(10)
+      .font('Helvetica-Bold')
+      .text('Billed To:', 50, 195)
+      .font('Helvetica')
+      .text(invoice.memberName, 50, 210)
+      .text(invoice.memberEmail, 50, 225);
+
+    const tableTop = 265;
+    const col = { desc: 50, qty: 300, unit: 380, total: 460 };
+
+    doc.rect(50, tableTop - 8, 495, 20).fill('#f0f0f0');
+
+    doc
+      .fillColor('#000000')
+      .fontSize(10)
+      .font('Helvetica-Bold')
+      .text('Description', col.desc, tableTop)
+      .text('Qty', col.qty, tableTop)
+      .text('Unit Price', col.unit, tableTop)
+      .text('Total', col.total, tableTop);
+
+    doc.moveTo(50, tableTop + 14).lineTo(545, tableTop + 14).strokeColor('#cccccc').stroke();
+
+    let y = tableTop + 24;
+    let subtotal = 0;
+
+    doc.font('Helvetica').fontSize(10).fillColor('#000000');
+
+    for (const item of invoice.lineItems) {
+      const lineTotal = item.quantity * item.unitPrice;
+      subtotal += lineTotal;
+
+      doc
+        .text(item.description, col.desc, y, { width: 230 })
+        .text(String(item.quantity), col.qty, y)
+        .text(formatCurrency(item.unitPrice), col.unit, y)
+        .text(formatCurrency(lineTotal), col.total, y);
+
+      y += 20;
+    }
+
+    const vat = subtotal * VAT_RATE;
+    const grandTotal = subtotal + vat;
+
+    y += 10;
+    doc.moveTo(50, y).lineTo(545, y).strokeColor('#cccccc').stroke();
+    y += 12;
+
+    doc
+      .font('Helvetica')
+      .text('Subtotal', col.unit - 60, y)
+      .text(formatCurrency(subtotal), col.total, y);
+
+    y += 18;
+    doc
+      .text(`VAT (${(VAT_RATE * 100).toFixed(1)}%)`, col.unit - 60, y)
+      .text(formatCurrency(vat), col.total, y);
+
+    y += 18;
+    doc.moveTo(col.unit - 60, y).lineTo(545, y).strokeColor('#000000').stroke();
+    y += 10;
+
+    doc
+      .font('Helvetica-Bold')
+      .fontSize(11)
+      .text('Grand Total', col.unit - 60, y)
+      .text(formatCurrency(grandTotal), col.total, y);
+
+    doc
+      .fontSize(9)
+      .font('Helvetica')
+      .fillColor('#888888')
+      .text('Thank you for using ManageHub.', 50, 750, { align: 'center', width: 495 });
+
+    doc.end();
+  });
+}
+
+function formatCurrency(amount: number): string {
+  return `N${amount.toLocaleString('en-NG', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}

--- a/backend/cntr/qrcode.service.spec.ts
+++ b/backend/cntr/qrcode.service.spec.ts
@@ -1,0 +1,57 @@
+import QRCode from 'qrcode';
+import { generateCheckInQRCode } from './qrcode.service';
+
+jest.mock('qrcode');
+
+const mockedToDataURL = QRCode.toDataURL as jest.MockedFunction<typeof QRCode.toDataURL>;
+
+describe('generateCheckInQRCode', () => {
+  const FAKE_DATA_URL = 'data:image/png;base64,abc123==';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedToDataURL.mockResolvedValue(FAKE_DATA_URL);
+  });
+
+  it('returns a Base64 PNG data URL', async () => {
+    const result = await generateCheckInQRCode('ws-001', 'token-xyz');
+    expect(result).toBe(FAKE_DATA_URL);
+    expect(result.startsWith('data:image/png;base64,')).toBe(true);
+  });
+
+  it('encodes workspaceId, token, and expiresAt in the QR payload', async () => {
+    const before = Date.now();
+    await generateCheckInQRCode('ws-001', 'token-xyz');
+    const after = Date.now();
+
+    const [payload] = (mockedToDataURL.mock.calls[0] as unknown[]) as [string, ...unknown[]];
+    const parsed = JSON.parse(payload);
+
+    expect(parsed.workspaceId).toBe('ws-001');
+    expect(parsed.token).toBe('token-xyz');
+
+    const expiresAt = new Date(parsed.expiresAt).getTime();
+    expect(expiresAt).toBeGreaterThanOrEqual(before + 15 * 60 * 1000);
+    expect(expiresAt).toBeLessThanOrEqual(after + 15 * 60 * 1000);
+  });
+
+  it('throws when workspaceId is empty', async () => {
+    await expect(generateCheckInQRCode('', 'token-xyz')).rejects.toThrow(
+      'workspaceId must not be empty',
+    );
+  });
+
+  it('throws when sessionToken is empty', async () => {
+    await expect(generateCheckInQRCode('ws-001', '')).rejects.toThrow(
+      'sessionToken must not be empty',
+    );
+  });
+
+  it('calls QRCode.toDataURL with png type option', async () => {
+    await generateCheckInQRCode('ws-002', 'tok-abc');
+    expect(mockedToDataURL).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ type: 'image/png' }),
+    );
+  });
+});

--- a/backend/cntr/qrcode.service.ts
+++ b/backend/cntr/qrcode.service.ts
@@ -1,0 +1,21 @@
+import QRCode from 'qrcode';
+
+export async function generateCheckInQRCode(
+  workspaceId: string,
+  sessionToken: string,
+): Promise<string> {
+  if (!workspaceId) {
+    throw new Error('workspaceId must not be empty');
+  }
+  if (!sessionToken) {
+    throw new Error('sessionToken must not be empty');
+  }
+
+  const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
+
+  const payload = JSON.stringify({ workspaceId, token: sessionToken, expiresAt });
+
+  const dataUrl = await QRCode.toDataURL(payload, { type: 'image/png' });
+
+  return dataUrl;
+}


### PR DESCRIPTION
Closes #952 
Closes #953
Closes #954

Adds two new services under `backend/cntr/`:

- **qrcode.service.ts** - `generateCheckInQRCode(workspaceId, sessionToken)` generates a Base64 PNG data URL encoding a 15-minute expiring JSON payload. Throws on empty inputs.
- **invoice-pdf.service.ts** - `generateInvoicePDF(invoice)` produces a valid PDF buffer with ManageHub branding, line-items table, subtotal, 7.5% VAT, and grand total. Returns `Promise<Buffer>` (PDFKit is stream-based; synchronous return is not possible).

Both services use already-installed packages (`qrcode`, `pdfkit`) and include unit tests with mocking where applicable.