### PR TITLE
feat(cntr): add CSV member export, booking/welcome/password-reset MJML email templates (BE-16–19)

### DIFF
--- a/backend/cntr/booking-confirmation.template.mjml
+++ b/backend/cntr/booking-confirmation.template.mjml
@@ -1,0 +1,65 @@
+<mjml>
+  <mj-head>
+    <mj-title>Booking Confirmation — ManageHub</mj-title>
+    <mj-attributes>
+      <mj-all font-family="Arial, sans-serif" />
+      <mj-text font-size="15px" line-height="1.6" color="#1f2937" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#f9fafb">
+    <mj-section background-color="#0ea5e9" padding="24px 0">
+      <mj-column>
+        <mj-text align="center" color="#ffffff" font-size="22px" font-weight="bold">
+          ManageHub
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#ffffff" padding="32px 24px">
+      <mj-column>
+        <mj-text font-size="20px" font-weight="bold" color="#111827">
+          Booking Confirmed!
+        </mj-text>
+        <mj-text>Hi {{memberName}},</mj-text>
+        <mj-text>
+          Your booking has been confirmed. Here are your booking details:
+        </mj-text>
+
+        <mj-table>
+          <tr style="border-bottom: 1px solid #e5e7eb;">
+            <td style="padding: 8px 0; color: #6b7280; width: 40%;">Workspace</td>
+            <td style="padding: 8px 0; font-weight: bold;">{{workspaceName}}</td>
+          </tr>
+          <tr style="border-bottom: 1px solid #e5e7eb;">
+            <td style="padding: 8px 0; color: #6b7280;">Start Date</td>
+            <td style="padding: 8px 0;">{{startDate}}</td>
+          </tr>
+          <tr style="border-bottom: 1px solid #e5e7eb;">
+            <td style="padding: 8px 0; color: #6b7280;">End Date</td>
+            <td style="padding: 8px 0;">{{endDate}}</td>
+          </tr>
+          <tr style="border-bottom: 1px solid #e5e7eb;">
+            <td style="padding: 8px 0; color: #6b7280;">Total Amount</td>
+            <td style="padding: 8px 0; font-weight: bold;">₦{{totalAmountNaira}}</td>
+          </tr>
+          <tr>
+            <td style="padding: 8px 0; color: #6b7280;">Reference</td>
+            <td style="padding: 8px 0; font-family: monospace;">{{bookingReference}}</td>
+          </tr>
+        </mj-table>
+
+        <mj-text font-size="13px" color="#6b7280" padding-top="16px">
+          Thank you for choosing ManageHub. We look forward to seeing you!
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#f3f4f6" padding="16px">
+      <mj-column>
+        <mj-text align="center" font-size="12px" color="#9ca3af">
+          © 2026 ManageHub. All rights reserved.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/backend/cntr/booking-confirmation.util.spec.ts
+++ b/backend/cntr/booking-confirmation.util.spec.ts
@@ -1,0 +1,56 @@
+jest.mock('mjml', () =>
+  jest.fn().mockReturnValue({ html: '<html>booking-confirmed</html>', errors: [] }),
+);
+jest.mock('fs', () => ({
+  readFileSync: jest
+    .fn()
+    .mockReturnValue(
+      'Hi {{memberName}}, workspace {{workspaceName}} from {{startDate}} to {{endDate}} costs {{totalAmountNaira}} ref {{bookingReference}}',
+    ),
+}));
+
+import mjml2html from 'mjml';
+import { renderBookingConfirmationEmail } from './booking-confirmation.util';
+
+const mockMjml = mjml2html as jest.MockedFunction<typeof mjml2html>;
+
+const sampleVars = {
+  memberName: 'Alice',
+  workspaceName: 'The Hub',
+  startDate: '2026-07-01',
+  endDate: '2026-07-03',
+  totalAmountNaira: '50000',
+  bookingReference: 'BK-20260701',
+};
+
+describe('renderBookingConfirmationEmail', () => {
+  it('returns the HTML string from mjml', () => {
+    const html = renderBookingConfirmationEmail(sampleVars);
+    expect(html).toBe('<html>booking-confirmed</html>');
+  });
+
+  it('substitutes all 6 variables before calling mjml', () => {
+    renderBookingConfirmationEmail(sampleVars);
+    const arg = mockMjml.mock.calls[mockMjml.mock.calls.length - 1][0] as string;
+    expect(arg).toContain('Alice');
+    expect(arg).toContain('The Hub');
+    expect(arg).toContain('2026-07-01');
+    expect(arg).toContain('2026-07-03');
+    expect(arg).toContain('50000');
+    expect(arg).toContain('BK-20260701');
+  });
+
+  it('does not contain any unreplaced {{}} placeholders', () => {
+    renderBookingConfirmationEmail(sampleVars);
+    const arg = mockMjml.mock.calls[mockMjml.mock.calls.length - 1][0] as string;
+    expect(arg).not.toMatch(/\{\{[^}]+\}\}/);
+  });
+
+  it('throws when mjml returns errors', () => {
+    mockMjml.mockReturnValueOnce({
+      html: '',
+      errors: [{ message: 'bad mjml', tagName: 'mj-x', severity: 'error', line: 1 }],
+    } as any);
+    expect(() => renderBookingConfirmationEmail(sampleVars)).toThrow('MJML errors');
+  });
+});

