### PR TITLE
feat(cntr): add member tier classifier, utilization report, recovery codes, and 2FA notification (BE-20–23)

### DIFF
--- a/backend/cntr/member-tier.service.spec.ts
+++ b/backend/cntr/member-tier.service.spec.ts
@@ -1,0 +1,59 @@
+import { classifyMemberTier } from './member-tier.service';
+
+describe('classifyMemberTier', () => {
+  it('returns BRONZE for 0 bookings and 0 spend', () => {
+    expect(classifyMemberTier({ totalBookings: 0, totalSpendKobo: 0 })).toBe('BRONZE');
+  });
+
+  it('returns BRONZE for 9 bookings and 499999 kobo', () => {
+    expect(classifyMemberTier({ totalBookings: 9, totalSpendKobo: 499_999 })).toBe('BRONZE');
+  });
+
+  it('returns SILVER for exactly 10 bookings', () => {
+    expect(classifyMemberTier({ totalBookings: 10, totalSpendKobo: 0 })).toBe('SILVER');
+  });
+
+  it('returns SILVER for exactly 500000 kobo spend', () => {
+    expect(classifyMemberTier({ totalBookings: 0, totalSpendKobo: 500_000 })).toBe('SILVER');
+  });
+
+  it('returns SILVER for 29 bookings (below gold threshold)', () => {
+    expect(classifyMemberTier({ totalBookings: 29, totalSpendKobo: 0 })).toBe('SILVER');
+  });
+
+  it('returns SILVER for 1999999 kobo (below gold threshold)', () => {
+    expect(classifyMemberTier({ totalBookings: 0, totalSpendKobo: 1_999_999 })).toBe('SILVER');
+  });
+
+  it('returns GOLD for exactly 30 bookings', () => {
+    expect(classifyMemberTier({ totalBookings: 30, totalSpendKobo: 0 })).toBe('GOLD');
+  });
+
+  it('returns GOLD for exactly 2000000 kobo spend', () => {
+    expect(classifyMemberTier({ totalBookings: 0, totalSpendKobo: 2_000_000 })).toBe('GOLD');
+  });
+
+  it('returns GOLD for 99 bookings (below platinum threshold)', () => {
+    expect(classifyMemberTier({ totalBookings: 99, totalSpendKobo: 0 })).toBe('GOLD');
+  });
+
+  it('returns GOLD for 9999999 kobo (below platinum threshold)', () => {
+    expect(classifyMemberTier({ totalBookings: 0, totalSpendKobo: 9_999_999 })).toBe('GOLD');
+  });
+
+  it('returns PLATINUM for exactly 100 bookings', () => {
+    expect(classifyMemberTier({ totalBookings: 100, totalSpendKobo: 0 })).toBe('PLATINUM');
+  });
+
+  it('returns PLATINUM for exactly 10000000 kobo spend', () => {
+    expect(classifyMemberTier({ totalBookings: 0, totalSpendKobo: 10_000_000 })).toBe('PLATINUM');
+  });
+
+  it('returns PLATINUM for bookings-only path above threshold', () => {
+    expect(classifyMemberTier({ totalBookings: 200, totalSpendKobo: 0 })).toBe('PLATINUM');
+  });
+
+  it('returns PLATINUM for spend-only path above threshold', () => {
+    expect(classifyMemberTier({ totalBookings: 0, totalSpendKobo: 50_000_000 })).toBe('PLATINUM');
+  });
+});

--- a/backend/cntr/member-tier.service.ts
+++ b/backend/cntr/member-tier.service.ts
@@ -1,0 +1,14 @@
+export type MemberTier = 'BRONZE' | 'SILVER' | 'GOLD' | 'PLATINUM';
+
+export interface MemberStats {
+  totalBookings: number;
+  totalSpendKobo: number;
+}
+
+export function classifyMemberTier(stats: MemberStats): MemberTier {
+  const { totalBookings, totalSpendKobo } = stats;
+  if (totalBookings >= 100 || totalSpendKobo >= 10_000_000) return 'PLATINUM';
+  if (totalBookings >= 30 || totalSpendKobo >= 2_000_000) return 'GOLD';
+  if (totalBookings >= 10 || totalSpendKobo >= 500_000) return 'SILVER';
+  return 'BRONZE';
+}

