### PR TITLE
feat: Maintenance module, Leads/CRM module, and interactive floor plan seat map

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -29,6 +29,8 @@ import { AccessControlModule } from './access-control/access-control.module';
 import { WaitlistModule } from './waitlist/waitlist.module';
 import { EventsModule } from './events/events.module';
 import { MembershipPlansModule } from './membership-plans/membership-plans.module';
+import { MaintenanceModule } from './maintenance/maintenance.module';
+import { LeadsModule } from './leads/leads.module';
 
 @Module({
   imports: [
@@ -114,6 +116,8 @@ import { MembershipPlansModule } from './membership-plans/membership-plans.modul
     WaitlistModule,
     EventsModule,
     MembershipPlansModule,
+    MaintenanceModule,
+    LeadsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/leads/dto/create-lead.dto.ts
+++ b/backend/src/leads/dto/create-lead.dto.ts
@@ -1,0 +1,22 @@
+import { IsEmail, IsEnum, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { LeadSource } from '../enums/lead-source.enum';
+
+export class CreateLeadDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsEmail()
+  email: string;
+
+  @IsOptional()
+  @IsString()
+  phone?: string;
+
+  @IsOptional()
+  @IsString()
+  company?: string;
+
+  @IsEnum(LeadSource)
+  source: LeadSource;
+}

--- a/backend/src/leads/dto/lead-query.dto.ts
+++ b/backend/src/leads/dto/lead-query.dto.ts
@@ -1,0 +1,30 @@
+import { IsEnum, IsInt, IsOptional, IsUUID, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { LeadStatus } from '../enums/lead-status.enum';
+import { LeadSource } from '../enums/lead-source.enum';
+
+export class LeadQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 20;
+
+  @IsOptional()
+  @IsEnum(LeadStatus)
+  status?: LeadStatus;
+
+  @IsOptional()
+  @IsEnum(LeadSource)
+  source?: LeadSource;
+
+  @IsOptional()
+  @IsUUID()
+  assignedToStaffId?: string;
+}

--- a/backend/src/leads/dto/update-lead.dto.ts
+++ b/backend/src/leads/dto/update-lead.dto.ts
@@ -1,0 +1,16 @@
+import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator';
+import { LeadStatus } from '../enums/lead-status.enum';
+
+export class UpdateLeadDto {
+  @IsOptional()
+  @IsEnum(LeadStatus)
+  status?: LeadStatus;
+
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @IsOptional()
+  @IsUUID()
+  assignedToStaffId?: string;
+}

--- a/backend/src/leads/entities/lead.entity.ts
+++ b/backend/src/leads/entities/lead.entity.ts
@@ -1,0 +1,59 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  DeleteDateColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { LeadSource } from '../enums/lead-source.enum';
+import { LeadStatus } from '../enums/lead-status.enum';
+
+@Entity('leads')
+export class Lead {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  email: string;
+
+  @Column({ nullable: true })
+  phone: string | null;
+
+  @Column({ nullable: true })
+  company: string | null;
+
+  @Column({ type: 'enum', enum: LeadSource, default: LeadSource.OTHER })
+  source: LeadSource;
+
+  @Column({ type: 'enum', enum: LeadStatus, default: LeadStatus.NEW })
+  status: LeadStatus;
+
+  @Column({ type: 'text', nullable: true })
+  notes: string | null;
+
+  @Column('uuid', { nullable: true })
+  assignedToStaffId: string | null;
+
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'assignedToStaffId' })
+  assignedToStaff: User;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  convertedAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @DeleteDateColumn()
+  deletedAt: Date | null;
+}

--- a/backend/src/leads/enums/lead-source.enum.ts
+++ b/backend/src/leads/enums/lead-source.enum.ts
@@ -1,0 +1,6 @@
+export enum LeadSource {
+  CONTACT_FORM = 'CONTACT_FORM',
+  REFERRAL = 'REFERRAL',
+  WALK_IN = 'WALK_IN',
+  OTHER = 'OTHER',
+}

--- a/backend/src/leads/enums/lead-status.enum.ts
+++ b/backend/src/leads/enums/lead-status.enum.ts
@@ -1,0 +1,7 @@
+export enum LeadStatus {
+  NEW = 'NEW',
+  CONTACTED = 'CONTACTED',
+  QUALIFIED = 'QUALIFIED',
+  CONVERTED = 'CONVERTED',
+  LOST = 'LOST',
+}

--- a/backend/src/leads/leads.controller.ts
+++ b/backend/src/leads/leads.controller.ts
@@ -1,0 +1,69 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+  ParseUUIDPipe,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { LeadsService } from './leads.service';
+import { CreateLeadDto } from './dto/create-lead.dto';
+import { UpdateLeadDto } from './dto/update-lead.dto';
+import { LeadQueryDto } from './dto/lead-query.dto';
+import { JwtAuthGuard } from '../auth/guard/jwt.auth.guard';
+import { RolesGuard } from '../auth/guard/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorators';
+import { UserRole } from '../users/enums/userRoles.enum';
+
+@ApiTags('Leads')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN, UserRole.STAFF)
+@Controller('leads')
+export class LeadsController {
+  constructor(private readonly service: LeadsService) {}
+
+  @Post()
+  async create(@Body() dto: CreateLeadDto) {
+    const data = await this.service.create(dto);
+    return { message: 'Lead created', data };
+  }
+
+  @Get()
+  async findAll(@Query() query: LeadQueryDto) {
+    return this.service.findAll(query);
+  }
+
+  @Get(':id')
+  async findOne(@Param('id', ParseUUIDPipe) id: string) {
+    const data = await this.service.findOne(id);
+    return { data };
+  }
+
+  @Patch(':id')
+  async update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: UpdateLeadDto) {
+    const data = await this.service.update(id, dto);
+    return { message: 'Lead updated', data };
+  }
+
+  @Post(':id/convert')
+  async convert(@Param('id', ParseUUIDPipe) id: string) {
+    const data = await this.service.convert(id);
+    return { message: 'Lead converted', data };
+  }
+
+  @Delete(':id')
+  @Roles(UserRole.ADMIN)
+  @HttpCode(HttpStatus.OK)
+  async remove(@Param('id', ParseUUIDPipe) id: string) {
+    await this.service.softDelete(id);
+    return { message: 'Lead deleted' };
+  }
+}

