### PR TITLE
feat: add membership plans and user subscription management

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { NotificationsModule } from './notifications/notifications.module';
 import { WorkspaceTrackingModule } from './workspace-tracking/workspace-tracking.module';
 import { HubSettingsModule } from './hub-settings/hub-settings.module';
 import { VisitorsModule } from './visitors/visitors.module';
+import { MembershipPlansModule } from './membership-plans/membership-plans.module';
 
 @Module({
   imports: [
@@ -103,6 +104,7 @@ import { VisitorsModule } from './visitors/visitors.module';
     WorkspaceTrackingModule,
     HubSettingsModule,
     VisitorsModule,
+    MembershipPlansModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/membership-plans/dto/create-membership-plan.dto.ts
+++ b/backend/src/membership-plans/dto/create-membership-plan.dto.ts
@@ -1,0 +1,62 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  Min,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { BillingCycle } from '../enums/billing-cycle.enum';
+import { WorkspaceType } from '../../workspaces/enums/workspace-type.enum';
+
+export class CreateMembershipPlanDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({ description: 'Price in kobo' })
+  @IsInt()
+  @Min(0)
+  price: number;
+
+  @ApiProperty({ enum: BillingCycle })
+  @IsEnum(BillingCycle)
+  billingCycle: BillingCycle;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  maxBookingsPerMonth?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  meetingRoomHoursPerMonth?: number;
+
+  @ApiProperty({ enum: WorkspaceType, isArray: true })
+  @IsArray()
+  @IsEnum(WorkspaceType, { each: true })
+  allowedWorkspaceTypes: WorkspaceType[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsObject()
+  features?: Record<string, unknown>;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean;
+}

--- a/backend/src/membership-plans/dto/update-membership-plan.dto.ts
+++ b/backend/src/membership-plans/dto/update-membership-plan.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateMembershipPlanDto } from './create-membership-plan.dto';
+
+export class UpdateMembershipPlanDto extends PartialType(CreateMembershipPlanDto) {}

--- a/backend/src/membership-plans/entities/membership-plan.entity.ts
+++ b/backend/src/membership-plans/entities/membership-plan.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { BillingCycle } from '../enums/billing-cycle.enum';
+import { WorkspaceType } from '../../workspaces/enums/workspace-type.enum';
+
+@Entity('membership_plans')
+export class MembershipPlan {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  description?: string;
+
+  @Column({ type: 'bigint' })
+  price: number;
+
+  @Column({ type: 'enum', enum: BillingCycle })
+  billingCycle: BillingCycle;
+
+  @Column({ type: 'int', nullable: true })
+  maxBookingsPerMonth?: number;
+
+  @Column({ type: 'int', nullable: true })
+  meetingRoomHoursPerMonth?: number;
+
+  @Column({ type: 'jsonb', default: [] })
+  allowedWorkspaceTypes: WorkspaceType[];
+
+  @Column({ type: 'jsonb', default: {} })
+  features: Record<string, unknown>;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/membership-plans/entities/user-membership.entity.ts
+++ b/backend/src/membership-plans/entities/user-membership.entity.ts
@@ -1,0 +1,61 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { MembershipPlan } from './membership-plan.entity';
+import { Payment } from '../../payments/entities/payment.entity';
+import { SubscriptionStatus } from '../enums/subscription-status.enum';
+
+@Entity('user_memberships')
+@Index(['userId'])
+@Index(['planId'])
+export class UserMembership {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column('uuid')
+  planId: string;
+
+  @ManyToOne(() => MembershipPlan, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'planId' })
+  plan: MembershipPlan;
+
+  @Column({ type: 'timestamptz' })
+  startDate: Date;
+
+  @Column({ type: 'timestamptz' })
+  endDate: Date;
+
+  @Column({ type: 'enum', enum: SubscriptionStatus })
+  status: SubscriptionStatus;
+
+  @Column({ default: false })
+  autoRenew: boolean;
+
+  @Column({ type: 'uuid', nullable: true })
+  paymentId?: string;
+
+  @ManyToOne(() => Payment, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'paymentId' })
+  payment?: Payment;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/membership-plans/enums/billing-cycle.enum.ts
+++ b/backend/src/membership-plans/enums/billing-cycle.enum.ts
@@ -1,0 +1,5 @@
+export enum BillingCycle {
+  MONTHLY = 'monthly',
+  QUARTERLY = 'quarterly',
+  YEARLY = 'yearly',
+}

--- a/backend/src/membership-plans/enums/subscription-status.enum.ts
+++ b/backend/src/membership-plans/enums/subscription-status.enum.ts
@@ -1,0 +1,6 @@
+export enum SubscriptionStatus {
+  ACTIVE = 'active',
+  EXPIRED = 'expired',
+  CANCELLED = 'cancelled',
+  PENDING_PAYMENT = 'pending_payment',
+}

--- a/backend/src/membership-plans/membership-plans.controller.ts
+++ b/backend/src/membership-plans/membership-plans.controller.ts
@@ -1,0 +1,101 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { MembershipPlansService } from './membership-plans.service';
+import { CreateMembershipPlanDto } from './dto/create-membership-plan.dto';
+import { UpdateMembershipPlanDto } from './dto/update-membership-plan.dto';
+import { RolesGuard } from '../auth/guard/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorators';
+import { Public } from '../auth/decorators/public.decorator';
+import { GetCurrentUserId } from '../auth/decorators/getCurrentUser.decorator';
+import { UserRole } from '../users/enums/userRoles.enum';
+
+@ApiTags('membership-plans')
+@ApiBearerAuth()
+@Controller('membership-plans')
+export class MembershipPlansController {
+  constructor(private readonly service: MembershipPlansService) {}
+
+  @Post()
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Create a membership plan (Admin only)' })
+  async create(@Body() dto: CreateMembershipPlanDto) {
+    const data = await this.service.create(dto);
+    return { message: 'Membership plan created successfully', data };
+  }
+
+  @Get()
+  @Public()
+  @ApiOperation({ summary: 'List active membership plans' })
+  async findAll() {
+    const data = await this.service.findAll();
+    return { message: 'Membership plans retrieved successfully', data };
+  }
+
+  @Get('subscriptions/me')
+  @ApiOperation({ summary: 'Get my active membership subscription' })
+  async getMySubscription(@GetCurrentUserId() userId: string) {
+    const data = await this.service.getMySubscription(userId);
+    return { message: 'Subscription retrieved successfully', data };
+  }
+
+  @Get(':id')
+  @Public()
+  @ApiOperation({ summary: 'Get a membership plan by ID' })
+  async findOne(@Param('id', ParseUUIDPipe) id: string) {
+    const data = await this.service.findById(id);
+    return { message: 'Membership plan retrieved successfully', data };
+  }
+
+  @Patch(':id')
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Update a membership plan (Admin only)' })
+  async update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateMembershipPlanDto,
+  ) {
+    const data = await this.service.update(id, dto);
+    return { message: 'Membership plan updated successfully', data };
+  }
+
+  @Delete(':id')
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Deactivate a membership plan (Admin only)' })
+  async remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    await this.service.remove(id);
+  }
+
+  @Post(':id/subscribe')
+  @ApiOperation({ summary: 'Subscribe to a membership plan' })
+  async subscribe(
+    @Param('id', ParseUUIDPipe) id: string,
+    @GetCurrentUserId() userId: string,
+  ) {
+    const data = await this.service.subscribe(id, userId);
+    return { message: 'Subscribed successfully', data };
+  }
+
+  @Delete('subscriptions/me')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Cancel my active membership subscription' })
+  async cancelSubscription(
+    @GetCurrentUserId() userId: string,
+  ): Promise<void> {
+    await this.service.cancelSubscription(userId);
+  }
+}