--- a/backend/cntr/booking-confirmation.util.ts
+++ b/backend/cntr/booking-confirmation.util.ts
@@ -1,0 +1,26 @@
+import mjml2html from 'mjml';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export function renderBookingConfirmationEmail(vars: {
+  memberName: string;
+  workspaceName: string;
+  startDate: string;
+  endDate: string;
+  totalAmountNaira: string;
+  bookingReference: string;
+}): string {
+  const templatePath = join(__dirname, 'booking-confirmation.template.mjml');
+  const raw = readFileSync(templatePath, 'utf8')
+    .replace(/\{\{memberName\}\}/g, vars.memberName)
+    .replace(/\{\{workspaceName\}\}/g, vars.workspaceName)
+    .replace(/\{\{startDate\}\}/g, vars.startDate)
+    .replace(/\{\{endDate\}\}/g, vars.endDate)
+    .replace(/\{\{totalAmountNaira\}\}/g, vars.totalAmountNaira)
+    .replace(/\{\{bookingReference\}\}/g, vars.bookingReference);
+  const { html, errors } = mjml2html(raw);
+  if (errors.length > 0) {
+    throw new Error(`MJML errors: ${errors.map((e: any) => e.message).join(', ')}`);
+  }
+  return html;
+}

--- a/backend/cntr/member-export.service.spec.ts
+++ b/backend/cntr/member-export.service.spec.ts
@@ -1,0 +1,57 @@
+import { exportMembersToCSV, MemberExportRow } from './member-export.service';
+
+const member = (overrides: Partial<MemberExportRow> = {}): MemberExportRow => ({
+  id: 'u-1',
+  email: 'alice@example.com',
+  fullName: 'Alice Smith',
+  role: 'MEMBER',
+  status: 'ACTIVE',
+  joinedDate: '2026-01-15',
+  totalBookings: 5,
+  ...overrides,
+});
+
+describe('exportMembersToCSV', () => {
+  it('returns a string', () => {
+    const csv = exportMembersToCSV([member()]);
+    expect(typeof csv).toBe('string');
+  });
+
+  it('first line is the header row', () => {
+    const csv = exportMembersToCSV([member()]);
+    const firstLine = csv.split('\n')[0];
+    expect(firstLine).toContain('ID');
+    expect(firstLine).toContain('Email');
+    expect(firstLine).toContain('Full Name');
+    expect(firstLine).toContain('Role');
+    expect(firstLine).toContain('Status');
+    expect(firstLine).toContain('Joined Date');
+    expect(firstLine).toContain('Total Bookings');
+  });
+
+  it('includes member data in the output', () => {
+    const csv = exportMembersToCSV([member({ email: 'bob@example.com', fullName: 'Bob Jones' })]);
+    expect(csv).toContain('bob@example.com');
+    expect(csv).toContain('Bob Jones');
+  });
+
+  it('returns only header for an empty array', () => {
+    const csv = exportMembersToCSV([]);
+    const lines = csv.split('\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
+  });
+
+  it('includes data for multiple members', () => {
+    const csv = exportMembersToCSV([
+      member({ id: 'u-1', email: 'alice@example.com' }),
+      member({ id: 'u-2', email: 'bob@example.com' }),
+    ]);
+    expect(csv).toContain('alice@example.com');
+    expect(csv).toContain('bob@example.com');
+  });
+
+  it('includes joinedDate in YYYY-MM-DD format', () => {
+    const csv = exportMembersToCSV([member({ joinedDate: '2026-03-20' })]);
+    expect(csv).toContain('2026-03-20');
+  });
+});

--- a/backend/cntr/member-export.service.ts
+++ b/backend/cntr/member-export.service.ts
@@ -1,0 +1,26 @@
+import { Parser } from 'json2csv';
+
+export interface MemberExportRow {
+  id: string;
+  email: string;
+  fullName: string;
+  role: string;
+  status: string;
+  joinedDate: string;
+  totalBookings: number;
+}
+
+const FIELDS = [
+  { label: 'ID', value: 'id' },
+  { label: 'Email', value: 'email' },
+  { label: 'Full Name', value: 'fullName' },
+  { label: 'Role', value: 'role' },
+  { label: 'Status', value: 'status' },
+  { label: 'Joined Date', value: 'joinedDate' },
+  { label: 'Total Bookings', value: 'totalBookings' },
+];
+
+export function exportMembersToCSV(members: MemberExportRow[]): string {
+  const parser = new Parser({ fields: FIELDS });
+  return parser.parse(members);
+}

--- a/backend/cntr/password-reset.template.mjml
+++ b/backend/cntr/password-reset.template.mjml
@@ -1,0 +1,54 @@
+<mjml>
+  <mj-head>
+    <mj-title>Reset Your Password — ManageHub</mj-title>
+    <mj-attributes>
+      <mj-all font-family="Arial, sans-serif" />
+      <mj-text font-size="15px" line-height="1.6" color="#1f2937" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#f9fafb">
+    <mj-section background-color="#0ea5e9" padding="24px 0">
+      <mj-column>
+        <mj-text align="center" color="#ffffff" font-size="22px" font-weight="bold">
+          ManageHub
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#ffffff" padding="32px 24px">
+      <mj-column>
+        <mj-text font-size="20px" font-weight="bold" color="#111827">
+          Password Reset Request
+        </mj-text>
+        <mj-text>Hi {{memberName}},</mj-text>
+        <mj-text>
+          You requested a password reset for your ManageHub account. Click the button below to set a new password.
+        </mj-text>
+        <mj-button
+          background-color="#0ea5e9"
+          color="#ffffff"
+          href="{{resetUrl}}"
+          border-radius="6px"
+          font-size="15px"
+          padding="12px 28px"
+        >
+          Reset Password
+        </mj-button>
+        <mj-text font-size="13px" color="#6b7280" padding-top="12px">
+          This link expires in <strong>{{expiryMinutes}} minutes</strong>.
+        </mj-text>
+        <mj-text font-size="13px" color="#6b7280">
+          If you didn't request this, you can safely ignore this email. Your password will remain unchanged.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#f3f4f6" padding="16px">
+      <mj-column>
+        <mj-text align="center" font-size="12px" color="#9ca3af">
+          © 2026 ManageHub. All rights reserved.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/backend/cntr/password-reset.util.spec.ts
+++ b/backend/cntr/password-reset.util.spec.ts
@@ -1,0 +1,72 @@
+jest.mock('mjml', () =>
+  jest.fn().mockReturnValue({ html: '<html>password-reset</html>', errors: [] }),
+);
+jest.mock('fs', () => ({
+  readFileSync: jest
+    .fn()
+    .mockReturnValue(
+      'Hi {{memberName}}, reset at {{resetUrl}}. Expires in {{expiryMinutes}} minutes. If you didn\'t request this, you can safely ignore this email.',
+    ),
+}));
+
+import mjml2html from 'mjml';
+import { renderPasswordResetEmail } from './password-reset.util';
+
+const mockMjml = mjml2html as jest.MockedFunction<typeof mjml2html>;
+
+describe('renderPasswordResetEmail', () => {
+  it('returns HTML string from mjml', () => {
+    const html = renderPasswordResetEmail({
+      memberName: 'Alice',
+      resetUrl: 'https://example.com/reset?token=abc',
+      expiryMinutes: 30,
+    });
+    expect(html).toBe('<html>password-reset</html>');
+  });
+
+  it('substitutes memberName, resetUrl, and expiryMinutes', () => {
+    renderPasswordResetEmail({
+      memberName: 'Bob',
+      resetUrl: 'https://example.com/reset?token=xyz',
+      expiryMinutes: 60,
+    });
+    const arg = mockMjml.mock.calls[mockMjml.mock.calls.length - 1][0] as string;
+    expect(arg).toContain('Bob');
+    expect(arg).toContain('https://example.com/reset?token=xyz');
+    expect(arg).toContain('60');
+  });
+
+  it('includes "did not request" disclaimer in the template', () => {
+    renderPasswordResetEmail({
+      memberName: 'Carol',
+      resetUrl: 'https://example.com/reset',
+      expiryMinutes: 30,
+    });
+    const arg = mockMjml.mock.calls[mockMjml.mock.calls.length - 1][0] as string;
+    expect(arg).toContain("If you didn't request this");
+  });
+
+  it('does not contain unreplaced placeholders', () => {
+    renderPasswordResetEmail({
+      memberName: 'Dave',
+      resetUrl: 'https://example.com/reset',
+      expiryMinutes: 15,
+    });
+    const arg = mockMjml.mock.calls[mockMjml.mock.calls.length - 1][0] as string;
+    expect(arg).not.toMatch(/\{\{[^}]+\}\}/);
+  });
+
+  it('throws when mjml returns errors', () => {
+    mockMjml.mockReturnValueOnce({
+      html: '',
+      errors: [{ message: 'bad tag', tagName: 'mj-x', severity: 'error', line: 1 }],
+    } as any);
+    expect(() =>
+      renderPasswordResetEmail({
+        memberName: 'Eve',
+        resetUrl: 'https://example.com/reset',
+        expiryMinutes: 30,
+      }),
+    ).toThrow('MJML errors');
+  });
+});