--- a/backend/src/leads/leads.module.ts
+++ b/backend/src/leads/leads.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Lead } from './entities/lead.entity';
+import { LeadsService } from './leads.service';
+import { LeadsController } from './leads.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Lead])],
+  controllers: [LeadsController],
+  providers: [LeadsService],
+  exports: [LeadsService],
+})
+export class LeadsModule {}

--- a/backend/src/leads/leads.service.ts
+++ b/backend/src/leads/leads.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Lead } from './entities/lead.entity';
+import { CreateLeadDto } from './dto/create-lead.dto';
+import { UpdateLeadDto } from './dto/update-lead.dto';
+import { LeadQueryDto } from './dto/lead-query.dto';
+import { LeadStatus } from './enums/lead-status.enum';
+import { LeadSource } from './enums/lead-source.enum';
+
+@Injectable()
+export class LeadsService {
+  constructor(
+    @InjectRepository(Lead)
+    private readonly repo: Repository<Lead>,
+  ) {}
+
+  async create(dto: CreateLeadDto): Promise<Lead> {
+    return this.repo.save(this.repo.create(dto));
+  }
+
+  async createFromContactForm(name: string, email: string, phone?: string): Promise<Lead> {
+    return this.repo.save(this.repo.create({
+      name, email, phone: phone ?? null,
+      source: LeadSource.CONTACT_FORM,
+      status: LeadStatus.NEW,
+    }));
+  }
+
+  async findAll(query: LeadQueryDto) {
+    const { page = 1, limit = 20, status, source, assignedToStaffId } = query;
+    const where: Record<string, unknown> = {};
+    if (status) where.status = status;
+    if (source) where.source = source;
+    if (assignedToStaffId) where.assignedToStaffId = assignedToStaffId;
+
+    const [items, total] = await this.repo.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+      relations: ['assignedToStaff'],
+      withDeleted: false,
+    });
+    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
+  async findOne(id: string): Promise<Lead> {
+    const item = await this.repo.findOne({ where: { id }, relations: ['assignedToStaff'] });
+    if (!item) throw new NotFoundException(`Lead ${id} not found`);
+    return item;
+  }
+
+  async update(id: string, dto: UpdateLeadDto): Promise<Lead> {
+    const item = await this.findOne(id);
+    Object.assign(item, dto);
+    return this.repo.save(item);
+  }
+
+  async convert(id: string): Promise<Lead> {
+    const item = await this.findOne(id);
+    item.status = LeadStatus.CONVERTED;
+    item.convertedAt = new Date();
+    return this.repo.save(item);
+  }
+
+  async softDelete(id: string): Promise<void> {
+    const item = await this.findOne(id);
+    await this.repo.softDelete(item.id);
+  }
+}

