### PR TITLE
feat(cntr): add booking reminder, stale booking cleanup, notification cleanup, and referral code (BE-24–27)

### DIFF
--- a/backend/cntr/booking-reminder.job.spec.ts
+++ b/backend/cntr/booking-reminder.job.spec.ts
@@ -1,0 +1,79 @@
+import { processBookingReminders, Booking } from './booking-reminder.job';
+
+const now = new Date('2026-06-02T10:00:00Z');
+const in12h = new Date('2026-06-02T22:00:00Z');
+const in25h = new Date('2026-06-03T11:00:00Z');
+const in24h = new Date('2026-06-03T10:00:00Z');
+
+const booking = (overrides: Partial<Booking> = {}): Booking => ({
+  id: 'bk-1',
+  userId: 'u-1',
+  workspaceName: 'The Hub',
+  startDate: in12h,
+  endDate: new Date('2026-06-03T22:00:00Z'),
+  status: 'CONFIRMED',
+  ...overrides,
+});
+
+describe('processBookingReminders', () => {
+  let notifyFn: jest.Mock;
+
+  beforeEach(() => {
+    notifyFn = jest.fn().mockResolvedValue(undefined);
+  });
+
+  it('calls notifyFn for bookings within 24 hours', async () => {
+    await processBookingReminders([booking({ startDate: in12h })], notifyFn, now);
+    expect(notifyFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call notifyFn for CANCELLED bookings', async () => {
+    await processBookingReminders([booking({ status: 'CANCELLED' })], notifyFn, now);
+    expect(notifyFn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call notifyFn for bookings more than 24 hours away', async () => {
+    await processBookingReminders([booking({ startDate: in25h })], notifyFn, now);
+    expect(notifyFn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call notifyFn for bookings in the past', async () => {
+    const past = new Date('2026-06-01T09:00:00Z');
+    await processBookingReminders([booking({ startDate: past })], notifyFn, now);
+    expect(notifyFn).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call notifyFn for booking exactly at the 24h boundary (exclusive)', async () => {
+    await processBookingReminders([booking({ startDate: in24h })], notifyFn, now);
+    expect(notifyFn).not.toHaveBeenCalled();
+  });
+
+  it('message contains workspaceName', async () => {
+    await processBookingReminders(
+      [booking({ workspaceName: 'Cowork Space Alpha' })],
+      notifyFn,
+      now,
+    );
+    expect(notifyFn.mock.calls[0][1]).toContain('Cowork Space Alpha');
+  });
+
+  it('message contains the formatted start time', async () => {
+    const startDate = new Date('2026-06-02T15:30:00Z');
+    await processBookingReminders([booking({ startDate })], notifyFn, now);
+    expect(notifyFn.mock.calls[0][1]).toContain(startDate.toISOString());
+  });
+
+  it('calls notifyFn with correct userId', async () => {
+    await processBookingReminders([booking({ userId: 'user-99' })], notifyFn, now);
+    expect(notifyFn.mock.calls[0][0]).toBe('user-99');
+  });
+
+  it('processes multiple eligible bookings', async () => {
+    const bookings = [
+      booking({ id: 'bk-1', startDate: in12h }),
+      booking({ id: 'bk-2', startDate: in12h }),
+    ];
+    await processBookingReminders(bookings, notifyFn, now);
+    expect(notifyFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/cntr/booking-reminder.job.ts
+++ b/backend/cntr/booking-reminder.job.ts
@@ -1,0 +1,23 @@
+export interface Booking {
+  id: string;
+  userId: string;
+  workspaceName: string;
+  startDate: Date;
+  endDate: Date;
+  status: string;
+}
+
+export async function processBookingReminders(
+  bookings: Booking[],
+  notifyFn: (userId: string, message: string) => Promise<void>,
+  now: Date = new Date(),
+): Promise<void> {
+  const cutoff = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+  const upcoming = bookings.filter(
+    (b) => b.status !== 'CANCELLED' && b.startDate > now && b.startDate <= cutoff,
+  );
+  for (const booking of upcoming) {
+    const message = `Reminder: Your booking at "${booking.workspaceName}" starts at ${booking.startDate.toISOString()}.`;
+    await notifyFn(booking.userId, message);
+  }
+}

--- a/backend/cntr/notification-cleanup.job.spec.ts
+++ b/backend/cntr/notification-cleanup.job.spec.ts
@@ -1,0 +1,51 @@
+import { identifyExpiredNotifications, Notification } from './notification-cleanup.job';
+
+const now = new Date('2026-06-02T12:00:00Z');
+
+const notification = (overrides: Partial<Notification> = {}): Notification => ({
+  id: 'n-1',
+  isRead: true,
+  createdAt: new Date('2026-04-01T00:00:00Z'),
+  ...overrides,
+});
+
+describe('identifyExpiredNotifications', () => {
+  it('returns read notifications older than retentionDays', () => {
+    const old = notification({ createdAt: new Date('2026-04-01T00:00:00Z') });
+    expect(identifyExpiredNotifications([old], 30, now)).toContain(old);
+  });
+
+  it('does not return read notifications younger than retentionDays', () => {
+    const recent = notification({ createdAt: new Date('2026-05-25T00:00:00Z') });
+    expect(identifyExpiredNotifications([recent], 30, now)).not.toContain(recent);
+  });
+
+  it('never returns unread notifications regardless of age', () => {
+    const old = notification({ isRead: false, createdAt: new Date('2020-01-01T00:00:00Z') });
+    expect(identifyExpiredNotifications([old], 30, now)).not.toContain(old);
+  });
+
+  it('does not return notification exactly at retentionDays (strict greater)', () => {
+    const exactly = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    const n = notification({ createdAt: exactly });
+    expect(identifyExpiredNotifications([n], 30, now)).not.toContain(n);
+  });
+
+  it('returns notification 1ms over retentionDays', () => {
+    const justOver = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000 - 1);
+    const n = notification({ createdAt: justOver });
+    expect(identifyExpiredNotifications([n], 30, now)).toContain(n);
+  });
+
+  it('respects custom retentionDays', () => {
+    const n = notification({ createdAt: new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000) });
+    expect(identifyExpiredNotifications([n], 5, now)).toContain(n);
+    expect(identifyExpiredNotifications([n], 15, now)).not.toContain(n);
+  });
+
+  it('accepts optional now parameter for testability', () => {
+    const customNow = new Date('2030-01-01T00:00:00Z');
+    const n = notification({ createdAt: new Date('2026-01-01T00:00:00Z') });
+    expect(identifyExpiredNotifications([n], 30, customNow)).toContain(n);
+  });
+});

--- a/backend/cntr/notification-cleanup.job.ts
+++ b/backend/cntr/notification-cleanup.job.ts
@@ -1,0 +1,17 @@
+export interface Notification {
+  id: string;
+  isRead: boolean;
+  createdAt: Date;
+}
+
+export function identifyExpiredNotifications(
+  notifications: Notification[],
+  retentionDays = 30,
+  now: Date = new Date(),
+): Notification[] {
+  return notifications.filter((n) => {
+    if (!n.isRead) return false;
+    const ageDays = (now.getTime() - n.createdAt.getTime()) / (1000 * 60 * 60 * 24);
+    return ageDays > retentionDays;
+  });
+}

--- a/backend/cntr/referral-code.service.spec.ts
+++ b/backend/cntr/referral-code.service.spec.ts
@@ -1,0 +1,53 @@
+import { generateReferralCode, isValidReferralCodeFormat } from './referral-code.service';
+
+describe('generateReferralCode', () => {
+  it('is deterministic — same userId always produces the same code', () => {
+    expect(generateReferralCode('user-123')).toBe(generateReferralCode('user-123'));
+  });
+
+  it('output is always exactly 8 characters', () => {
+    expect(generateReferralCode('user-1')).toHaveLength(8);
+    expect(generateReferralCode('another-user')).toHaveLength(8);
+    expect(generateReferralCode('')).toHaveLength(8);
+  });
+
+  it('output matches uppercase alphanumeric pattern', () => {
+    expect(generateReferralCode('test-user')).toMatch(/^[A-Z0-9]{8}$/);
+  });
+
+  it('different userIds produce different codes', () => {
+    const a = generateReferralCode('user-aaa');
+    const b = generateReferralCode('user-bbb');
+    const c = generateReferralCode('user-ccc');
+    expect(a).not.toBe(b);
+    expect(b).not.toBe(c);
+  });
+});
+
+describe('isValidReferralCodeFormat', () => {
+  it('returns true for valid 8-char uppercase alphanumeric', () => {
+    expect(isValidReferralCodeFormat('ABCD1234')).toBe(true);
+    expect(isValidReferralCodeFormat('00000000')).toBe(true);
+    expect(isValidReferralCodeFormat('ZZZZZZZZ')).toBe(true);
+  });
+
+  it('returns false for 7-character code', () => {
+    expect(isValidReferralCodeFormat('ABCDE12')).toBe(false);
+  });
+
+  it('returns false for 9-character code', () => {
+    expect(isValidReferralCodeFormat('ABCDE1234')).toBe(false);
+  });
+
+  it('returns false for lowercase letters', () => {
+    expect(isValidReferralCodeFormat('abcd1234')).toBe(false);
+  });
+
+  it('returns false for special characters', () => {
+    expect(isValidReferralCodeFormat('ABCD-123')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isValidReferralCodeFormat('')).toBe(false);
+  });
+});

--- a/backend/cntr/referral-code.service.ts
+++ b/backend/cntr/referral-code.service.ts
@@ -1,0 +1,9 @@
+import { createHash } from 'crypto';
+
+export function generateReferralCode(userId: string): string {
+  return createHash('sha256').update(userId).digest('hex').toUpperCase().slice(0, 8);
+}
+
+export function isValidReferralCodeFormat(code: string): boolean {
+  return /^[A-Z0-9]{8}$/.test(code);
+}

--- a/backend/cntr/stale-booking-cleanup.job.spec.ts
+++ b/backend/cntr/stale-booking-cleanup.job.spec.ts
@@ -1,0 +1,53 @@
+import { identifyStaleBookings, Booking } from './stale-booking-cleanup.job';
+
+const now = new Date('2026-06-02T12:00:00Z');
+
+const booking = (overrides: Partial<Booking> = {}): Booking => ({
+  id: 'bk-1',
+  status: 'PENDING',
+  createdAt: new Date('2026-06-01T10:00:00Z'),
+  ...overrides,
+});
+
+describe('identifyStaleBookings', () => {
+  it('returns PENDING bookings older than maxAgeHours', () => {
+    const old = booking({ createdAt: new Date('2026-06-01T10:00:00Z') }); // 26h ago
+    expect(identifyStaleBookings([old], 24, now)).toContain(old);
+  });
+
+  it('does not return PENDING bookings younger than maxAgeHours', () => {
+    const fresh = booking({ createdAt: new Date('2026-06-02T10:00:00Z') }); // 2h ago
+    expect(identifyStaleBookings([fresh], 24, now)).not.toContain(fresh);
+  });
+
+  it('does not return booking exactly at maxAgeHours (strict greater)', () => {
+    const exactly = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    const b = booking({ createdAt: exactly });
+    expect(identifyStaleBookings([b], 24, now)).not.toContain(b);
+  });
+
+  it('returns booking 1ms over maxAgeHours', () => {
+    const justOver = new Date(now.getTime() - 24 * 60 * 60 * 1000 - 1);
+    const b = booking({ createdAt: justOver });
+    expect(identifyStaleBookings([b], 24, now)).toContain(b);
+  });
+
+  it('ignores non-PENDING statuses', () => {
+    for (const status of ['CONFIRMED', 'CANCELLED', 'COMPLETED']) {
+      const b = booking({ status, createdAt: new Date('2026-06-01T00:00:00Z') });
+      expect(identifyStaleBookings([b], 24, now)).not.toContain(b);
+    }
+  });
+
+  it('respects custom maxAgeHours', () => {
+    const b = booking({ createdAt: new Date(now.getTime() - 3 * 60 * 60 * 1000) });
+    expect(identifyStaleBookings([b], 2, now)).toContain(b);
+    expect(identifyStaleBookings([b], 4, now)).not.toContain(b);
+  });
+
+  it('accepts optional now parameter for testability', () => {
+    const customNow = new Date('2030-01-01T00:00:00Z');
+    const b = booking({ createdAt: new Date('2026-06-01T00:00:00Z') });
+    expect(identifyStaleBookings([b], 24, customNow)).toContain(b);
+  });
+});

--- a/backend/cntr/stale-booking-cleanup.job.ts
+++ b/backend/cntr/stale-booking-cleanup.job.ts
@@ -1,0 +1,17 @@
+export interface Booking {
+  id: string;
+  status: string;
+  createdAt: Date;
+}
+
+export function identifyStaleBookings(
+  bookings: Booking[],
+  maxAgeHours = 24,
+  now: Date = new Date(),
+): Booking[] {
+  return bookings.filter((b) => {
+    if (b.status !== 'PENDING') return false;
+    const ageHours = (now.getTime() - b.createdAt.getTime()) / (1000 * 60 * 60);
+    return ageHours > maxAgeHours;
+  });
+}


### PR DESCRIPTION
## Summary

- **[BE-24]** Add booking reminder job that notifies users 24 hours before their booking starts (skips CANCELLED)
- **[BE-25]** Add stale booking cleanup job to identify PENDING bookings older than `maxAgeHours` (default 24h)
- **[BE-26]** Add notification cleanup job to identify read notifications older than `retentionDays` (default 30 days)
- **[BE-27]** Add referral code generator using deterministic SHA-256 hash and format validator

## Closes

Closes #963
Closes #964
Closes #965
Closes #966