--- a/backend/cntr/password-reset.util.ts
+++ b/backend/cntr/password-reset.util.ts
@@ -1,0 +1,20 @@
+import mjml2html from 'mjml';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export function renderPasswordResetEmail(vars: {
+  memberName: string;
+  resetUrl: string;
+  expiryMinutes: number;
+}): string {
+  const templatePath = join(__dirname, 'password-reset.template.mjml');
+  const raw = readFileSync(templatePath, 'utf8')
+    .replace(/\{\{memberName\}\}/g, vars.memberName)
+    .replace(/\{\{resetUrl\}\}/g, vars.resetUrl)
+    .replace(/\{\{expiryMinutes\}\}/g, String(vars.expiryMinutes));
+  const { html, errors } = mjml2html(raw);
+  if (errors.length > 0) {
+    throw new Error(`MJML errors: ${errors.map((e: any) => e.message).join(', ')}`);
+  }
+  return html;
+}

--- a/backend/cntr/welcome-email.template.mjml
+++ b/backend/cntr/welcome-email.template.mjml
@@ -1,0 +1,57 @@
+<mjml>
+  <mj-head>
+    <mj-title>Welcome to ManageHub</mj-title>
+    <mj-attributes>
+      <mj-all font-family="Arial, sans-serif" />
+      <mj-text font-size="15px" line-height="1.6" color="#1f2937" />
+    </mj-attributes>
+  </mj-head>
+  <mj-body background-color="#f9fafb">
+    <mj-section background-color="#0ea5e9" padding="24px 0">
+      <mj-column>
+        <mj-text align="center" color="#ffffff" font-size="22px" font-weight="bold">
+          ManageHub
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#ffffff" padding="32px 24px">
+      <mj-column>
+        <mj-text font-size="22px" font-weight="bold" color="#111827">
+          Welcome to ManageHub, {{memberName}}!
+        </mj-text>
+        <mj-text>
+          We're thrilled to have you on board. ManageHub makes it easy to discover, book, and manage
+          workspace solutions tailored to your needs.
+        </mj-text>
+        <mj-text>
+          Start exploring available workspaces and make your first booking today.
+        </mj-text>
+        <mj-button
+          background-color="#0ea5e9"
+          color="#ffffff"
+          href="{{exploreUrl}}"
+          border-radius="6px"
+          font-size="15px"
+          padding="12px 28px"
+        >
+          Explore Workspaces
+        </mj-button>
+        <mj-text align="center" font-size="13px" color="#6b7280" padding-top="12px">
+          Already set up? <a href="{{loginUrl}}" style="color: #0ea5e9;">Login to your account</a>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+
+    <mj-section background-color="#f3f4f6" padding="16px">
+      <mj-column>
+        <mj-text align="center" font-size="12px" color="#9ca3af">
+          You can unsubscribe at any time by updating your notification preferences in your account settings.
+        </mj-text>
+        <mj-text align="center" font-size="12px" color="#9ca3af">
+          © 2026 ManageHub. All rights reserved.
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/backend/cntr/welcome-email.util.spec.ts
+++ b/backend/cntr/welcome-email.util.spec.ts
@@ -1,0 +1,72 @@
+jest.mock('mjml', () =>
+  jest.fn().mockReturnValue({ html: '<html>welcome</html>', errors: [] }),
+);
+jest.mock('fs', () => ({
+  readFileSync: jest
+    .fn()
+    .mockReturnValue(
+      'Welcome {{memberName}}! Explore: {{exploreUrl}} Login: {{loginUrl}} You can unsubscribe at any time.',
+    ),
+}));
+
+import mjml2html from 'mjml';
+import { renderWelcomeEmail } from './welcome-email.util';
+
+const mockMjml = mjml2html as jest.MockedFunction<typeof mjml2html>;
+
+describe('renderWelcomeEmail', () => {
+  it('returns HTML string from mjml', () => {
+    const html = renderWelcomeEmail({
+      memberName: 'Alice',
+      loginUrl: 'https://example.com/login',
+      exploreUrl: 'https://example.com/explore',
+    });
+    expect(html).toBe('<html>welcome</html>');
+  });
+
+  it('substitutes memberName, loginUrl, and exploreUrl before calling mjml', () => {
+    renderWelcomeEmail({
+      memberName: 'Bob',
+      loginUrl: 'https://example.com/login',
+      exploreUrl: 'https://example.com/workspaces',
+    });
+    const arg = mockMjml.mock.calls[mockMjml.mock.calls.length - 1][0] as string;
+    expect(arg).toContain('Bob');
+    expect(arg).toContain('https://example.com/login');
+    expect(arg).toContain('https://example.com/workspaces');
+  });
+
+  it('calls mjml exactly once', () => {
+    mockMjml.mockClear();
+    renderWelcomeEmail({
+      memberName: 'Carol',
+      loginUrl: 'https://example.com/login',
+      exploreUrl: 'https://example.com/explore',
+    });
+    expect(mockMjml).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not contain unreplaced placeholders', () => {
+    renderWelcomeEmail({
+      memberName: 'Dave',
+      loginUrl: 'https://example.com/login',
+      exploreUrl: 'https://example.com/explore',
+    });
+    const arg = mockMjml.mock.calls[mockMjml.mock.calls.length - 1][0] as string;
+    expect(arg).not.toMatch(/\{\{[^}]+\}\}/);
+  });
+
+  it('throws when mjml returns errors', () => {
+    mockMjml.mockReturnValueOnce({
+      html: '',
+      errors: [{ message: 'invalid', tagName: 'mj-x', severity: 'error', line: 1 }],
+    } as any);
+    expect(() =>
+      renderWelcomeEmail({
+        memberName: 'Eve',
+        loginUrl: 'https://example.com/login',
+        exploreUrl: 'https://example.com/explore',
+      }),
+    ).toThrow('MJML errors');
+  });
+});