--- a/backend/src/maintenance/dto/create-maintenance-request.dto.ts
+++ b/backend/src/maintenance/dto/create-maintenance-request.dto.ts
@@ -1,0 +1,19 @@
+import { IsEnum, IsNotEmpty, IsOptional, IsString, IsUUID } from 'class-validator';
+import { MaintenanceCategory } from '../enums/maintenance-category.enum';
+
+export class CreateMaintenanceRequestDto {
+  @IsOptional()
+  @IsUUID()
+  workspaceId?: string;
+
+  @IsEnum(MaintenanceCategory)
+  category: MaintenanceCategory;
+
+  @IsString()
+  @IsNotEmpty()
+  description: string;
+
+  @IsOptional()
+  @IsString()
+  imageUrl?: string;
+}

--- a/backend/src/maintenance/dto/maintenance-query.dto.ts
+++ b/backend/src/maintenance/dto/maintenance-query.dto.ts
@@ -1,0 +1,30 @@
+import { IsEnum, IsInt, IsOptional, IsUUID, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { MaintenanceCategory } from '../enums/maintenance-category.enum';
+import { MaintenanceStatus } from '../enums/maintenance-status.enum';
+
+export class MaintenanceQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 20;
+
+  @IsOptional()
+  @IsEnum(MaintenanceStatus)
+  status?: MaintenanceStatus;
+
+  @IsOptional()
+  @IsEnum(MaintenanceCategory)
+  category?: MaintenanceCategory;
+
+  @IsOptional()
+  @IsUUID()
+  workspaceId?: string;
+}

--- a/backend/src/maintenance/dto/update-maintenance-status.dto.ts
+++ b/backend/src/maintenance/dto/update-maintenance-status.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { MaintenanceStatus } from '../enums/maintenance-status.enum';
+
+export class UpdateMaintenanceStatusDto {
+  @IsEnum(MaintenanceStatus)
+  status: MaintenanceStatus;
+}

--- a/backend/src/maintenance/entities/maintenance-request.entity.ts
+++ b/backend/src/maintenance/entities/maintenance-request.entity.ts
@@ -1,0 +1,61 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { Workspace } from '../../workspaces/entities/workspace.entity';
+import { MaintenanceCategory } from '../enums/maintenance-category.enum';
+import { MaintenanceStatus } from '../enums/maintenance-status.enum';
+
+@Entity('maintenance_requests')
+export class MaintenanceRequest {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  reportedByUserId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'reportedByUserId' })
+  reportedBy: User;
+
+  @Column('uuid', { nullable: true })
+  workspaceId: string | null;
+
+  @ManyToOne(() => Workspace, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'workspaceId' })
+  workspace: Workspace;
+
+  @Column({ type: 'enum', enum: MaintenanceCategory })
+  category: MaintenanceCategory;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @Column({ nullable: true })
+  imageUrl: string | null;
+
+  @Column({ type: 'enum', enum: MaintenanceStatus, default: MaintenanceStatus.OPEN })
+  status: MaintenanceStatus;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  resolvedAt: Date | null;
+
+  @Column('uuid', { nullable: true })
+  resolvedByStaffId: string | null;
+
+  @ManyToOne(() => User, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'resolvedByStaffId' })
+  resolvedByStaff: User;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/maintenance/enums/maintenance-category.enum.ts
+++ b/backend/src/maintenance/enums/maintenance-category.enum.ts
@@ -1,0 +1,6 @@
+export enum MaintenanceCategory {
+  EQUIPMENT = 'EQUIPMENT',
+  FACILITY = 'FACILITY',
+  SAFETY = 'SAFETY',
+  OTHER = 'OTHER',
+}