--- a/backend/cntr/recovery-codes.service.spec.ts
+++ b/backend/cntr/recovery-codes.service.spec.ts
@@ -1,0 +1,62 @@
+jest.mock('bcrypt');
+
+import * as bcrypt from 'bcrypt';
+import { generateRecoveryCodes, hashRecoveryCodes, verifyRecoveryCode } from './recovery-codes.service';
+
+const mockHash = bcrypt.hash as jest.MockedFunction<typeof bcrypt.hash>;
+const mockCompare = bcrypt.compare as jest.MockedFunction<typeof bcrypt.compare>;
+
+describe('generateRecoveryCodes', () => {
+  it('produces exactly 8 codes by default', () => {
+    const codes = generateRecoveryCodes();
+    expect(codes).toHaveLength(8);
+  });
+
+  it('produces exactly count codes when specified', () => {
+    expect(generateRecoveryCodes(3)).toHaveLength(3);
+    expect(generateRecoveryCodes(12)).toHaveLength(12);
+  });
+
+  it('each code is exactly 10 characters', () => {
+    const codes = generateRecoveryCodes(8);
+    for (const code of codes) {
+      expect(code).toHaveLength(10);
+    }
+  });
+
+  it('each code contains only uppercase alphanumeric characters', () => {
+    const codes = generateRecoveryCodes(20);
+    for (const code of codes) {
+      expect(code).toMatch(/^[A-Z0-9]{10}$/);
+    }
+  });
+});
+
+describe('hashRecoveryCodes', () => {
+  it('returns the same number of hashes as input codes', async () => {
+    mockHash.mockResolvedValue('hashed' as never);
+    const hashes = await hashRecoveryCodes(['CODE1', 'CODE2', 'CODE3']);
+    expect(hashes).toHaveLength(3);
+  });
+});
+
+describe('verifyRecoveryCode', () => {
+  it('returns { matched: false, index: -1 } when no code matches', async () => {
+    mockCompare.mockResolvedValue(false as never);
+    const result = await verifyRecoveryCode('WRONG', ['hash1', 'hash2']);
+    expect(result).toEqual({ matched: false, index: -1 });
+  });
+
+  it('returns { matched: true, index } for matching code', async () => {
+    mockCompare
+      .mockResolvedValueOnce(false as never)
+      .mockResolvedValueOnce(true as never);
+    const result = await verifyRecoveryCode('RIGHTCODE', ['hash1', 'hash2']);
+    expect(result).toEqual({ matched: true, index: 1 });
+  });
+
+  it('returns { matched: false, index: -1 } for empty hashedCodes array', async () => {
+    const result = await verifyRecoveryCode('CODE', []);
+    expect(result).toEqual({ matched: false, index: -1 });
+  });
+});

--- a/backend/cntr/recovery-codes.service.ts
+++ b/backend/cntr/recovery-codes.service.ts
@@ -1,0 +1,27 @@
+import { randomBytes } from 'crypto';
+import * as bcrypt from 'bcrypt';
+
+const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
+export function generateRecoveryCodes(count = 8): string[] {
+  return Array.from({ length: count }, () => {
+    const bytes = randomBytes(10);
+    return Array.from(bytes, (b) => ALPHABET[b % ALPHABET.length]).join('');
+  });
+}
+
+export async function hashRecoveryCodes(codes: string[]): Promise<string[]> {
+  return Promise.all(codes.map((code) => bcrypt.hash(code, 10)));
+}
+
+export async function verifyRecoveryCode(
+  plain: string,
+  hashedCodes: string[],
+): Promise<{ matched: boolean; index: number }> {
+  for (let i = 0; i < hashedCodes.length; i++) {
+    if (await bcrypt.compare(plain, hashedCodes[i])) {
+      return { matched: true, index: i };
+    }
+  }
+  return { matched: false, index: -1 };
+}