--- a/backend/src/membership-plans/membership-plans.module.ts
+++ b/backend/src/membership-plans/membership-plans.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MembershipPlan } from './entities/membership-plan.entity';
+import { UserMembership } from './entities/user-membership.entity';
+import { MembershipPlansService } from './membership-plans.service';
+import { MembershipPlansController } from './membership-plans.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MembershipPlan, UserMembership])],
+  controllers: [MembershipPlansController],
+  providers: [MembershipPlansService],
+  exports: [MembershipPlansService],
+})
+export class MembershipPlansModule {}

--- a/backend/src/membership-plans/membership-plans.service.ts
+++ b/backend/src/membership-plans/membership-plans.service.ts
@@ -1,0 +1,121 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MembershipPlan } from './entities/membership-plan.entity';
+import { UserMembership } from './entities/user-membership.entity';
+import { CreateMembershipPlanDto } from './dto/create-membership-plan.dto';
+import { UpdateMembershipPlanDto } from './dto/update-membership-plan.dto';
+import { BillingCycle } from './enums/billing-cycle.enum';
+import { SubscriptionStatus } from './enums/subscription-status.enum';
+
+@Injectable()
+export class MembershipPlansService {
+  constructor(
+    @InjectRepository(MembershipPlan)
+    private readonly plansRepository: Repository<MembershipPlan>,
+    @InjectRepository(UserMembership)
+    private readonly membershipsRepository: Repository<UserMembership>,
+  ) {}
+
+  async create(dto: CreateMembershipPlanDto): Promise<MembershipPlan> {
+    const plan = this.plansRepository.create({
+      ...dto,
+      features: dto.features ?? {},
+    });
+    return this.plansRepository.save(plan);
+  }
+
+  async findAll(): Promise<MembershipPlan[]> {
+    return this.plansRepository.find({
+      where: { isActive: true },
+      order: { price: 'ASC' },
+    });
+  }
+
+  async findById(id: string): Promise<MembershipPlan> {
+    const plan = await this.plansRepository.findOne({ where: { id } });
+    if (!plan) {
+      throw new NotFoundException(`Membership plan "${id}" not found`);
+    }
+    return plan;
+  }
+
+  async update(
+    id: string,
+    dto: UpdateMembershipPlanDto,
+  ): Promise<MembershipPlan> {
+    const plan = await this.findById(id);
+    Object.assign(plan, dto);
+    return this.plansRepository.save(plan);
+  }
+
+  async remove(id: string): Promise<void> {
+    const plan = await this.findById(id);
+    plan.isActive = false;
+    await this.plansRepository.save(plan);
+  }
+
+  async subscribe(planId: string, userId: string): Promise<UserMembership> {
+    const plan = await this.findById(planId);
+    if (!plan.isActive) {
+      throw new BadRequestException('Plan is not active');
+    }
+    const existing = await this.membershipsRepository.findOne({
+      where: { userId, status: SubscriptionStatus.ACTIVE },
+    });
+    if (existing) {
+      existing.status = SubscriptionStatus.CANCELLED;
+      existing.autoRenew = false;
+      await this.membershipsRepository.save(existing);
+    }
+    const now = new Date();
+    const membership = this.membershipsRepository.create({
+      userId,
+      planId,
+      startDate: now,
+      endDate: this.computeEndDate(now, plan.billingCycle),
+      status: SubscriptionStatus.ACTIVE,
+      autoRenew: true,
+    });
+    return this.membershipsRepository.save(membership);
+  }
+
+  async getMySubscription(userId: string): Promise<UserMembership | null> {
+    return this.membershipsRepository.findOne({
+      where: { userId, status: SubscriptionStatus.ACTIVE },
+      relations: ['plan'],
+    });
+  }
+
+  async cancelSubscription(userId: string): Promise<void> {
+    const membership = await this.membershipsRepository.findOne({
+      where: { userId, status: SubscriptionStatus.ACTIVE },
+    });
+    if (!membership) {
+      throw new NotFoundException('No active membership found');
+    }
+    membership.status = SubscriptionStatus.CANCELLED;
+    membership.autoRenew = false;
+    await this.membershipsRepository.save(membership);
+  }
+
+  private computeEndDate(start: Date, cycle: BillingCycle): Date {
+    const end = new Date(start);
+    switch (cycle) {
+      case BillingCycle.MONTHLY:
+        end.setMonth(end.getMonth() + 1);
+        break;
+      case BillingCycle.QUARTERLY:
+        end.setMonth(end.getMonth() + 3);
+        break;
+      case BillingCycle.YEARLY:
+        end.setFullYear(end.getFullYear() + 1);
+        break;
+    }
+    return end;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a complete `MembershipPlansModule` to the ManageHub backend implementing plan administration and user subscription flows.

### New files
- `enums/billing-cycle.enum.ts` — `monthly | quarterly | yearly`
- `enums/subscription-status.enum.ts` — `active | expired | cancelled | pending_payment`
- `entities/membership-plan.entity.ts` — `membership_plans` table (name, price in kobo, billingCycle, workspace type list, JSONB features, isActive)
- `entities/user-membership.entity.ts` — `user_memberships` table (FK to users, membership_plans, and payments)
- `dto/create-membership-plan.dto.ts` / `dto/update-membership-plan.dto.ts` — validated DTOs
- `membership-plans.service.ts` — CRUD + subscribe / cancel logic with end-date computation per cycle
- `membership-plans.controller.ts` — REST endpoints with role guards and `@Public()` for read-only routes
- `membership-plans.module.ts` — TypeORM feature registration; exported for other modules

### Endpoints
| Method | Path | Access |
|--------|------|--------|
| `POST` | `/membership-plans` | Admin |
| `GET` | `/membership-plans` | Public |
| `GET` | `/membership-plans/:id` | Public |
| `PATCH` | `/membership-plans/:id` | Admin |
| `DELETE` | `/membership-plans/:id` | Admin |
| `POST` | `/membership-plans/:id/subscribe` | Authenticated |
| `GET` | `/membership-plans/subscriptions/me` | Authenticated |
| `DELETE` | `/membership-plans/subscriptions/me` | Authenticated |

`MembershipPlansModule` registered in `AppModule`; TypeORM `synchronize: true` auto-migrates the two new tables.

Closes #1081