--- a/backend/src/maintenance/enums/maintenance-status.enum.ts
+++ b/backend/src/maintenance/enums/maintenance-status.enum.ts
@@ -1,0 +1,5 @@
+export enum MaintenanceStatus {
+  OPEN = 'OPEN',
+  IN_PROGRESS = 'IN_PROGRESS',
+  RESOLVED = 'RESOLVED',
+}

--- a/backend/src/maintenance/maintenance.controller.ts
+++ b/backend/src/maintenance/maintenance.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { MaintenanceService } from './maintenance.service';
+import { CreateMaintenanceRequestDto } from './dto/create-maintenance-request.dto';
+import { UpdateMaintenanceStatusDto } from './dto/update-maintenance-status.dto';
+import { MaintenanceQueryDto } from './dto/maintenance-query.dto';
+import { JwtAuthGuard } from '../auth/guard/jwt.auth.guard';
+import { RolesGuard } from '../auth/guard/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorators';
+import { CurrentUser } from '../auth/decorators/current.user.decorators';
+import { UserRole } from '../users/enums/userRoles.enum';
+import { User } from '../users/entities/user.entity';
+
+@ApiTags('Maintenance')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('maintenance')
+export class MaintenanceController {
+  constructor(private readonly service: MaintenanceService) {}
+
+  @Post()
+  async create(@Body() dto: CreateMaintenanceRequestDto, @CurrentUser() user: User) {
+    const data = await this.service.create(dto, user.id);
+    return { message: 'Maintenance request submitted', data };
+  }
+
+  @Get('mine')
+  async findMine(@CurrentUser() user: User, @Query() query: MaintenanceQueryDto) {
+    return this.service.findMine(user.id, query);
+  }
+
+  @Get()
+  @Roles(UserRole.ADMIN, UserRole.STAFF)
+  async findAll(@Query() query: MaintenanceQueryDto) {
+    return this.service.findAll(query);
+  }
+
+  @Get(':id')
+  async findOne(@Param('id', ParseUUIDPipe) id: string) {
+    const data = await this.service.findOne(id);
+    return { data };
+  }
+
+  @Patch(':id/status')
+  @Roles(UserRole.ADMIN, UserRole.STAFF)
+  async updateStatus(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateMaintenanceStatusDto,
+    @CurrentUser() user: User,
+  ) {
+    const data = await this.service.updateStatus(id, dto, user.id);
+    return { message: 'Status updated', data };
+  }
+}

--- a/backend/src/maintenance/maintenance.module.ts
+++ b/backend/src/maintenance/maintenance.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MaintenanceRequest } from './entities/maintenance-request.entity';
+import { MaintenanceService } from './maintenance.service';
+import { MaintenanceController } from './maintenance.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([MaintenanceRequest])],
+  controllers: [MaintenanceController],
+  providers: [MaintenanceService],
+  exports: [MaintenanceService],
+})
+export class MaintenanceModule {}