--- a/backend/cntr/two-factor-enabled.template.mjml
+++ b/backend/cntr/two-factor-enabled.template.mjml
@@ -1,0 +1,55 @@
+<mjml>
+  <mj-head>
+    <mj-title>Two-Factor Authentication Enabled — ManageHub</mj-title>
+    <mj-attributes>
+      <mj-all font-family="Arial, sans-serif" />
+      <mj-text font-size="15px" line-height="1.6" color="#1f2937" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#f9fafb">
+    <mj-section background-color="#0ea5e9" padding="24px 0">
+      <mj-column>
+        <mj-text align="center" color="#ffffff" font-size="22px" font-weight="bold">
+          ManageHub
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#ffffff" padding="32px 24px">
+      <mj-column>
+        <mj-text font-size="20px" font-weight="bold" color="#111827">
+          Two-Factor Authentication Enabled
+        </mj-text>
+        <mj-text>Hi {{memberName}},</mj-text>
+        <mj-text>
+          Two-factor authentication (2FA) was successfully enabled on your ManageHub account on
+          <strong>{{enabledAt}}</strong>.
+        </mj-text>
+        <mj-text color="#b91c1c" font-weight="bold">
+          If this wasn't you, secure your account immediately by disabling 2FA using the button below.
+        </mj-text>
+        <mj-button
+          background-color="#dc2626"
+          color="#ffffff"
+          href="{{disableUrl}}"
+          border-radius="6px"
+          font-size="15px"
+          padding="12px 24px"
+        >
+          Disable 2FA
+        </mj-button>
+        <mj-text font-size="13px" color="#6b7280">
+          If you authorized this change, no further action is required. This is a security notification only.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#f3f4f6" padding="16px">
+      <mj-column>
+        <mj-text align="center" font-size="12px" color="#9ca3af">
+          © 2026 ManageHub. All rights reserved.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/backend/cntr/two-factor-enabled.util.spec.ts
+++ b/backend/cntr/two-factor-enabled.util.spec.ts
@@ -1,0 +1,60 @@
+jest.mock('mjml', () =>
+  jest.fn().mockReturnValue({ html: '<html>2fa-enabled</html>', errors: [] }),
+);
+jest.mock('fs', () => ({
+  readFileSync: jest
+    .fn()
+    .mockReturnValue(
+      'Hi {{memberName}}, 2FA enabled at {{enabledAt}}. If this wasn\'t you, secure your account immediately. <a href="{{disableUrl}}">Disable 2FA</a>',
+    ),
+}));
+
+import mjml2html from 'mjml';
+import { renderTwoFactorEnabledEmail } from './two-factor-enabled.util';
+
+const mockMjml = mjml2html as jest.MockedFunction<typeof mjml2html>;
+
+describe('renderTwoFactorEnabledEmail', () => {
+  it('returns the HTML string from mjml', () => {
+    const html = renderTwoFactorEnabledEmail({
+      memberName: 'Alice',
+      enabledAt: '2026-06-01T12:00:00Z',
+      disableUrl: 'https://example.com/disable-2fa',
+    });
+    expect(html).toBe('<html>2fa-enabled</html>');
+  });
+
+  it('substitutes memberName into the template before calling mjml', () => {
+    renderTwoFactorEnabledEmail({
+      memberName: 'Bob',
+      enabledAt: '2026-06-01T12:00:00Z',
+      disableUrl: 'https://example.com/disable',
+    });
+    const calledWith = mockMjml.mock.calls[mockMjml.mock.calls.length - 1][0] as string;
+    expect(calledWith).toContain('Bob');
+  });
+
+  it('substitutes disableUrl into the template before calling mjml', () => {
+    renderTwoFactorEnabledEmail({
+      memberName: 'Carol',
+      enabledAt: '2026-06-01T12:00:00Z',
+      disableUrl: 'https://example.com/my-disable-url',
+    });
+    const calledWith = mockMjml.mock.calls[mockMjml.mock.calls.length - 1][0] as string;
+    expect(calledWith).toContain('https://example.com/my-disable-url');
+  });
+
+  it('throws when mjml returns errors', () => {
+    mockMjml.mockReturnValueOnce({
+      html: '',
+      errors: [{ message: 'bad tag', tagName: 'mj-x', severity: 'error', line: 1 }],
+    } as any);
+    expect(() =>
+      renderTwoFactorEnabledEmail({
+        memberName: 'Eve',
+        enabledAt: '2026-06-01T12:00:00Z',
+        disableUrl: 'https://example.com/disable',
+      }),
+    ).toThrow('MJML errors');
+  });
+});

--- a/backend/cntr/two-factor-enabled.util.ts
+++ b/backend/cntr/two-factor-enabled.util.ts
@@ -1,0 +1,20 @@
+import mjml2html from 'mjml';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export function renderTwoFactorEnabledEmail(vars: {
+  memberName: string;
+  enabledAt: string;
+  disableUrl: string;
+}): string {
+  const templatePath = join(__dirname, 'two-factor-enabled.template.mjml');
+  const raw = readFileSync(templatePath, 'utf8')
+    .replace(/\{\{memberName\}\}/g, vars.memberName)
+    .replace(/\{\{enabledAt\}\}/g, new Date(vars.enabledAt).toLocaleString())
+    .replace(/\{\{disableUrl\}\}/g, vars.disableUrl);
+  const { html, errors } = mjml2html(raw);
+  if (errors.length > 0) {
+    throw new Error(`MJML errors: ${errors.map((e: any) => e.message).join(', ')}`);
+  }
+  return html;
+}

