### PR TITLE
feat(cntr): resolve BE-36, BE-37, BE-38, BE-39 — rating, webhook logger, token blacklist, opening hours

### DIFF
--- a/backend/cntr/opening-hours.validator.spec.ts
+++ b/backend/cntr/opening-hours.validator.spec.ts
@@ -1,0 +1,79 @@
+import { validateOpeningHours, OpeningHoursEntry } from './opening-hours.validator';
+
+const entry = (overrides: Partial<OpeningHoursEntry> = {}): OpeningHoursEntry => ({
+  dayOfWeek: 1,
+  openTime: '09:00',
+  closeTime: '17:00',
+  isClosed: false,
+  ...overrides,
+});
+
+describe('validateOpeningHours', () => {
+  it('returns valid for a correct single entry', () => {
+    const result = validateOpeningHours([entry()]);
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects openTime with invalid format', () => {
+    const result = validateOpeningHours([entry({ openTime: '9:00' })]);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some(e => e.includes('openTime'))).toBe(true);
+  });
+
+  it('rejects closeTime with invalid format', () => {
+    const result = validateOpeningHours([entry({ closeTime: '17:60' })]);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some(e => e.includes('closeTime'))).toBe(true);
+  });
+
+  it('rejects closeTime equal to openTime when not closed', () => {
+    const result = validateOpeningHours([entry({ openTime: '09:00', closeTime: '09:00' })]);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some(e => e.includes('closeTime must be after'))).toBe(true);
+  });
+
+  it('rejects closeTime before openTime when not closed', () => {
+    const result = validateOpeningHours([entry({ openTime: '17:00', closeTime: '09:00' })]);
+    expect(result.isValid).toBe(false);
+  });
+
+  it('allows closeTime before openTime when isClosed is true', () => {
+    const result = validateOpeningHours([entry({ openTime: '17:00', closeTime: '09:00', isClosed: true })]);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('rejects duplicate dayOfWeek entries', () => {
+    const result = validateOpeningHours([
+      entry({ dayOfWeek: 1 }),
+      entry({ dayOfWeek: 1 }),
+    ]);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some(e => e.includes('Duplicate dayOfWeek'))).toBe(true);
+  });
+
+  it('collects ALL errors at once (no fail-fast)', () => {
+    const result = validateOpeningHours([
+      entry({ dayOfWeek: 0, openTime: 'bad', closeTime: 'also-bad' }),
+      entry({ dayOfWeek: 0, openTime: '17:00', closeTime: '09:00' }),
+    ]);
+    expect(result.errors.length).toBeGreaterThan(2);
+  });
+
+  it('returns valid for a full week of correct entries', () => {
+    const week: OpeningHoursEntry[] = [0, 1, 2, 3, 4, 5, 6].map(day => ({
+      dayOfWeek: day as OpeningHoursEntry['dayOfWeek'],
+      openTime: '08:00',
+      closeTime: '20:00',
+      isClosed: day === 0,
+    }));
+    const result = validateOpeningHours(week);
+    expect(result.isValid).toBe(true);
+  });
+
+  it('returns valid for an empty array', () => {
+    const result = validateOpeningHours([]);
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/backend/cntr/opening-hours.validator.ts
+++ b/backend/cntr/opening-hours.validator.ts
@@ -1,0 +1,47 @@
+export interface OpeningHoursEntry {
+  dayOfWeek: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+  openTime: string;
+  closeTime: string;
+  isClosed: boolean;
+}
+
+export interface ValidationResult {
+  isValid: boolean;
+  errors: string[];
+}
+
+const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export function validateOpeningHours(hours: OpeningHoursEntry[]): ValidationResult {
+  const errors: string[] = [];
+  const seenDays = new Set<number>();
+
+  for (const entry of hours) {
+    const day = entry.dayOfWeek;
+
+    if (seenDays.has(day)) {
+      errors.push(`Duplicate dayOfWeek: ${day}`);
+    } else {
+      seenDays.add(day);
+    }
+
+    if (!TIME_REGEX.test(entry.openTime)) {
+      errors.push(`Invalid openTime format for day ${day}: "${entry.openTime}" (expected HH:MM)`);
+    }
+
+    if (!TIME_REGEX.test(entry.closeTime)) {
+      errors.push(`Invalid closeTime format for day ${day}: "${entry.closeTime}" (expected HH:MM)`);
+    }
+
+    if (
+      !entry.isClosed &&
+      TIME_REGEX.test(entry.openTime) &&
+      TIME_REGEX.test(entry.closeTime) &&
+      entry.closeTime <= entry.openTime
+    ) {
+      errors.push(`closeTime must be after openTime for day ${day}: ${entry.openTime} → ${entry.closeTime}`);
+    }
+  }
+
+  return { isValid: errors.length === 0, errors };
+}

--- a/backend/cntr/token-blacklist.util.spec.ts
+++ b/backend/cntr/token-blacklist.util.spec.ts
@@ -1,0 +1,53 @@
+import { TokenBlacklist } from './token-blacklist.util';
+
+describe('TokenBlacklist', () => {
+  let blacklist: TokenBlacklist;
+
+  beforeEach(() => {
+    blacklist = new TokenBlacklist();
+  });
+
+  const future = (offsetMs: number) => new Date(Date.now() + offsetMs);
+  const past = (offsetMs: number) => new Date(Date.now() - offsetMs);
+
+  it('returns false for an unknown JTI', () => {
+    expect(blacklist.isBlacklisted('unknown-jti')).toBe(false);
+  });
+
+  it('returns true for a blacklisted token that has not yet expired', () => {
+    blacklist.blacklist('jti-1', future(60_000));
+    expect(blacklist.isBlacklisted('jti-1')).toBe(true);
+  });
+
+  it('returns false for a blacklisted token whose expiresAt has passed', () => {
+    blacklist.blacklist('jti-2', past(1_000));
+    expect(blacklist.isBlacklisted('jti-2')).toBe(false);
+  });
+
+  it('purgeExpired removes entries whose expiresAt is before now', () => {
+    const now = new Date();
+    blacklist.blacklist('expired', new Date(now.getTime() - 1_000));
+    blacklist.blacklist('valid', new Date(now.getTime() + 60_000));
+
+    blacklist.purgeExpired(now);
+
+    expect(blacklist.isBlacklisted('expired')).toBe(false);
+    expect(blacklist.isBlacklisted('valid')).toBe(true);
+  });
+
+  it('purgeExpired accepts an optional now parameter for testability', () => {
+    const fixedNow = new Date('2030-01-01T00:00:00Z');
+    blacklist.blacklist('jti-old', new Date('2029-12-31T23:59:59Z'));
+    blacklist.blacklist('jti-future', new Date('2030-01-02T00:00:00Z'));
+
+    blacklist.purgeExpired(fixedNow);
+
+    expect(blacklist.isBlacklisted('jti-old')).toBe(false);
+  });
+
+  it('purgeExpired leaves valid entries intact', () => {
+    blacklist.blacklist('jti-live', future(60_000));
+    blacklist.purgeExpired();
+    expect(blacklist.isBlacklisted('jti-live')).toBe(true);
+  });
+});

--- a/backend/cntr/token-blacklist.util.ts
+++ b/backend/cntr/token-blacklist.util.ts
@@ -1,0 +1,21 @@
+export class TokenBlacklist {
+  private readonly store = new Map<string, Date>();
+
+  blacklist(jti: string, expiresAt: Date): void {
+    this.store.set(jti, expiresAt);
+  }
+
+  isBlacklisted(jti: string): boolean {
+    const expiresAt = this.store.get(jti);
+    if (!expiresAt) return false;
+    return expiresAt > new Date();
+  }
+
+  purgeExpired(now: Date = new Date()): void {
+    for (const [jti, expiresAt] of this.store) {
+      if (expiresAt < now) {
+        this.store.delete(jti);
+      }
+    }
+  }
+}

--- a/backend/cntr/webhook-event-logger.spec.ts
+++ b/backend/cntr/webhook-event-logger.spec.ts
@@ -1,0 +1,63 @@
+import { createWebhookEventLog } from './webhook-event-logger';
+
+describe('createWebhookEventLog', () => {
+  it('generates a UUID id', () => {
+    const log = createWebhookEventLog('charge.success', {}, 'RECEIVED');
+    expect(log.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
+  });
+
+  it('sets receivedAt as an ISO 8601 string', () => {
+    const log = createWebhookEventLog('charge.success', {}, 'RECEIVED');
+    expect(() => new Date(log.receivedAt)).not.toThrow();
+    expect(log.receivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it('stores the event and status', () => {
+    const log = createWebhookEventLog('transfer.failed', {}, 'FAILED', 'timeout');
+    expect(log.event).toBe('transfer.failed');
+    expect(log.status).toBe('FAILED');
+    expect(log.error).toBe('timeout');
+  });
+
+  it('omits the error field when not provided', () => {
+    const log = createWebhookEventLog('charge.success', {}, 'PROCESSED');
+    expect('error' in log).toBe(false);
+  });
+
+  it('removes keys matching /(card|cvv|pan|account_number)/i from payload', () => {
+    const payload = {
+      card_number: '4111111111111111',
+      CardType: 'visa',
+      cvv: '123',
+      CVV2: '456',
+      pan: '411111',
+      account_number: '0123456789',
+      ACCOUNT_NUMBER: '9876543210',
+      reference: 'ref-001',
+      amount: 5000,
+    };
+    const log = createWebhookEventLog('charge.success', payload, 'RECEIVED');
+
+    expect(log.payload).not.toHaveProperty('card_number');
+    expect(log.payload).not.toHaveProperty('CardType');
+    expect(log.payload).not.toHaveProperty('cvv');
+    expect(log.payload).not.toHaveProperty('CVV2');
+    expect(log.payload).not.toHaveProperty('pan');
+    expect(log.payload).not.toHaveProperty('account_number');
+    expect(log.payload).not.toHaveProperty('ACCOUNT_NUMBER');
+
+    expect(log.payload['reference']).toBe('ref-001');
+    expect(log.payload['amount']).toBe(5000);
+  });
+
+  it('does not mutate the original payload object', () => {
+    const payload = { card: '4111', reference: 'ref-002' };
+    createWebhookEventLog('charge.success', payload, 'RECEIVED');
+    expect(payload).toHaveProperty('card');
+  });
+
+  it('handles an empty payload', () => {
+    const log = createWebhookEventLog('subscription.create', {}, 'RECEIVED');
+    expect(log.payload).toEqual({});
+  });
+});

--- a/backend/cntr/webhook-event-logger.ts
+++ b/backend/cntr/webhook-event-logger.ts
@@ -1,0 +1,41 @@
+import { randomUUID } from 'crypto';
+
+export interface WebhookEventLog {
+  id: string;
+  event: string;
+  payload: Record<string, unknown>;
+  status: 'RECEIVED' | 'PROCESSED' | 'FAILED';
+  error?: string;
+  receivedAt: string;
+}
+
+const SENSITIVE_KEY_REGEX = /(card|cvv|pan|account_number)/i;
+
+function sanitizePayload(payload: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(payload)) {
+    if (!SENSITIVE_KEY_REGEX.test(key)) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+export function createWebhookEventLog(
+  event: string,
+  payload: Record<string, unknown>,
+  status: 'RECEIVED' | 'PROCESSED' | 'FAILED',
+  error?: string,
+): WebhookEventLog {
+  const log: WebhookEventLog = {
+    id: randomUUID(),
+    event,
+    payload: sanitizePayload(payload),
+    status,
+    receivedAt: new Date().toISOString(),
+  };
+  if (error !== undefined) {
+    log.error = error;
+  }
+  return log;
+}

--- a/backend/cntr/workspace-rating.service.spec.ts
+++ b/backend/cntr/workspace-rating.service.spec.ts
@@ -1,0 +1,88 @@
+import { validateRating, computeAverageRating, WorkspaceRating } from './workspace-rating.service';
+
+const rating = (overrides: Partial<WorkspaceRating> = {}): WorkspaceRating => ({
+  workspaceId: 'ws-1',
+  memberId: 'mem-1',
+  bookingId: 'bk-1',
+  score: 5,
+  createdAt: new Date().toISOString(),
+  ...overrides,
+});
+
+describe('validateRating', () => {
+  it('does not throw for a valid score with no comment', () => {
+    expect(() => validateRating(rating({ score: 3 }))).not.toThrow();
+  });
+
+  it('does not throw for a valid score with a comment under 500 chars', () => {
+    expect(() => validateRating(rating({ score: 1, comment: 'Good' }))).not.toThrow();
+  });
+
+  it('throws RangeError for score 0', () => {
+    expect(() => validateRating({ score: 0 as any })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for score 6', () => {
+    expect(() => validateRating({ score: 6 as any })).toThrow(RangeError);
+  });
+
+  it('throws RangeError for negative score', () => {
+    expect(() => validateRating({ score: -1 as any })).toThrow(RangeError);
+  });
+
+  it('throws RangeError when score is undefined', () => {
+    expect(() => validateRating({})).toThrow(RangeError);
+  });
+
+  it('throws Error when comment exceeds 500 characters', () => {
+    const longComment = 'x'.repeat(501);
+    expect(() => validateRating(rating({ comment: longComment }))).toThrow(Error);
+  });
+
+  it('does not throw for a comment exactly 500 characters', () => {
+    const exactComment = 'x'.repeat(500);
+    expect(() => validateRating(rating({ comment: exactComment }))).not.toThrow();
+  });
+
+  it('accepts all valid scores 1-5', () => {
+    for (const score of [1, 2, 3, 4, 5] as const) {
+      expect(() => validateRating(rating({ score }))).not.toThrow();
+    }
+  });
+});
+
+describe('computeAverageRating', () => {
+  it('returns 0 for an empty array', () => {
+    expect(computeAverageRating([])).toBe(0);
+  });
+
+  it('returns the score itself for a single rating', () => {
+    expect(computeAverageRating([rating({ score: 4 })])).toBe(4);
+  });
+
+  it('computes the correct average rounded to 1 decimal', () => {
+    const ratings = [
+      rating({ score: 5 }),
+      rating({ score: 4 }),
+      rating({ score: 3 }),
+    ];
+    expect(computeAverageRating(ratings)).toBe(4);
+  });
+
+  it('rounds to 1 decimal place', () => {
+    const ratings = [
+      rating({ score: 5 }),
+      rating({ score: 4 }),
+    ];
+    expect(computeAverageRating(ratings)).toBe(4.5);
+  });
+
+  it('handles a mix that produces a non-trivial decimal', () => {
+    const ratings = [
+      rating({ score: 5 }),
+      rating({ score: 5 }),
+      rating({ score: 4 }),
+    ];
+    expect(computeAverageRating(ratings)).toBe(4.7);
+  });
+});

--- a/backend/cntr/workspace-rating.service.ts
+++ b/backend/cntr/workspace-rating.service.ts
@@ -1,0 +1,23 @@
+export interface WorkspaceRating {
+  workspaceId: string;
+  memberId: string;
+  bookingId: string;
+  score: 1 | 2 | 3 | 4 | 5;
+  comment?: string;
+  createdAt: string;
+}
+
+export function validateRating(rating: Partial<WorkspaceRating>): void {
+  if (rating.score === undefined || rating.score < 1 || rating.score > 5) {
+    throw new RangeError(`score must be between 1 and 5, got: ${rating.score}`);
+  }
+  if (rating.comment !== undefined && rating.comment.length > 500) {
+    throw new Error(`comment must not exceed 500 characters`);
+  }
+}
+
+export function computeAverageRating(ratings: WorkspaceRating[]): number {
+  if (ratings.length === 0) return 0;
+  const total = ratings.reduce((sum, r) => sum + r.score, 0);
+  return Math.round((total / ratings.length) * 10) / 10;
+}


### PR DESCRIPTION
## Summary

Implements four self-contained utility/service files in `backend/cntr/`, each with a paired unit test spec. All logic is pure TypeScript with no framework dependencies or external I/O.

---

### BE-38 — In-Memory JWT Token Blacklist (`#977`)
**File:** `backend/cntr/token-blacklist.util.ts`

- `TokenBlacklist` class backed by `Map<string, Date>`
- `blacklist(jti, expiresAt)` — stores the token
- `isBlacklisted(jti)` — returns `false` for unknown or expired JTIs
- `purgeExpired(now?)` — removes all entries whose `expiresAt < now`; accepts optional `now` param for deterministic tests

---

### BE-39 — Workspace Opening Hours Validator (`#978`)
**File:** `backend/cntr/opening-hours.validator.ts`

- Exports `OpeningHoursEntry`, `ValidationResult` interfaces and `validateOpeningHours(hours)`
- Validates `HH:MM` format with `/^([01]\d|2[0-3]):[0-5]\d$/`
- Rejects `closeTime <= openTime` when `isClosed = false`
- Rejects duplicate `dayOfWeek` entries
- Accumulates **all** errors before returning — no fail-fast

---

### BE-37 — Webhook Event Logger with Payload Sanitization (`#976`)
**File:** `backend/cntr/webhook-event-logger.ts`

- Exports `WebhookEventLog` interface and `createWebhookEventLog(event, payload, status, error?)`
- `id` generated via `crypto.randomUUID()`
- `receivedAt` is ISO 8601 string
- Sanitizes payload by removing keys matching `/(card|cvv|pan|account_number)/i` (case-insensitive)
- Original payload object is **not mutated** — operates on a shallow copy

---

### BE-36 — Workspace Rating Service (`#975`)
**File:** `backend/cntr/workspace-rating.service.ts`

- Exports `WorkspaceRating` interface, `validateRating`, and `computeAverageRating`
- `validateRating` throws `RangeError` for score outside 1–5 and `Error` for comment > 500 chars
- `computeAverageRating([])` returns `0`
- Average rounded to 1 decimal place via `Math.round(avg * 10) / 10`

---

## Test plan

- [ ] `backend/cntr/token-blacklist.util.spec.ts` — 6 tests covering unknown JTIs, valid tokens, expired tokens, `purgeExpired` with and without `now`
- [ ] `backend/cntr/opening-hours.validator.spec.ts` — 9 tests covering format errors, close≤open, duplicate days, multi-error accumulation, isClosed bypass, full week
- [ ] `backend/cntr/webhook-event-logger.spec.ts` — 7 tests covering UUID format, ISO date, sensitive key removal (all variants), no mutation, empty payload
- [ ] `backend/cntr/workspace-rating.service.spec.ts` — 13 tests covering all invalid scores, comment length boundary, all valid scores 1–5, average edge cases

Closes #975 
Closes #976 
Closes #977 
Closes #978