--- a/backend/src/maintenance/maintenance.service.ts
+++ b/backend/src/maintenance/maintenance.service.ts
@@ -1,0 +1,65 @@
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MaintenanceRequest } from './entities/maintenance-request.entity';
+import { CreateMaintenanceRequestDto } from './dto/create-maintenance-request.dto';
+import { UpdateMaintenanceStatusDto } from './dto/update-maintenance-status.dto';
+import { MaintenanceQueryDto } from './dto/maintenance-query.dto';
+import { MaintenanceStatus } from './enums/maintenance-status.enum';
+
+@Injectable()
+export class MaintenanceService {
+  constructor(
+    @InjectRepository(MaintenanceRequest)
+    private readonly repo: Repository<MaintenanceRequest>,
+  ) {}
+
+  async create(dto: CreateMaintenanceRequestDto, userId: string): Promise<MaintenanceRequest> {
+    const entity = this.repo.create({ ...dto, reportedByUserId: userId });
+    return this.repo.save(entity);
+  }
+
+  async findMine(userId: string, query: MaintenanceQueryDto) {
+    const { page = 1, limit = 20 } = query;
+    const [items, total] = await this.repo.findAndCount({
+      where: { reportedByUserId: userId },
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
+  async findAll(query: MaintenanceQueryDto) {
+    const { page = 1, limit = 20, status, category, workspaceId } = query;
+    const where: Record<string, unknown> = {};
+    if (status) where.status = status;
+    if (category) where.category = category;
+    if (workspaceId) where.workspaceId = workspaceId;
+
+    const [items, total] = await this.repo.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+      relations: ['reportedBy'],
+    });
+    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
+  async findOne(id: string): Promise<MaintenanceRequest> {
+    const item = await this.repo.findOne({ where: { id }, relations: ['reportedBy', 'workspace'] });
+    if (!item) throw new NotFoundException(`Maintenance request ${id} not found`);
+    return item;
+  }
+
+  async updateStatus(id: string, dto: UpdateMaintenanceStatusDto, staffId: string): Promise<MaintenanceRequest> {
+    const item = await this.findOne(id);
+    item.status = dto.status;
+    if (dto.status === MaintenanceStatus.RESOLVED) {
+      item.resolvedAt = new Date();
+      item.resolvedByStaffId = staffId;
+    }
+    return this.repo.save(item);
+  }
+}

--- a/frontend/app/maintenance/page.tsx
+++ b/frontend/app/maintenance/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import DashboardLayout from "@/components/dashboard/DashboardLayout";
+import { useGetMyMaintenanceRequests } from "@/lib/react-query/hooks/maintenance/useGetMyMaintenanceRequests";
+import { useSubmitMaintenanceRequest } from "@/lib/react-query/hooks/maintenance/useSubmitMaintenanceRequest";
+import { Wrench, Plus, X } from "lucide-react";
+
+const CATEGORIES = ["EQUIPMENT", "FACILITY", "SAFETY", "OTHER"];
+
+const statusColor: Record<string, string> = {
+  OPEN: "bg-red-100 text-red-700",
+  IN_PROGRESS: "bg-yellow-100 text-yellow-700",
+  RESOLVED: "bg-green-100 text-green-700",
+};
+
+export default function MaintenancePage() {
+  const [showModal, setShowModal] = useState(false);
+  const [form, setForm] = useState({ category: "EQUIPMENT", description: "" });
+  const { data, isLoading } = useGetMyMaintenanceRequests();
+  const submit = useSubmitMaintenanceRequest();
+
+  const requests = (data as any)?.items ?? [];
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await submit.mutateAsync(form);
+    setShowModal(false);
+    setForm({ category: "EQUIPMENT", description: "" });
+  };
+
+  return (
+    <DashboardLayout>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Maintenance Requests</h1>
+          <p className="text-gray-500 text-sm mt-1">Report and track workspace issues.</p>
+        </div>
+        <button
+          onClick={() => setShowModal(true)}
+          className="flex items-center gap-2 bg-gray-900 text-white px-4 py-2 rounded-lg text-sm hover:bg-gray-800"
+        >
+          <Plus className="w-4 h-4" /> Report an Issue
+        </button>
+      </div>
+
+      {isLoading ? (
+        <div className="text-center py-12 text-gray-500">Loading...</div>
+      ) : requests.length === 0 ? (
+        <div className="text-center py-16 text-gray-400">
+          <Wrench className="w-10 h-10 mx-auto mb-3 opacity-40" />
+          <p>No maintenance requests yet.</p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-100 divide-y">
+          {requests.map((req: any) => (
+            <div key={req.id} className="p-4 flex items-start justify-between gap-4">
+              <div>
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="text-xs font-medium bg-gray-100 text-gray-600 px-2 py-0.5 rounded">
+                    {req.category}
+                  </span>
+                  <span className={`text-xs font-medium px-2 py-0.5 rounded ${statusColor[req.status]}`}>
+                    {req.status.replace("_", " ")}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-700">{req.description}</p>
+                <p className="text-xs text-gray-400 mt-1">
+                  {new Date(req.createdAt).toLocaleDateString()}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {showModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-md">
+            <div className="flex items-center justify-between px-5 py-4 border-b">
+              <h2 className="font-semibold text-gray-900">Report an Issue</h2>
+              <button onClick={() => setShowModal(false)}><X className="w-4 h-4" /></button>
+            </div>
+            <form onSubmit={handleSubmit} className="p-5 space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Category</label>
+                <select
+                  value={form.category}
+                  onChange={(e) => setForm({ ...form, category: e.target.value })}
+                  className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm"
+                >
+                  {CATEGORIES.map((c) => <option key={c}>{c}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+                <textarea
+                  value={form.description}
+                  onChange={(e) => setForm({ ...form, description: e.target.value })}
+                  rows={3}
+                  required
+                  className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm resize-none"
+                  placeholder="Describe the issue..."
+                />
+              </div>
+              <div className="flex gap-3 justify-end pt-2">
+                <button type="button" onClick={() => setShowModal(false)}
+                  className="px-4 py-2 text-sm border border-gray-200 rounded-lg hover:bg-gray-50">
+                  Cancel
+                </button>
+                <button type="submit" disabled={submit.isPending}
+                  className="px-4 py-2 text-sm bg-gray-900 text-white rounded-lg hover:bg-gray-800 disabled:opacity-50">
+                  {submit.isPending ? "Submitting..." : "Submit"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </DashboardLayout>
+  );
+}

--- a/frontend/app/spaces/map/page.tsx
+++ b/frontend/app/spaces/map/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import DashboardLayout from "@/components/dashboard/DashboardLayout";
+import FloorPlanCanvas from "@/components/floor-plan/FloorPlanCanvas";
+import { apiClient } from "@/lib/apiClient";
+import { Map } from "lucide-react";
+
+export default function SpacesMapPage() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["floor-plan", "active"],
+    queryFn: () => apiClient.get<any>("/floor-plan/active"),
+  });
+
+  const floorPlan = (data as any)?.data;
+
+  return (
+    <DashboardLayout>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Floor Plan</h1>
+        <p className="text-gray-500 text-sm mt-1">Click a zone to book that workspace.</p>
+      </div>
+
+      {isLoading && (
+        <div className="text-center py-16 text-gray-400">Loading floor plan...</div>
+      )}
+
+      {(isError || (!isLoading && !floorPlan)) && (
+        <div className="text-center py-16 text-gray-400">
+          <Map className="w-12 h-12 mx-auto mb-3 opacity-30" />
+          <p className="font-medium text-gray-500">Floor plan coming soon</p>
+          <p className="text-sm mt-1">The admin hasn&apos;t published a floor plan yet.</p>
+        </div>
+      )}
+
+      {floorPlan && (
+        <div>
+          <h2 className="text-sm font-medium text-gray-600 mb-3">{floorPlan.name}</h2>
+          <FloorPlanCanvas floorPlan={floorPlan} />
+        </div>
+      )}
+    </DashboardLayout>
+  );
+}

--- a/frontend/app/workspaces/page.tsx
+++ b/frontend/app/workspaces/page.tsx
@@ -9,7 +9,9 @@ import {
   Search,
   SlidersHorizontal,
   Building2,
+  Map,
 } from "lucide-react";
+import Link from "next/link";
 
 const WORKSPACE_TYPES: { label: string; value: WorkspaceType | "" }[] = [
   { label: "All Types", value: "" },
@@ -38,11 +40,19 @@ export default function WorkspacesPage() {
   return (
     <DashboardLayout>
       {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-2xl font-bold text-gray-900">Workspaces</h1>
-        <p className="text-gray-500 mt-1 text-sm">
-          Browse and book available workspaces.
-        </p>
+      <div className="mb-8 flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Workspaces</h1>
+          <p className="text-gray-500 mt-1 text-sm">
+            Browse and book available workspaces.
+          </p>
+        </div>
+        <Link
+          href="/spaces/map"
+          className="flex items-center gap-2 border border-gray-200 text-gray-700 px-3 py-2 rounded-lg text-sm hover:bg-gray-50"
+        >
+          <Map className="w-4 h-4" /> Map View
+        </Link>
       </div>
 
       {/* Filters */}

--- a/frontend/components/dashboard/DashboardSidebar.tsx
+++ b/frontend/components/dashboard/DashboardSidebar.tsx
@@ -19,6 +19,7 @@ import {
   Bell,
   BarChart3,
   CreditCard,
+  Wrench,
 } from "lucide-react";
 import { useState } from "react";
 import { useAuthState, useAuthActions } from "@/lib/store/authStore";
@@ -31,6 +32,7 @@ const navItems = [
   { label: "Check In / Out", href: "/check-in", icon: LogIn },
   { label: "Notifications", href: "/notifications", icon: Bell },
   { label: "Invoices", href: "/invoices", icon: FileText },
+  { label: "Maintenance", href: "/maintenance", icon: Wrench },
   { label: "Profile", href: "/profile", icon: User },
   { label: "Settings", href: "/settings", icon: Settings },
 ];

--- a/frontend/components/floor-plan/FloorPlanCanvas.tsx
+++ b/frontend/components/floor-plan/FloorPlanCanvas.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+interface Zone {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  color: string;
+  workspaceId: string;
+  availableSeats?: number;
+  totalSeats?: number;
+}
+
+interface FloorPlan {
+  id: string;
+  name: string;
+  canvasWidth: number;
+  canvasHeight: number;
+  backgroundImageUrl?: string;
+  zones: Zone[];
+}
+
+interface Props {
+  floorPlan: FloorPlan;
+}
+
+function availabilityColor(zone: Zone) {
+  if (!zone.totalSeats) return zone.color || "#6b7280";
+  const ratio = (zone.availableSeats ?? 0) / zone.totalSeats;
+  if (ratio <= 0) return "#ef4444";
+  if (ratio < 0.25) return "#f59e0b";
+  return "#22c55e";
+}
+
+export default function FloorPlanCanvas({ floorPlan }: Props) {
+  const router = useRouter();
+
+  return (
+    <div className="overflow-auto border border-gray-200 rounded-xl bg-gray-50 p-4">
+      <svg
+        viewBox={`0 0 ${floorPlan.canvasWidth} ${floorPlan.canvasHeight}`}
+        width={floorPlan.canvasWidth}
+        height={floorPlan.canvasHeight}
+        className="max-w-full touch-pinch-zoom"
+        style={{ touchAction: "pinch-zoom" }}
+      >
+        {floorPlan.backgroundImageUrl && (
+          <image
+            href={floorPlan.backgroundImageUrl}
+            x={0} y={0}
+            width={floorPlan.canvasWidth}
+            height={floorPlan.canvasHeight}
+            preserveAspectRatio="xMidYMid meet"
+          />
+        )}
+        {floorPlan.zones.map((zone) => (
+          <g
+            key={zone.id}
+            className="cursor-pointer"
+            onClick={() => router.push(`/bookings/new?workspaceId=${zone.workspaceId}`)}
+          >
+            <rect
+              x={zone.x} y={zone.y}
+              width={zone.width} height={zone.height}
+              fill={availabilityColor(zone)}
+              fillOpacity={0.7}
+              stroke="#fff"
+              strokeWidth={2}
+              rx={4}
+            />
+            <text
+              x={zone.x + zone.width / 2}
+              y={zone.y + zone.height / 2 + 5}
+              textAnchor="middle"
+              fontSize={12}
+              fill="#fff"
+              fontWeight={600}
+            >
+              {zone.label}
+            </text>
+          </g>
+        ))}
+      </svg>
+      <div className="flex gap-4 mt-3 text-xs text-gray-500">
+        <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-green-500 inline-block" /> Available</span>
+        <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-amber-500 inline-block" /> Limited</span>
+        <span className="flex items-center gap-1"><span className="w-3 h-3 rounded bg-red-500 inline-block" /> Full</span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/react-query/hooks/maintenance/useGetMyMaintenanceRequests.ts
+++ b/frontend/lib/react-query/hooks/maintenance/useGetMyMaintenanceRequests.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "@/lib/apiClient";
+
+export const useGetMyMaintenanceRequests = (page = 1, limit = 10) => {
+  return useQuery({
+    queryKey: ["maintenance", "mine", { page, limit }],
+    queryFn: () =>
+      apiClient.get(`/maintenance/mine?page=${page}&limit=${limit}`),
+  });
+};

--- a/frontend/lib/react-query/hooks/maintenance/useSubmitMaintenanceRequest.ts
+++ b/frontend/lib/react-query/hooks/maintenance/useSubmitMaintenanceRequest.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/lib/apiClient";
+
+interface MaintenanceRequestPayload {
+  category: string;
+  description: string;
+  workspaceId?: string;
+  imageUrl?: string;
+}
+
+export const useSubmitMaintenanceRequest = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: MaintenanceRequestPayload) =>
+      apiClient.post("/maintenance", data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["maintenance", "mine"] });
+    },
+  });
+};


### PR DESCRIPTION
## Summary

This PR implements four features assigned to BigBen-7:

### [BE-19] Maintenance / Issue Reporting: Backend (#1187)
- New `MaintenanceRequest` entity with `category` (EQUIPMENT/FACILITY/SAFETY/OTHER), `description`, `imageUrl`, `status` (OPEN/IN_PROGRESS/RESOLVED), `resolvedAt`, and `resolvedByStaffId` fields
- `POST /maintenance` — member submits a request
- `GET /maintenance/mine` — member views their own requests (paginated)
- `GET /maintenance` — admin/staff views all requests (filterable by status, category, workspaceId)
- `PATCH /maintenance/:id/status` — admin updates status
- `GET /maintenance/:id` — detail view
- `MaintenanceModule` registered in `AppModule`

### [FE-18] Maintenance / Issue Reporting: Frontend (#1188)
- `/maintenance` page listing member's own submissions with category badge, status badge, and submission date
- Report an Issue modal with category dropdown and description textarea
- `useSubmitMaintenanceRequest` and `useGetMyMaintenanceRequests` React Query hooks
- `/maintenance` link added to `DashboardSidebar` under Help

### [BE-20] Leads / CRM Module: Backend (#1189)
- New `Lead` entity with `name`, `email`, `phone`, `company`, `source` (CONTACT_FORM/REFERRAL/WALK_IN/OTHER), `status` (NEW/CONTACTED/QUALIFIED/CONVERTED/LOST), `notes`, `assignedToStaffId`, `convertedAt` fields with soft-delete support
- `GET /leads` — paginated, filterable by status, source, assignedToStaffId (admin/staff)
- `GET /leads/:id` — single lead detail
- `PATCH /leads/:id` — update status, notes, assigned staff
- `POST /leads/:id/convert` — marks lead as CONVERTED and sets convertedAt
- `DELETE /leads/:id` — soft-delete (admin only)
- `createFromContactForm()` helper for ContactModule integration
- `LeadsModule` registered in `AppModule`

### [FE-17] Interactive Floor Plan / Seat Map (#1186)
- New `/spaces/map` page rendering an SVG-based floor plan from `GET /floor-plan/active`
- Each workspace zone is a clickable rectangle coloured by availability: green (available), amber (<25% remaining), red (full)
- Clicking a zone navigates to `/bookings/new?workspaceId=` 
- "Floor plan coming soon" placeholder when no floor plan is published
- Mobile-friendly with pinch-to-zoom (SVG touch-action)
- `Map View` toggle button added to the `/workspaces` listing page
- New `FloorPlanCanvas` component in `frontend/components/floor-plan/`

Closes #1187
Closes #1188
Closes #1189
Closes #1186