### PR TITLE
feat(cntr): add password history, seat map, audit trail, and IP whitelist guard (BE-28–31)

### DIFF
--- a/backend/cntr/audit-trail.service.spec.ts
+++ b/backend/cntr/audit-trail.service.spec.ts
@@ -1,0 +1,58 @@
+import { createAuditEntry } from './audit-trail.service';
+
+const actor = { userId: 'user-1', role: 'ADMIN' };
+
+describe('createAuditEntry', () => {
+  it('id is a valid UUID', () => {
+    const entry = createAuditEntry(actor, 'DELETE', 'workspace', 'ws-42');
+    expect(entry.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('generates unique ids for each call', () => {
+    const a = createAuditEntry(actor, 'CREATE', 'workspace', 'ws-1');
+    const b = createAuditEntry(actor, 'CREATE', 'workspace', 'ws-1');
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it('timestamp is a valid ISO 8601 string', () => {
+    const entry = createAuditEntry(actor, 'UPDATE', 'member', 'm-1');
+    expect(() => new Date(entry.timestamp)).not.toThrow();
+    expect(new Date(entry.timestamp).toISOString()).toBe(entry.timestamp);
+  });
+
+  it('maps actor.userId to actorId', () => {
+    const entry = createAuditEntry({ userId: 'u-99', role: 'ADMIN' }, 'READ', 'report', 'r-1');
+    expect(entry.actorId).toBe('u-99');
+  });
+
+  it('maps actor.role to actorRole', () => {
+    const entry = createAuditEntry({ userId: 'u-1', role: 'SUPERADMIN' }, 'DELETE', 'ws', 'ws-1');
+    expect(entry.actorRole).toBe('SUPERADMIN');
+  });
+
+  it('metadata defaults to {} when not provided', () => {
+    const entry = createAuditEntry(actor, 'DELETE', 'workspace', 'ws-1');
+    expect(entry.metadata).toEqual({});
+  });
+
+  it('metadata is deep-cloned to prevent mutation', () => {
+    const originalMeta = { reason: 'test', nested: { count: 1 } };
+    const entry = createAuditEntry(actor, 'UPDATE', 'member', 'm-1', originalMeta);
+    originalMeta.nested.count = 999;
+    expect((entry.metadata as any).nested.count).toBe(1);
+  });
+
+  it('includes all required fields', () => {
+    const entry = createAuditEntry(actor, 'DELETE', 'booking', 'bk-1', { note: 'test' });
+    expect(entry).toHaveProperty('id');
+    expect(entry).toHaveProperty('actorId');
+    expect(entry).toHaveProperty('actorRole');
+    expect(entry).toHaveProperty('action');
+    expect(entry).toHaveProperty('resourceType');
+    expect(entry).toHaveProperty('resourceId');
+    expect(entry).toHaveProperty('metadata');
+    expect(entry).toHaveProperty('timestamp');
+  });
+});

--- a/backend/cntr/audit-trail.service.ts
+++ b/backend/cntr/audit-trail.service.ts
@@ -1,0 +1,31 @@
+import { randomUUID } from 'crypto';
+
+export interface AuditEntry {
+  id: string;
+  actorId: string;
+  actorRole: string;
+  action: string;
+  resourceType: string;
+  resourceId: string;
+  metadata: Record<string, unknown>;
+  timestamp: string;
+}
+
+export function createAuditEntry(
+  actor: { userId: string; role: string },
+  action: string,
+  resourceType: string,
+  resourceId: string,
+  metadata?: Record<string, unknown>,
+): AuditEntry {
+  return {
+    id: randomUUID(),
+    actorId: actor.userId,
+    actorRole: actor.role,
+    action,
+    resourceType,
+    resourceId,
+    metadata: metadata ? JSON.parse(JSON.stringify(metadata)) : {},
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/backend/cntr/ip-whitelist.guard.spec.ts
+++ b/backend/cntr/ip-whitelist.guard.spec.ts
@@ -1,0 +1,53 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { IpWhitelistGuard } from './ip-whitelist.guard';
+
+function makeContext(ip: string): ExecutionContext {
+  return {
+    switchToHttp: () => ({
+      getRequest: () => ({ ip }),
+    }),
+  } as unknown as ExecutionContext;
+}
+
+describe('IpWhitelistGuard', () => {
+  const guard = new IpWhitelistGuard();
+  const originalEnv = process.env.ADMIN_IP_WHITELIST;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.ADMIN_IP_WHITELIST;
+    } else {
+      process.env.ADMIN_IP_WHITELIST = originalEnv;
+    }
+  });
+
+  it('allows matching IP when ADMIN_IP_WHITELIST is set', () => {
+    process.env.ADMIN_IP_WHITELIST = '192.168.1.1, 10.0.0.1';
+    expect(guard.canActivate(makeContext('192.168.1.1'))).toBe(true);
+  });
+
+  it('trims whitespace around IPs in the whitelist', () => {
+    process.env.ADMIN_IP_WHITELIST = '  10.0.0.1  ,  192.168.1.1  ';
+    expect(guard.canActivate(makeContext('10.0.0.1'))).toBe(true);
+  });
+
+  it('throws ForbiddenException for non-matching IP', () => {
+    process.env.ADMIN_IP_WHITELIST = '10.0.0.1';
+    expect(() => guard.canActivate(makeContext('1.2.3.4'))).toThrow(ForbiddenException);
+  });
+
+  it('allows all traffic when ADMIN_IP_WHITELIST is unset', () => {
+    delete process.env.ADMIN_IP_WHITELIST;
+    expect(guard.canActivate(makeContext('1.2.3.4'))).toBe(true);
+  });
+
+  it('allows all traffic when ADMIN_IP_WHITELIST is empty string', () => {
+    process.env.ADMIN_IP_WHITELIST = '';
+    expect(guard.canActivate(makeContext('9.9.9.9'))).toBe(true);
+  });
+
+  it('allows all traffic when ADMIN_IP_WHITELIST is only whitespace', () => {
+    process.env.ADMIN_IP_WHITELIST = '   ';
+    expect(guard.canActivate(makeContext('9.9.9.9'))).toBe(true);
+  });
+});

--- a/backend/cntr/ip-whitelist.guard.ts
+++ b/backend/cntr/ip-whitelist.guard.ts
@@ -1,0 +1,17 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class IpWhitelistGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<{ ip: string }>();
+    const raw = process.env.ADMIN_IP_WHITELIST ?? '';
+    if (!raw.trim()) return true;
+    const allowed = raw
+      .split(',')
+      .map((ip) => ip.trim())
+      .filter(Boolean);
+    if (allowed.length === 0) return true;
+    if (allowed.includes(request.ip)) return true;
+    throw new ForbiddenException('IP not whitelisted');
+  }
+}

--- a/backend/cntr/password-history.service.spec.ts
+++ b/backend/cntr/password-history.service.spec.ts
@@ -1,0 +1,65 @@
+jest.mock('bcrypt');
+
+import * as bcrypt from 'bcrypt';
+import { isPasswordReused, addToHistory } from './password-history.service';
+
+const mockCompare = bcrypt.compare as jest.MockedFunction<typeof bcrypt.compare>;
+
+describe('isPasswordReused', () => {
+  it('returns true when any hash matches', async () => {
+    mockCompare
+      .mockResolvedValueOnce(false as never)
+      .mockResolvedValueOnce(true as never);
+    const result = await isPasswordReused('password123', ['hash1', 'hash2']);
+    expect(result).toBe(true);
+  });
+
+  it('returns false when no hash matches', async () => {
+    mockCompare.mockResolvedValue(false as never);
+    const result = await isPasswordReused('password123', ['hash1', 'hash2', 'hash3']);
+    expect(result).toBe(false);
+  });
+
+  it('returns false for an empty history', async () => {
+    const result = await isPasswordReused('password123', []);
+    expect(result).toBe(false);
+  });
+
+  it('stops checking after first match (returns true for match at index 0)', async () => {
+    mockCompare.mockResolvedValueOnce(true as never);
+    const result = await isPasswordReused('password123', ['matchHash', 'other']);
+    expect(result).toBe(true);
+    expect(mockCompare).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('addToHistory', () => {
+  it('prepends new hash at index 0', () => {
+    const result = addToHistory('newHash', ['old1', 'old2']);
+    expect(result[0]).toBe('newHash');
+  });
+
+  it('default maxHistory is 5 — trims to 5 entries', () => {
+    const history = ['h1', 'h2', 'h3', 'h4', 'h5'];
+    const result = addToHistory('h0', history);
+    expect(result).toHaveLength(5);
+    expect(result[0]).toBe('h0');
+  });
+
+  it('never exceeds maxHistory entries', () => {
+    const history = ['h1', 'h2', 'h3'];
+    const result = addToHistory('h0', history, 3);
+    expect(result).toHaveLength(3);
+  });
+
+  it('discards oldest (last) entries when exceeding maxHistory', () => {
+    const result = addToHistory('new', ['a', 'b', 'c'], 3);
+    expect(result).toEqual(['new', 'a', 'b']);
+  });
+
+  it('works with custom maxHistory', () => {
+    const result = addToHistory('x', ['a', 'b', 'c', 'd', 'e', 'f'], 4);
+    expect(result).toHaveLength(4);
+    expect(result[0]).toBe('x');
+  });
+});

--- a/backend/cntr/password-history.service.ts
+++ b/backend/cntr/password-history.service.ts
@@ -1,0 +1,19 @@
+import * as bcrypt from 'bcrypt';
+
+export async function isPasswordReused(
+  newPassword: string,
+  hashedHistory: string[],
+): Promise<boolean> {
+  for (const hash of hashedHistory) {
+    if (await bcrypt.compare(newPassword, hash)) return true;
+  }
+  return false;
+}
+
+export function addToHistory(
+  newHash: string,
+  history: string[],
+  maxHistory = 5,
+): string[] {
+  return [newHash, ...history].slice(0, maxHistory);
+}

--- a/backend/cntr/seat-map.service.spec.ts
+++ b/backend/cntr/seat-map.service.spec.ts
@@ -1,0 +1,59 @@
+import { generateSeatMap } from './seat-map.service';
+
+describe('generateSeatMap', () => {
+  it('total seats across all rows equals capacity', () => {
+    const map = generateSeatMap(10, 2, []);
+    const total = map.rows.reduce((sum, row) => sum + row.seats.length, 0);
+    expect(total).toBe(10);
+  });
+
+  it('seats are numbered 1 to capacity sequentially', () => {
+    const map = generateSeatMap(6, 2, []);
+    const allSeats = map.rows.flatMap((r) => r.seats);
+    expect(allSeats.map((s) => s.seatNumber)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('isBooked is true for seats in bookedSeatNumbers', () => {
+    const map = generateSeatMap(10, 2, [1, 5]);
+    const allSeats = map.rows.flatMap((r) => r.seats);
+    const seat1 = allSeats.find((s) => s.seatNumber === 1);
+    const seat5 = allSeats.find((s) => s.seatNumber === 5);
+    expect(seat1?.isBooked).toBe(true);
+    expect(seat5?.isBooked).toBe(true);
+  });
+
+  it('isBooked is false for unbooked seats', () => {
+    const map = generateSeatMap(10, 2, [1, 5]);
+    const allSeats = map.rows.flatMap((r) => r.seats);
+    const seat2 = allSeats.find((s) => s.seatNumber === 2);
+    expect(seat2?.isBooked).toBe(false);
+  });
+
+  it('rowIndex values are 0-based sequential', () => {
+    const map = generateSeatMap(6, 3, []);
+    const indices = map.rows.map((r) => r.rowIndex);
+    expect(indices).toEqual([0, 1, 2]);
+  });
+
+  it('produces correct number of rows', () => {
+    const map = generateSeatMap(10, 2, []);
+    expect(map.rows).toHaveLength(2);
+  });
+
+  it('works for capacity=6, rows=3, no bookings', () => {
+    const map = generateSeatMap(6, 3, []);
+    expect(map.rows).toHaveLength(3);
+    const total = map.rows.reduce((s, r) => s + r.seats.length, 0);
+    expect(total).toBe(6);
+    for (const seat of map.rows.flatMap((r) => r.seats)) {
+      expect(seat.isBooked).toBe(false);
+    }
+  });
+
+  it('distributes extra seats to earlier rows when capacity is not divisible by rows', () => {
+    const map = generateSeatMap(7, 3, []);
+    expect(map.rows[0].seats).toHaveLength(3);
+    expect(map.rows[1].seats).toHaveLength(2);
+    expect(map.rows[2].seats).toHaveLength(2);
+  });
+});

--- a/backend/cntr/seat-map.service.ts
+++ b/backend/cntr/seat-map.service.ts
@@ -1,0 +1,38 @@
+export interface Seat {
+  seatNumber: number;
+  isBooked: boolean;
+}
+
+export interface SeatRow {
+  rowIndex: number;
+  seats: Seat[];
+}
+
+export interface SeatMap {
+  rows: SeatRow[];
+}
+
+export function generateSeatMap(
+  capacity: number,
+  rows: number,
+  bookedSeatNumbers: number[],
+): SeatMap {
+  const booked = new Set(bookedSeatNumbers);
+  const seatsPerRow = Math.floor(capacity / rows);
+  const extraSeats = capacity % rows;
+
+  const seatRows: SeatRow[] = [];
+  let seatNumber = 1;
+
+  for (let rowIndex = 0; rowIndex < rows; rowIndex++) {
+    const count = seatsPerRow + (rowIndex < extraSeats ? 1 : 0);
+    const seats: Seat[] = [];
+    for (let i = 0; i < count; i++) {
+      seats.push({ seatNumber, isBooked: booked.has(seatNumber) });
+      seatNumber++;
+    }
+    seatRows.push({ rowIndex, seats });
+  }
+
+  return { rows: seatRows };
+}


### PR DESCRIPTION
## Summary

- **[BE-28]** Add password history tracker using bcrypt to prevent reuse of last N passwords
- **[BE-29]** Add workspace seat map generator distributing seats evenly across rows with booked status tracking
- **[BE-30]** Add audit trail logger using `crypto.randomUUID()` with deep-cloned metadata for sensitive admin actions
- **[BE-31]** Add IP whitelist NestJS guard reading `ADMIN_IP_WHITELIST` env var; fail-open when unset or empty

## Closes

Closes #967
Closes #968
Closes #969
Closes #970