--- a/backend/cntr/welcome-email.util.ts
+++ b/backend/cntr/welcome-email.util.ts
@@ -1,0 +1,20 @@
+import mjml2html from 'mjml';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export function renderWelcomeEmail(vars: {
+  memberName: string;
+  loginUrl: string;
+  exploreUrl: string;
+}): string {
+  const templatePath = join(__dirname, 'welcome-email.template.mjml');
+  const raw = readFileSync(templatePath, 'utf8')
+    .replace(/\{\{memberName\}\}/g, vars.memberName)
+    .replace(/\{\{loginUrl\}\}/g, vars.loginUrl)
+    .replace(/\{\{exploreUrl\}\}/g, vars.exploreUrl);
+  const { html, errors } = mjml2html(raw);
+  if (errors.length > 0) {
+    throw new Error(`MJML errors: ${errors.map((e: any) => e.message).join(', ')}`);
+  }
+  return html;
+}


### PR DESCRIPTION
## Summary

- **[BE-16]** Add CSV member list export service using `json2csv` with ID, Email, Full Name, Role, Status, Joined Date, Total Bookings fields
- **[BE-17]** Add booking confirmation MJML email template and renderer with all 6 booking variables and ManageHub brand colour (#0ea5e9)
- **[BE-18]** Add welcome email MJML template with "Explore Workspaces" CTA, login link, and unsubscribe footer
- **[BE-19]** Add password reset MJML email with "Reset Password" CTA, expiry duration, and "did not request" disclaimer

## Closes

Closes #955
Closes #956
Closes #957
Closes #958