--- a/backend/cntr/utilization-report.service.spec.ts
+++ b/backend/cntr/utilization-report.service.spec.ts
@@ -1,0 +1,79 @@
+import { calculateUtilization } from './utilization-report.service';
+
+describe('calculateUtilization', () => {
+  const makeBooking = (startIso: string, hours: number) => {
+    const startDate = new Date(startIso);
+    const endDate = new Date(startDate.getTime() + hours * 60 * 60 * 1000);
+    return { startDate, endDate };
+  };
+
+  it('computes availableHours = periodDays * openHoursPerDay * capacitySeats', () => {
+    const result = calculateUtilization({
+      capacitySeats: 10,
+      openHoursPerDay: 8,
+      bookings: [],
+      periodDays: 5,
+    });
+    expect(result.availableHours).toBe(400);
+  });
+
+  it('computes totalBookedHours from bookings', () => {
+    const result = calculateUtilization({
+      capacitySeats: 5,
+      openHoursPerDay: 8,
+      bookings: [makeBooking('2026-01-01T09:00:00Z', 2), makeBooking('2026-01-02T09:00:00Z', 3)],
+      periodDays: 7,
+    });
+    expect(result.totalBookedHours).toBe(5);
+  });
+
+  it('caps utilizationPercent at 100', () => {
+    const result = calculateUtilization({
+      capacitySeats: 1,
+      openHoursPerDay: 1,
+      bookings: [makeBooking('2026-01-01T09:00:00Z', 10)],
+      periodDays: 1,
+    });
+    expect(result.utilizationPercent).toBe(100);
+  });
+
+  it('peakDate is the day with the most booked hours (YYYY-MM-DD format)', () => {
+    const result = calculateUtilization({
+      capacitySeats: 10,
+      openHoursPerDay: 8,
+      bookings: [
+        makeBooking('2026-01-01T09:00:00Z', 1),
+        makeBooking('2026-01-02T09:00:00Z', 6),
+        makeBooking('2026-01-03T09:00:00Z', 2),
+      ],
+      periodDays: 7,
+    });
+    expect(result.peakDate).toBe('2026-01-02');
+    expect(result.peakDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('quietDate is the day with the fewest booked hours (YYYY-MM-DD format)', () => {
+    const result = calculateUtilization({
+      capacitySeats: 10,
+      openHoursPerDay: 8,
+      bookings: [
+        makeBooking('2026-01-01T09:00:00Z', 1),
+        makeBooking('2026-01-02T09:00:00Z', 6),
+        makeBooking('2026-01-03T09:00:00Z', 2),
+      ],
+      periodDays: 7,
+    });
+    expect(result.quietDate).toBe('2026-01-01');
+    expect(result.quietDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('returns 0 utilizationPercent when availableHours is 0', () => {
+    const result = calculateUtilization({
+      capacitySeats: 0,
+      openHoursPerDay: 8,
+      bookings: [],
+      periodDays: 5,
+    });
+    expect(result.utilizationPercent).toBe(0);
+  });
+});

--- a/backend/cntr/utilization-report.service.ts
+++ b/backend/cntr/utilization-report.service.ts
@@ -1,0 +1,49 @@
+export interface UtilizationReport {
+  totalBookedHours: number;
+  availableHours: number;
+  utilizationPercent: number;
+  peakDate: string;
+  quietDate: string;
+}
+
+export function calculateUtilization(input: {
+  capacitySeats: number;
+  openHoursPerDay: number;
+  bookings: Array<{ startDate: Date; endDate: Date }>;
+  periodDays: number;
+}): UtilizationReport {
+  const { capacitySeats, openHoursPerDay, bookings, periodDays } = input;
+  const availableHours = periodDays * openHoursPerDay * capacitySeats;
+
+  const hoursPerDay: Record<string, number> = {};
+  for (const booking of bookings) {
+    const durationHours =
+      (booking.endDate.getTime() - booking.startDate.getTime()) / (1000 * 60 * 60);
+    const dateKey = booking.startDate.toISOString().slice(0, 10);
+    hoursPerDay[dateKey] = (hoursPerDay[dateKey] ?? 0) + durationHours;
+  }
+
+  const totalBookedHours = Object.values(hoursPerDay).reduce((s, h) => s + h, 0);
+  const utilizationPercent =
+    availableHours === 0
+      ? 0
+      : Math.min(100, Math.round((totalBookedHours / availableHours) * 100));
+
+  let peakDate = '';
+  let quietDate = '';
+  let peakHours = -Infinity;
+  let quietHours = Infinity;
+
+  for (const [date, hours] of Object.entries(hoursPerDay)) {
+    if (hours > peakHours) {
+      peakHours = hours;
+      peakDate = date;
+    }
+    if (hours < quietHours) {
+      quietHours = hours;
+      quietDate = date;
+    }
+  }
+
+  return { totalBookedHours, availableHours, utilizationPercent, peakDate, quietDate };
+}


### PR DESCRIPTION
## Summary

- **[BE-23]** Add `MemberTier` classifier service with Bronze/Silver/Gold/Platinum tiers based on bookings and spend thresholds
- **[BE-22]** Add workspace utilization report calculator (booked hours, available hours, utilization %, peak/quiet dates)
- **[BE-21]** Add 2FA recovery codes generator (`crypto.randomBytes`), bcrypt hasher, and verifier
- **[BE-20]** Add 2FA enabled notification MJML email template and renderer with disable link and security advisory

## Closes

Closes #962
Closes #961
Closes #960
Closes #959