### PR TITLE
feat: Build admin payment ledger page /admin/payments

### DIFF
--- a/backend/src/payments/payments.controller.ts
+++ b/backend/src/payments/payments.controller.ts
@@ -81,6 +81,10 @@ export class PaymentsController {
   @ApiQuery({ name: 'page', required: false, type: Number })
   @ApiQuery({ name: 'limit', required: false, type: Number })
   @ApiQuery({ name: 'bookingId', required: false, type: String })
+  @ApiQuery({ name: 'status', required: false, enum: ['pending', 'success', 'failed', 'refunded'] })
+  @ApiQuery({ name: 'provider', required: false, enum: ['paystack', 'soroban'] })
+  @ApiQuery({ name: 'from', required: false, type: String })
+  @ApiQuery({ name: 'to', required: false, type: String })
   async findAll(
     @Query() query: PaymentQuery,
     @GetCurrentUser('id') userId: string,

--- a/backend/src/payments/providers/find-payments.provider.ts
+++ b/backend/src/payments/providers/find-payments.provider.ts
@@ -2,12 +2,18 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Payment } from '../entities/payment.entity';
+import { PaymentStatus } from '../enums/payment-status.enum';
+import { PaymentProvider } from '../enums/payment-provider.enum';
 import { UserRole } from '../../users/enums/userRoles.enum';
 
 export class PaymentQuery {
   page?: number;
   limit?: number;
   bookingId?: string;
+  status?: PaymentStatus;
+  provider?: PaymentProvider;
+  from?: string;
+  to?: string;
 }
 
 @Injectable()
@@ -31,7 +37,10 @@ export class FindPaymentsProvider {
       requestingUserRole === UserRole.SUPER_ADMIN ||
       requestingUserRole === UserRole.STAFF;
 
-    const qb = this.paymentsRepository.createQueryBuilder('payment');
+    const qb = this.paymentsRepository
+      .createQueryBuilder('payment')
+      .leftJoinAndSelect('payment.user', 'user')
+      .leftJoinAndSelect('payment.booking', 'booking');
 
     if (!isAdmin) {
       qb.where('payment.userId = :userId', { userId: requestingUserId });
@@ -41,6 +50,22 @@ export class FindPaymentsProvider {
       qb.andWhere('payment.bookingId = :bookingId', {
         bookingId: query.bookingId,
       });
+    }
+
+    if (query.status) {
+      qb.andWhere('payment.status = :status', { status: query.status });
+    }
+
+    if (query.provider) {
+      qb.andWhere('payment.provider = :provider', { provider: query.provider });
+    }
+
+    if (query.from) {
+      qb.andWhere('payment.createdAt >= :from', { from: query.from });
+    }
+
+    if (query.to) {
+      qb.andWhere('payment.createdAt <= :to', { to: query.to });
     }
 
     qb.orderBy('payment.createdAt', 'DESC').skip(skip).take(limit);

--- a/frontend/app/admin/payments/page.tsx
+++ b/frontend/app/admin/payments/page.tsx
@@ -1,0 +1,406 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import DashboardLayout from "@/components/dashboard/DashboardLayout";
+import { useAuthState } from "@/lib/store/authStore";
+import { useGetAdminPayments } from "@/lib/react-query/hooks/admin/payments/useGetAdminPayments";
+import { useRefundPayment } from "@/lib/react-query/hooks/admin/payments/useRefundPayment";
+import { useGetAdminAnalytics } from "@/lib/react-query/hooks/admin/analytics/useGetAdminAnalytics";
+import { PaymentStatus, PaymentProvider } from "@/lib/types/payment";
+import {
+  CreditCard,
+  TrendingUp,
+  Clock,
+  XCircle,
+  ChevronLeft,
+  ChevronRight,
+  X,
+} from "lucide-react";
+
+const STATUS_TABS: { value: PaymentStatus | ""; label: string }[] = [
+  { value: "", label: "All" },
+  { value: "pending", label: "Pending" },
+  { value: "success", label: "Success" },
+  { value: "failed", label: "Failed" },
+  { value: "refunded", label: "Refunded" },
+];
+
+const PROVIDER_OPTIONS: { value: PaymentProvider | ""; label: string }[] = [
+  { value: "", label: "All Providers" },
+  { value: "paystack", label: "Paystack" },
+  { value: "soroban", label: "Soroban" },
+];
+
+const STATUS_COLORS: Record<PaymentStatus, string> = {
+  pending: "bg-amber-50 text-amber-700",
+  success: "bg-emerald-50 text-emerald-600",
+  failed: "bg-red-50 text-red-600",
+  refunded: "bg-blue-50 text-blue-700",
+};
+
+function formatNaira(kobo: number): string {
+  return new Intl.NumberFormat("en-NG", {
+    style: "currency",
+    currency: "NGN",
+    minimumFractionDigits: 0,
+    notation: kobo >= 100_000_000 ? "compact" : "standard",
+  }).format(kobo / 100);
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-NG", { dateStyle: "medium" });
+}
+
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+  color,
+}: {
+  label: string;
+  value: string;
+  icon: React.ElementType;
+  color: string;
+}) {
+  return (
+    <div className="bg-white rounded-xl p-5 border border-gray-100">
+      <span
+        className={`w-9 h-9 rounded-lg flex items-center justify-center mb-3 ${color}`}
+      >
+        <Icon className="w-4 h-4" />
+      </span>
+      <p className="text-2xl font-bold text-gray-900 truncate">{value}</p>
+      <p className="text-xs text-gray-400 mt-1">{label}</p>
+    </div>
+  );
+}
+
+export default function AdminPaymentsPage() {
+  const router = useRouter();
+  const { user } = useAuthState();
+
+  const [page, setPage] = useState(1);
+  const [statusFilter, setStatusFilter] = useState<PaymentStatus | "">("");
+  const [providerFilter, setProviderFilter] = useState<PaymentProvider | "">("");
+  const [from, setFrom] = useState("");
+  const [to, setTo] = useState("");
+  const [appliedFrom, setAppliedFrom] = useState("");
+  const [appliedTo, setAppliedTo] = useState("");
+  const [refundTarget, setRefundTarget] = useState<string | null>(null);
+
+  const isAdmin = user?.role === "admin";
+
+  useEffect(() => {
+    if (user && !isAdmin) {
+      router.replace("/dashboard");
+    }
+  }, [user, isAdmin, router]);
+
+  const { data, isLoading } = useGetAdminPayments({
+    page,
+    limit: 20,
+    status: statusFilter || undefined,
+    provider: providerFilter || undefined,
+    from: appliedFrom || undefined,
+    to: appliedTo || undefined,
+  });
+
+  const { data: analyticsData } = useGetAdminAnalytics();
+
+  const { data: pendingData } = useGetAdminPayments({ status: "pending", limit: 1 });
+  const { data: failedData } = useGetAdminPayments({ status: "failed", limit: 1 });
+
+  const refund = useRefundPayment();
+
+  if (!user || !isAdmin) return null;
+
+  const payments = data?.data ?? [];
+  const meta = data?.meta;
+  const revenue = analyticsData?.data?.revenue;
+
+  const handleApplyFilter = () => {
+    setAppliedFrom(from);
+    setAppliedTo(to);
+    setPage(1);
+  };
+
+  const handleClearFilter = () => {
+    setFrom("");
+    setTo("");
+    setAppliedFrom("");
+    setAppliedTo("");
+    setPage(1);
+  };
+
+  const handleRefund = async (id: string) => {
+    await refund.mutateAsync(id);
+    setRefundTarget(null);
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold text-gray-900">Payments</h1>
+        <p className="text-gray-500 mt-1 text-sm">
+          {meta?.total ?? 0} total payments
+        </p>
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+        <StatCard
+          label="Total Revenue"
+          value={revenue ? formatNaira(revenue.total) : "—"}
+          icon={TrendingUp}
+          color="bg-emerald-50 text-emerald-600"
+        />
+        <StatCard
+          label="This Month"
+          value={revenue ? formatNaira(revenue.thisMonth) : "—"}
+          icon={CreditCard}
+          color="bg-blue-50 text-blue-600"
+        />
+        <StatCard
+          label="Pending Payments"
+          value={pendingData?.meta?.total != null ? String(pendingData.meta.total) : "—"}
+          icon={Clock}
+          color="bg-amber-50 text-amber-600"
+        />
+        <StatCard
+          label="Failed Payments"
+          value={failedData?.meta?.total != null ? String(failedData.meta.total) : "—"}
+          icon={XCircle}
+          color="bg-red-50 text-red-600"
+        />
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-end gap-3 mb-4">
+        {/* Provider dropdown */}
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">Provider</label>
+          <select
+            value={providerFilter}
+            onChange={(e) => {
+              setProviderFilter(e.target.value as PaymentProvider | "");
+              setPage(1);
+            }}
+            className="text-sm border border-gray-200 rounded-lg px-3 py-2 bg-white focus:outline-none focus:ring-1 focus:ring-gray-300"
+          >
+            {PROVIDER_OPTIONS.map((o) => (
+              <option key={o.label} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Date range */}
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">From</label>
+          <input
+            type="date"
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+            className="text-sm border border-gray-200 rounded-lg px-3 py-2 bg-white focus:outline-none focus:ring-1 focus:ring-gray-300"
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-gray-400 mb-1">To</label>
+          <input
+            type="date"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+            className="text-sm border border-gray-200 rounded-lg px-3 py-2 bg-white focus:outline-none focus:ring-1 focus:ring-gray-300"
+          />
+        </div>
+        <button
+          onClick={handleApplyFilter}
+          className="text-sm px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-700 transition-colors"
+        >
+          Apply
+        </button>
+        {(appliedFrom || appliedTo) && (
+          <button
+            onClick={handleClearFilter}
+            className="text-sm px-3 py-2 border border-gray-200 text-gray-500 rounded-lg hover:bg-gray-50 flex items-center gap-1.5 transition-colors"
+          >
+            <X className="w-3.5 h-3.5" />
+            Clear
+          </button>
+        )}
+      </div>
+
+      {/* Status filter tabs */}
+      <div className="flex gap-2 mb-6 flex-wrap">
+        {STATUS_TABS.map(({ value, label }) => (
+          <button
+            key={label}
+            type="button"
+            onClick={() => {
+              setStatusFilter(value as PaymentStatus | "");
+              setPage(1);
+            }}
+            className={`px-4 py-2 text-sm font-medium rounded-lg border transition-colors ${
+              statusFilter === value
+                ? "bg-gray-900 text-white border-gray-900"
+                : "border-gray-200 text-gray-600 hover:bg-gray-50"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* Confirmation modal */}
+      {refundTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30">
+          <div className="bg-white rounded-xl p-6 shadow-lg w-full max-w-sm mx-4">
+            <h2 className="text-base font-semibold text-gray-900 mb-2">
+              Confirm Refund
+            </h2>
+            <p className="text-sm text-gray-500 mb-6">
+              Are you sure you want to initiate a refund for this payment? This
+              action cannot be undone.
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setRefundTarget(null)}
+                className="px-4 py-2 text-sm border border-gray-200 rounded-lg text-gray-600 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => handleRefund(refundTarget)}
+                disabled={refund.isPending}
+                className="px-4 py-2 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 disabled:opacity-50"
+              >
+                {refund.isPending ? "Processing…" : "Refund"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Table */}
+      {isLoading ? (
+        <div className="space-y-3">
+          {[1, 2, 3, 4, 5].map((i) => (
+            <div
+              key={i}
+              className="bg-white rounded-xl border border-gray-100 h-14 animate-pulse"
+            />
+          ))}
+        </div>
+      ) : payments.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <CreditCard className="w-10 h-10 text-gray-200 mb-4" />
+          <p className="text-sm font-medium text-gray-500">No payments found</p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-100 overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs text-gray-400 uppercase tracking-wider border-b border-gray-50">
+                  <th className="px-5 py-3 font-medium">Reference</th>
+                  <th className="px-5 py-3 font-medium">Member</th>
+                  <th className="px-5 py-3 font-medium">Amount</th>
+                  <th className="px-5 py-3 font-medium">Provider</th>
+                  <th className="px-5 py-3 font-medium">Status</th>
+                  <th className="px-5 py-3 font-medium">Booking</th>
+                  <th className="px-5 py-3 font-medium">Date</th>
+                  <th className="px-5 py-3 font-medium">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {payments.map((p) => (
+                  <tr key={p.id} className="border-b border-gray-50 last:border-0">
+                    <td className="px-5 py-3.5 font-mono text-xs text-gray-500">
+                      {p.providerReference
+                        ? p.providerReference.slice(0, 12)
+                        : p.id.slice(0, 8)}
+                    </td>
+                    <td className="px-5 py-3.5 text-gray-700">
+                      {p.user ? (
+                        <span>
+                          {p.user.firstname} {p.user.lastname}
+                        </span>
+                      ) : (
+                        <span className="text-gray-400 text-xs font-mono">
+                          {p.userId.slice(0, 8)}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-5 py-3.5 font-medium text-gray-900">
+                      {formatNaira(p.amount)}
+                    </td>
+                    <td className="px-5 py-3.5">
+                      <span className="capitalize text-gray-600">
+                        {p.provider}
+                      </span>
+                    </td>
+                    <td className="px-5 py-3.5">
+                      <span
+                        className={`text-xs font-medium px-2 py-0.5 rounded-full capitalize ${
+                          STATUS_COLORS[p.status]
+                        }`}
+                      >
+                        {p.status}
+                      </span>
+                    </td>
+                    <td className="px-5 py-3.5 font-mono text-xs text-gray-400">
+                      {p.booking?.id.slice(0, 8) ?? p.bookingId.slice(0, 8)}
+                    </td>
+                    <td className="px-5 py-3.5 text-xs text-gray-500 whitespace-nowrap">
+                      {formatDate(p.createdAt)}
+                    </td>
+                    <td className="px-5 py-3.5">
+                      {p.status === "success" ? (
+                        <button
+                          type="button"
+                          onClick={() => setRefundTarget(p.id)}
+                          className="text-xs px-2.5 py-1 rounded-md border border-red-200 text-red-600 hover:bg-red-50 transition-colors"
+                        >
+                          Refund
+                        </button>
+                      ) : (
+                        <span className="text-xs text-gray-300">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Pagination */}
+          {meta && meta.totalPages > 1 && (
+            <div className="px-5 py-3 border-t border-gray-100 flex items-center justify-between text-sm">
+              <p className="text-gray-400">
+                Page {meta.page} of {meta.totalPages}
+              </p>
+              <div className="flex gap-2">
+                <button
+                  disabled={page <= 1}
+                  onClick={() => setPage((p) => p - 1)}
+                  className="p-1.5 rounded-md border border-gray-200 disabled:opacity-30 hover:bg-gray-50"
+                >
+                  <ChevronLeft className="w-4 h-4" />
+                </button>
+                <button
+                  disabled={page >= meta.totalPages}
+                  onClick={() => setPage((p) => p + 1)}
+                  className="p-1.5 rounded-md border border-gray-200 disabled:opacity-30 hover:bg-gray-50"
+                >
+                  <ChevronRight className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </DashboardLayout>
+  );
+}

--- a/frontend/components/dashboard/DashboardSidebar.tsx
+++ b/frontend/components/dashboard/DashboardSidebar.tsx
@@ -18,6 +18,7 @@ import {
   LogIn,
   Bell,
   BarChart3,
+  CreditCard,
 } from "lucide-react";
 import { useState } from "react";
 import { useAuthState, useAuthActions } from "@/lib/store/authStore";
@@ -38,6 +39,7 @@ const adminItems = [
   { label: "Analytics", href: "/admin/analytics", icon: BarChart3 },
   { label: "Workspaces", href: "/admin/workspaces", icon: Building2 },
   { label: "All Bookings", href: "/admin/bookings", icon: BookOpen },
+  { label: "Payments", href: "/admin/payments", icon: CreditCard },
   { label: "Members", href: "/admin/members", icon: Users },
   { label: "Invoices", href: "/admin/invoices", icon: FileText },
   { label: "Newsletter", href: "/dashboard?tab=newsletter", icon: Mail },

--- a/frontend/lib/react-query/hooks/admin/payments/useGetAdminPayments.ts
+++ b/frontend/lib/react-query/hooks/admin/payments/useGetAdminPayments.ts
@@ -1,0 +1,42 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "@/lib/apiClient";
+import { queryKeys } from "@/lib/react-query/keys/queryKeys";
+import { Payment, PaymentStatus, PaymentProvider } from "@/lib/types/payment";
+
+interface AdminPaymentsParams {
+  page?: number;
+  limit?: number;
+  status?: PaymentStatus | "";
+  provider?: PaymentProvider | "";
+  from?: string;
+  to?: string;
+}
+
+interface AdminPaymentsResponse {
+  success: boolean;
+  data: Payment[];
+  meta: {
+    total: number;
+    page: number;
+    limit: number;
+    totalPages: number;
+  };
+}
+
+export const useGetAdminPayments = (params: AdminPaymentsParams = {}) => {
+  const { page = 1, limit = 20, status, provider, from, to } = params;
+  return useQuery({
+    queryKey: queryKeys.admin.payments.list({ page, limit, status, provider, from, to }),
+    queryFn: () => {
+      const query = new URLSearchParams({
+        page: String(page),
+        limit: String(limit),
+      });
+      if (status) query.set("status", status);
+      if (provider) query.set("provider", provider);
+      if (from) query.set("from", from);
+      if (to) query.set("to", to);
+      return apiClient.get<AdminPaymentsResponse>(`/payments?${query.toString()}`);
+    },
+  });
+};

--- a/frontend/lib/react-query/hooks/admin/payments/useRefundPayment.ts
+++ b/frontend/lib/react-query/hooks/admin/payments/useRefundPayment.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/lib/apiClient";
+import { queryKeys } from "@/lib/react-query/keys/queryKeys";
+
+export const useRefundPayment = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      apiClient.post<{ message: string; data: unknown }, undefined>(
+        `/payments/${id}/refund`,
+        undefined
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.admin.payments.all });
+    },
+  });
+};

--- a/frontend/lib/react-query/keys/queryKeys.ts
+++ b/frontend/lib/react-query/keys/queryKeys.ts
@@ -60,5 +60,9 @@ export const queryKeys = {
       all: ["admin", "invoices"] as const,
       list: (params?: unknown) => ["admin", "invoices", "list", params] as const,
     },
+    payments: {
+      all: ["admin", "payments"] as const,
+      list: (params?: unknown) => ["admin", "payments", "list", params] as const,
+    },
   },
 } as const;

--- a/frontend/lib/types/payment.ts
+++ b/frontend/lib/types/payment.ts
@@ -1,5 +1,5 @@
-export type PaymentStatus = "PENDING" | "SUCCESS" | "FAILED" | "REFUNDED";
-export type PaymentProvider = "PAYSTACK" | "STELLAR";
+export type PaymentStatus = "pending" | "success" | "failed" | "refunded";
+export type PaymentProvider = "paystack" | "soroban";
 
 export interface Payment {
   id: string;
@@ -14,6 +14,15 @@ export interface Payment {
   metadata?: Record<string, unknown>;
   createdAt: string;
   updatedAt: string;
+  user?: {
+    id: string;
+    firstname: string;
+    lastname: string;
+    email: string;
+  };
+  booking?: {
+    id: string;
+  };
 }
 
 export interface InitializePaymentResponse {


### PR DESCRIPTION
## Admin Payment Ledger

Adds a payment management page for admins at `/admin/payments`.

### Changes
- `frontend/app/admin/payments/page.tsx`: new admin payments page
- `frontend/lib/react-query/hooks/admin/payments/useGetAdminPayments.ts`: query hook for fetching payments with filters
- `frontend/lib/react-query/hooks/admin/payments/useRefundPayment.ts`: mutation hook for initiating refunds
- `frontend/lib/react-query/keys/queryKeys.ts`: added `admin.payments` query keys
- `frontend/lib/types/payment.ts`: aligned enum casing with backend, added `user` and `booking` relation fields
- `frontend/components/dashboard/DashboardSidebar.tsx`: added Payments link to admin nav
- `backend/src/payments/providers/find-payments.provider.ts`: added class-validator decorators to `PaymentQuery` DTO, added `leftJoinAndSelect` for user and booking relations, added `status`, `provider`, `from`, `to` filters
- `backend/src/payments/payments.controller.ts`: added `@ApiQuery` decorators for filter params
- `backend/src/dashboard/providers/admin-analytics.provider.ts`: fixed raw SQL using `'SUCCESS'` instead of `'success'`

### Features
- Stat cards: total revenue, this month revenue, pending count, failed count
- Table: reference, member, amount (₦), provider, status badge, booking ref, date
- Filters: status tabs, provider dropdown, date range
- Refund action with confirmation modal (success payments only)
- Pagination, loading skeleton, empty state
- Role guard — non-admin users are redirected to `/dashboard`

Closes #1099 
