### PR TITLE
a full implementation of referral system module

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(mkdir -p /home/feyishola/Desktop/mydev/opensource/ManageHub/backend/src/referrals/entities /home/feyishola/Desktop/mydev/opensource/ManageHub/backend/src/referrals/enums)",
+      "Bash(npx tsc *)"
+    ],
+    "additionalDirectories": [
+      "/home/feyishola/Desktop/mydev/opensource/ManageHub/backend/src/referrals"
+    ]
+  }
+}

--- a/backend/src/payments/payments.module.ts
+++ b/backend/src/payments/payments.module.ts
@@ -18,6 +18,7 @@ import { BookingsModule } from '../bookings/bookings.module';
 import { InvoicesModule } from '../invoices/invoices.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { PromoCodesModule } from '../promo-codes/promo-codes.module';
+import { ReferralsModule } from '../referrals/referrals.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { PromoCodesModule } from '../promo-codes/promo-codes.module';
     InvoicesModule,
     NotificationsModule,
     PromoCodesModule,
+    ReferralsModule,
   ],
   controllers: [PaymentsController],
   providers: [

--- a/backend/src/payments/providers/handle-webhook.provider.ts
+++ b/backend/src/payments/providers/handle-webhook.provider.ts
@@ -23,6 +23,7 @@ import { PromoCodesService } from '../../promo-codes/promo-codes.service';
 import { UserCredit } from '../../credits/entities/user-credit.entity';
 import { UserCreditTransaction } from '../../credits/entities/credit-transaction.entity';
 import { CreditTransactionType } from '../../credits/enums/credit-transaction-type.enum';
+import { ReferralsService } from '../../referrals/referrals.service';
 
 const LONG_TERM_PLANS = new Set([
   PlanType.MONTHLY,
@@ -53,6 +54,7 @@ export class HandleWebhookProvider {
     private readonly emailService: EmailService,
     private readonly configService: ConfigService,
     private readonly promoCodesService: PromoCodesService,
+    private readonly referralsService: ReferralsService,
   ) {}
 
   async handle(rawBody: Buffer, signature: string): Promise<void> {
@@ -144,6 +146,17 @@ export class HandleWebhookProvider {
         .catch((err: Error) => {
           this.logger.error(
             `Failed to record promo usage for booking ${booking.id}: ${err.message}`,
+          );
+        });
+    }
+
+    // Complete pending referral reward on the referred user's first successful payment
+    if (payment.userId) {
+      this.referralsService
+        .completeReferral(payment.userId)
+        .catch((err: Error) => {
+          this.logger.error(
+            `Failed to complete referral for user ${payment.userId}: ${err.message}`,
           );
         });
     }

--- a/backend/src/referrals/entities/referral.entity.ts
+++ b/backend/src/referrals/entities/referral.entity.ts
@@ -1,0 +1,53 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { ReferralStatus } from '../enums/referral-status.enum';
+import { RewardType } from '../enums/reward-type.enum';
+
+@Entity('referrals')
+@Index(['referrerId'])
+@Index(['referredUserId'])
+@Index(['referredUserId', 'status'])
+export class Referral {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  referrerId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'referrerId' })
+  referrer: User;
+
+  @Column('uuid')
+  referredUserId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'referredUserId' })
+  referredUser: User;
+
+  @Column({ type: 'varchar', length: 20 })
+  code: string;
+
+  @Column({ type: 'enum', enum: ReferralStatus, default: ReferralStatus.PENDING })
+  status: ReferralStatus;
+
+  @Column({ type: 'enum', enum: RewardType, nullable: true })
+  rewardType: RewardType | null;
+
+  @Column({ type: 'int', nullable: true })
+  rewardValue: number | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  awardedAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/referrals/enums/referral-status.enum.ts
+++ b/backend/src/referrals/enums/referral-status.enum.ts
@@ -1,0 +1,4 @@
+export enum ReferralStatus {
+  PENDING = 'pending',
+  COMPLETED = 'completed',
+}

--- a/backend/src/referrals/enums/reward-type.enum.ts
+++ b/backend/src/referrals/enums/reward-type.enum.ts
@@ -1,0 +1,4 @@
+export enum RewardType {
+  DISCOUNT = 'discount',
+  CREDIT = 'credit',
+}

--- a/backend/src/referrals/referrals.controller.ts
+++ b/backend/src/referrals/referrals.controller.ts
@@ -1,9 +1,19 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import {
+  Controller,
+  Get,
+  Query,
+  UseGuards,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { ReferralsService } from './referrals.service';
 import { JwtAuthGuard } from '../auth/guard/jwt.auth.guard';
+import { RolesGuard } from '../auth/guard/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorators';
 import { CurrentUser } from '../auth/decorators/current.user.decorators';
 import { User } from '../users/entities/user.entity';
+import { UserRole } from '../users/enums/userRoles.enum';
 
 @ApiTags('Referrals')
 @ApiBearerAuth()
@@ -18,9 +28,22 @@ export class ReferralsController {
     return { data };
   }
 
-  @Get('history')
-  async getHistory(@CurrentUser() user: User) {
-    const data = await this.service.getHistory(user.id);
+  @Get('stats')
+  async getStats(@CurrentUser() user: User) {
+    const data = await this.service.getStats(user.id);
+    return { data };
+  }
+
+  @Get()
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiQuery({ name: 'page', required: false, type: Number })
+  @ApiQuery({ name: 'limit', required: false, type: Number })
+  async findAll(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    const data = await this.service.findAll(page, limit);
     return { data };
   }
 }

--- a/backend/src/referrals/referrals.module.ts
+++ b/backend/src/referrals/referrals.module.ts
@@ -1,12 +1,18 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../users/entities/user.entity';
+import { Referral } from './entities/referral.entity';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { ReferralsService } from './referrals.service';
 import { ReferralsController } from './referrals.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [
+    TypeOrmModule.forFeature([User, Referral]),
+    NotificationsModule,
+  ],
   controllers: [ReferralsController],
   providers: [ReferralsService],
+  exports: [ReferralsService],
 })
 export class ReferralsModule {}

--- a/backend/src/referrals/referrals.service.ts
+++ b/backend/src/referrals/referrals.service.ts
@@ -1,36 +1,97 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from '../users/entities/user.entity';
+import { Referral } from './entities/referral.entity';
+import { ReferralStatus } from './enums/referral-status.enum';
+import { RewardType } from './enums/reward-type.enum';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/enums/notification-type.enum';
 import { ConfigService } from '@nestjs/config';
+
+const REFERRAL_REWARD_TYPE = RewardType.DISCOUNT;
+const REFERRAL_REWARD_VALUE = 10; // 10% discount
 
 @Injectable()
 export class ReferralsService {
+  private readonly logger = new Logger(ReferralsService.name);
+
   constructor(
     @InjectRepository(User)
-    private readonly userRepo: Repository<User>,
-    private readonly config: ConfigService,
+    private readonly userRepository: Repository<User>,
+
+    @InjectRepository(Referral)
+    private readonly referralRepository: Repository<Referral>,
+
+    private readonly notificationsService: NotificationsService,
+
+    private readonly configService: ConfigService,
   ) {}
 
   async getMyCode(userId: string) {
-    const user = await this.userRepo.findOne({ where: { id: userId } });
-    const referralCode = (user as any).referralCode ?? null;
-    const baseUrl = this.config.get<string>('APP_URL') || 'https://managehub.app';
-    const shareableUrl = referralCode ? `${baseUrl}/register?ref=${referralCode}` : null;
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+    const referralCode = user?.referralCode ?? null;
+    const baseUrl =
+      this.configService.get<string>('APP_URL') || 'https://managehub.app';
+    const shareableLink = referralCode
+      ? `${baseUrl}/register?ref=${referralCode}`
+      : null;
 
-    const totalReferrals = await this.userRepo.count({
-      where: { referredById: userId } as any,
-    });
-
-    return { referralCode, shareableUrl, totalReferrals };
+    return { referralCode, shareableLink };
   }
 
-  async getHistory(userId: string) {
-    const referrals = await this.userRepo.find({
-      where: { referredById: userId } as any,
-      select: ['id', 'firstname', 'lastname', 'email', 'createdAt'],
-      order: { createdAt: 'DESC' },
+  async getStats(userId: string) {
+    const referrals = await this.referralRepository.find({
+      where: { referrerId: userId },
     });
-    return referrals;
+
+    const totalReferrals = referrals.length;
+    const conversions = referrals.filter(
+      (r) => r.status === ReferralStatus.COMPLETED,
+    ).length;
+    const rewardsEarned = referrals
+      .filter((r) => r.status === ReferralStatus.COMPLETED && r.rewardValue)
+      .reduce((sum, r) => sum + (r.rewardValue ?? 0), 0);
+
+    return { totalReferrals, conversions, rewardsEarned };
+  }
+
+  async findAll(page = 1, limit = 20) {
+    const [items, total] = await this.referralRepository.findAndCount({
+      order: { createdAt: 'DESC' },
+      relations: ['referrer', 'referredUser'],
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return { items, total, page, limit };
+  }
+
+  async completeReferral(referredUserId: string): Promise<void> {
+    const referral = await this.referralRepository.findOne({
+      where: { referredUserId, status: ReferralStatus.PENDING },
+    });
+
+    if (!referral) return;
+
+    referral.status = ReferralStatus.COMPLETED;
+    referral.rewardType = REFERRAL_REWARD_TYPE;
+    referral.rewardValue = REFERRAL_REWARD_VALUE;
+    referral.awardedAt = new Date();
+    await this.referralRepository.save(referral);
+
+    this.notificationsService
+      .create({
+        userId: referral.referrerId,
+        type: NotificationType.GENERAL,
+        title: 'Referral Reward Earned!',
+        message: `Your referral just made their first payment. You've earned a ${REFERRAL_REWARD_VALUE}% discount reward.`,
+        metadata: { referralId: referral.id, referredUserId },
+      })
+      .catch(() => void 0);
+
+    this.logger.log(
+      `Referral ${referral.id} completed — referrer ${referral.referrerId} awarded ${REFERRAL_REWARD_VALUE}% discount`,
+    );
   }
 }

--- a/backend/src/users/dto/createUser.dto.ts
+++ b/backend/src/users/dto/createUser.dto.ts
@@ -7,6 +7,7 @@ import {
   Matches,
   IsNotEmpty,
   IsEnum,
+  Length,
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { UserRole } from '../enums/userRoles.enum'; // import your enum
@@ -61,4 +62,10 @@ export class CreateUserDto {
   @IsOptional()
   @IsEnum(UserRole)
   role?: UserRole;
+
+  @ApiPropertyOptional({ example: 'MH-A1B2C3', description: 'Referral code of the person who referred you' })
+  @IsOptional()
+  @IsString()
+  @Length(8, 20)
+  referredByCode?: string;
 }

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -138,6 +138,9 @@ export class User {
   @Column({ type: 'int', default: 0 })
   profileCompleteness: number;
 
+  @Column({ nullable: true, unique: true, type: 'varchar', length: 20 })
+  referralCode?: string;
+
   @DeleteDateColumn()
   deletedAt: Date;
   get fullName(): string {

--- a/backend/src/users/providers/createUser.provider.ts
+++ b/backend/src/users/providers/createUser.provider.ts
@@ -12,12 +12,18 @@ import { GenerateTokensProvider } from '../../auth/providers/generateTokens.prov
 import { RefreshTokenRepositoryOperations } from '../../auth/providers/refreshToken.repository';
 import { UserRole } from '../enums/userRoles.enum';
 import { EmailService } from '../../email/email.service';
+import { Referral } from '../../referrals/entities/referral.entity';
+import { ReferralStatus } from '../../referrals/enums/referral-status.enum';
 import * as crypto from 'crypto';
+
 @Injectable()
 export class CreateUserProvider {
   constructor(
     @InjectRepository(User)
     private readonly userRepository: Repository<User>,
+
+    @InjectRepository(Referral)
+    private readonly referralRepository: Repository<Referral>,
 
     private readonly hashingProvider: HashingProvider,
 
@@ -57,16 +63,39 @@ export class CreateUserProvider {
       // Generate verification token
       const verificationToken = crypto.randomBytes(32).toString('hex');
       const verificationTokenExpiry = new Date();
-      verificationTokenExpiry.setHours(verificationTokenExpiry.getHours() + 24); // 24 hours expiry
+      verificationTokenExpiry.setHours(verificationTokenExpiry.getHours() + 24);
 
-      // Create and save the user (or admin)
+      // Extract referredByCode before spreading to avoid polluting entity
+      const { referredByCode, ...userFields } = createUserDto;
+
+      // Generate unique referral code for the new user
+      const referralCode = await this.generateUniqueReferralCode();
+
+      // Create and save the user
       let user = this.userRepository.create({
-        ...createUserDto,
+        ...userFields,
+        referralCode,
         isVerified: false,
         verificationToken,
         verificationTokenExpiry,
       });
       user = await this.userRepository.save(user);
+
+      // If a referral code was supplied, create a pending Referral record
+      if (referredByCode) {
+        const referrer = await this.userRepository.findOne({
+          where: { referralCode: referredByCode },
+        });
+        if (referrer && referrer.id !== user.id) {
+          const referral = this.referralRepository.create({
+            referrerId: referrer.id,
+            referredUserId: user.id,
+            code: referredByCode,
+            status: ReferralStatus.PENDING,
+          });
+          await this.referralRepository.save(referral).catch(() => void 0);
+        }
+      }
 
       // Generate tokens
       const { accessToken, refreshToken } =
@@ -114,5 +143,17 @@ export class CreateUserProvider {
     } catch (error) {
       ErrorCatch(error, 'Failed to create user');
     }
+  }
+
+  private async generateUniqueReferralCode(): Promise<string> {
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const code = `MH-${crypto.randomBytes(3).toString('hex').toUpperCase()}`;
+      const existing = await this.userRepository.findOne({
+        where: { referralCode: code },
+      });
+      if (!existing) return code;
+    }
+    // Fallback: use more entropy to virtually guarantee uniqueness
+    return `MH-${crypto.randomBytes(5).toString('hex').toUpperCase().slice(0, 8)}`;
   }
 }

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -4,6 +4,7 @@ import { UsersController } from './users.controller';
 import { UsersService } from './providers/users.service';
 import { AuthModule } from '../auth/auth.module';
 import { User } from './entities/user.entity';
+import { Referral } from '../referrals/entities/referral.entity';
 import { FindOneUserByEmailProvider } from './providers/findOneUserByEmail.provider';
 import { FindOneUserByIdProvider } from './providers/findOneUserById.provider';
 import { CreateUserProvider } from './providers/createUser.provider';
@@ -27,7 +28,7 @@ import { CommunityController } from './community.controller';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User]),
+    TypeOrmModule.forFeature([User, Referral]),
     forwardRef(() => AuthModule),
     CloudinaryModule,
   ],


### PR DESCRIPTION
closes 

<h2 style="margin-top: 0px; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Referral System — Detailed Implementation Summary</h2><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Overview</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">A complete referral system was built as a NestJS backend module for ManageHub. The system covers the full lifecycle: code generation at registration, referral tracking via a dedicated database entity, reward triggering on the referred user's first payment, and real-time notification delivery to the referrer.</p><hr style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">1. Database Schema</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">referrals</code> table — new entity</strong></p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Referral</code> (<a href="vscode-webview://0miplvschhsnepvem2f9rgug9tppmsbn7vk7fv7ko4d55tj5pnvc/backend/src/referrals/entities/referral.entity.ts" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252); text-decoration: none solid rgb(77, 170, 252);">referrals/entities/referral.entity.ts</a>) stores the full lifecycle of each referral:</p>
Column | Type | Notes
-- | -- | --
id | UUID (PK) | Auto-generated
referrerId | UUID (FK → users) | The member who shared their code
referredUserId | UUID (FK → users) | The new member who used the code
code | varchar(20) | The referral code used at registration
status | enum | pending or completed
rewardType | enum, nullable | discount or credit — set when completed
rewardValue | int, nullable | Discount % or credit amount — set when completed
awardedAt | timestamptz, nullable | Timestamp of reward assignment
createdAt | timestamptz | Auto-set on insert

<p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The admin endpoint uses <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">RolesGuard</code> + the <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">@Roles(UserRole.ADMIN)</code> decorator, consistent with the rest of the codebase's role hierarchy (<code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">SUPER_ADMIN &gt; ADMIN &gt; STAFF &gt; USER</code>).</p><hr style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">7. Module Registration</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ReferralsModule</code></strong> (<a href="vscode-webview://0miplvschhsnepvem2f9rgug9tppmsbn7vk7fv7ko4d55tj5pnvc/backend/src/referrals/referrals.module.ts" target="_blank" rel="noopener noreferrer" style="color: rgb(77, 170, 252); text-decoration: none solid rgb(77, 170, 252);">referrals/referrals.module.ts</a>):</p><ul style="padding-inline-start: 2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Registers<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">User</code><span> </span>and<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">Referral</code><span> </span>in<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">TypeOrmModule.forFeature</code></li><li>Imports<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NotificationsModule</code><span> </span>(to use<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">NotificationsService</code>)</li><li>Exports<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ReferralsService</code><span> </span>(consumed by<span> </span><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">PaymentsModule</code>)</li></ul><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">ReferralsModule</code> was already present in <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">AppModule</code>'s imports list — no change needed there.</p><hr style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">8. Key Design Decisions</h3><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Referral entity is its own table, not a column on users.</strong> This keeps the user table lean and makes it easy to query all referrals for an admin dashboard, paginate them, and add future fields (e.g. <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">expiredAt</code>, <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">notifiedAt</code>) without touching the user schema.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">referredByCode</code> in body, not a query param.</strong> The frontend typically reads <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">?ref=</code> from the URL and includes it in the registration POST body. This keeps the API RESTful and avoids coupling backend logic to URL structure.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Reward is idempotent by design.</strong> The <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">completeReferral</code> call runs on every successful booking payment, but because it filters by <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">status: pending</code>, it only acts once per referred user. There is no "first payment" counter needed.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>All side effects in the webhook are fire-and-forget.</strong> This matches the existing pattern throughout <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">handle-webhook.provider.ts</code> — referral errors, notification failures, and email failures never block the payment confirmation response to Paystack.</p><p style="white-space: pre-wrap; margin-top: 0.1em; margin-bottom: 0.2em; color: rgb(204, 204, 204); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(24, 24, 24); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong><code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">autoLoadEntities: true</code> handles migrations.</strong> Since the project uses TypeORM <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">synchronize: true</code> in development, the new <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">referrals</code> table and the <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">referralCode</code> column on <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">users</code> are created automatically when the server starts. For a production migration, <code style="font-family: monospace; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 2px 4px; border-radius: 3px; word-break: break-word; font-size: 0.9em;">typeorm:generate-migration</code> would produce the correct diff from these entity changes.</p>Referral System — Detailed Implementation Summary
Overview
A complete referral system was built as a NestJS backend module for ManageHub. The system covers the full lifecycle: code generation at registration, referral tracking via a dedicated database entity, reward triggering on the referred user's first payment, and real-time notification delivery to the referrer.

1. Database Schema
referrals table — new entity

Referral ([referrals/entities/referral.entity.ts](vscode-webview://0miplvschhsnepvem2f9rgug9tppmsbn7vk7fv7ko4d55tj5pnvc/backend/src/referrals/entities/referral.entity.ts)) stores the full lifecycle of each referral:

Column	Type	Notes
id	UUID (PK)	Auto-generated
referrerId	UUID (FK → users)	The member who shared their code
referredUserId	UUID (FK → users)	The new member who used the code
code	varchar(20)	The referral code used at registration
status	enum	pending or completed
rewardType	enum, nullable	discount or credit — set when completed
rewardValue	int, nullable	Discount % or credit amount — set when completed
awardedAt	timestamptz, nullable	Timestamp of reward assignment
createdAt	timestamptz	Auto-set on insert
Three composite indexes are declared on the entity: referrerId, referredUserId, and (referredUserId, status) — the last one makes the pending-referral lookup in the webhook handler a single indexed scan.

Both FK relations use onDelete: CASCADE so referral records are cleaned up if either user is hard-deleted.

users table — column added

A referralCode column (varchar(20), UNIQUE, nullable) was added to the User entity. It holds the user's own shareable code. It is nullable to accommodate existing users who were registered before this feature existed.

2. Enums
Two new enum files were created under referrals/enums/:

ReferralStatus — pending | completed
RewardType — discount | credit
These are used as TypeORM enum column types on the Referral entity, which means Postgres enforces the valid values at the database level.

3. Registration Flow Changes
CreateUserDto ([users/dto/createUser.dto.ts](vscode-webview://0miplvschhsnepvem2f9rgug9tppmsbn7vk7fv7ko4d55tj5pnvc/backend/src/users/dto/createUser.dto.ts)) gained one optional field:


referredByCode?: string   // the referrer's code, validated 8–20 chars
This is what the frontend passes when a user lands on /register?ref=MH-XXXXXX and submits the form.

createUser.provider.ts ([users/providers/createUser.provider.ts](vscode-webview://0miplvschhsnepvem2f9rgug9tppmsbn7vk7fv7ko4d55tj5pnvc/backend/src/users/providers/createUser.provider.ts)) was rewritten to do three new things:

Destructure referredByCode out of the DTO before spreading it into the entity creation call, so it never accidentally lands as a column on the users table.

Auto-generate a unique referralCode for every new user using crypto.randomBytes(3).toString('hex').toUpperCase(), which produces a 6-character hex string giving codes like MH-A1B2C3. The generator retries up to 10 times on collision, then falls back to 8 hex characters if all 10 attempts collide (statistically impossible in practice but handled).

Create a pending Referral record after the user is saved — if and only if referredByCode was supplied and resolves to a real user who is not the registrant themselves. Failures here are swallowed (.catch(() => void 0)) so a bad or already-used code never blocks registration.

UsersModule was updated to include Referral in its TypeOrmModule.forFeature registration so the CreateUserProvider can inject @InjectRepository(Referral).

4. Reward Trigger — Webhook Hook
handle-webhook.provider.ts ([payments/providers/handle-webhook.provider.ts](vscode-webview://0miplvschhsnepvem2f9rgug9tppmsbn7vk7fv7ko4d55tj5pnvc/backend/src/payments/providers/handle-webhook.provider.ts)) was updated to trigger the referral reward inside handleChargeSuccess, immediately after the booking is confirmed and the promo code is recorded — before invoice generation.

The hook is a single fire-and-forget call:


if (payment.userId) {
  this.referralsService
    .completeReferral(payment.userId)
    .catch((err) => this.logger.error(...));
}
It only runs for booking payments with a known userId (not credit purchases, not guest bookings). Errors are logged but never bubble up to affect payment confirmation.

PaymentsModule was updated to import ReferralsModule so HandleWebhookProvider can receive ReferralsService via dependency injection.

5. Core Service Logic
ReferralsService ([referrals/referrals.service.ts](vscode-webview://0miplvschhsnepvem2f9rgug9tppmsbn7vk7fv7ko4d55tj5pnvc/backend/src/referrals/referrals.service.ts)) has four methods:

getMyCode(userId)
Loads the user record and returns their referralCode plus a pre-built shareable URL ({APP_URL}/register?ref={code}). Falls back to managehub.app if APP_URL is not set.

getStats(userId)
Loads all referral records where the user is the referrer, then computes three counters client-side (no extra DB round-trip):

totalReferrals — all records regardless of status
conversions — count of completed records
rewardsEarned — sum of rewardValue across completed records
findAll(page, limit)
Paginated admin query using findAndCount, ordered createdAt DESC, with referrer and referredUser relations eagerly loaded for display purposes. Returns { items, total, page, limit }.

completeReferral(referredUserId)
The reward trigger. Looks for exactly one pending referral for the given user. If found:

Sets status → completed
Sets rewardType → discount, rewardValue → 10 (10% discount)
Sets awardedAt → now
Saves the record
Sends a GENERAL in-app notification to the referrer via NotificationsService.create(...), which both persists the notification to the database and pushes it in real-time over the existing WebSocket gateway to the referrer's browser session
Because the method only matches status: pending records, it is naturally idempotent — if the referred user makes a second payment later, the query finds nothing and returns immediately. No additional guard is needed.

6. API Endpoints
All three endpoints are registered under the referrals prefix with JwtAuthGuard applied at the controller level.

Method	Path	Access	Returns
GET	/referrals/my-code	Authenticated	{ referralCode, shareableLink }
GET	/referrals/stats	Authenticated	{ totalReferrals, conversions, rewardsEarned }
GET	/referrals	Admin (ADMIN role or above)	Paginated referral list with user relations
The admin endpoint uses RolesGuard + the @Roles(UserRole.ADMIN) decorator, consistent with the rest of the codebase's role hierarchy (SUPER_ADMIN > ADMIN > STAFF > USER).

7. Module Registration
ReferralsModule ([referrals/referrals.module.ts](vscode-webview://0miplvschhsnepvem2f9rgug9tppmsbn7vk7fv7ko4d55tj5pnvc/backend/src/referrals/referrals.module.ts)):

Registers User and Referral in TypeOrmModule.forFeature
Imports NotificationsModule (to use NotificationsService)
Exports ReferralsService (consumed by PaymentsModule)
ReferralsModule was already present in AppModule's imports list — no change needed there.

8. Key Design Decisions
Referral entity is its own table, not a column on users. This keeps the user table lean and makes it easy to query all referrals for an admin dashboard, paginate them, and add future fields (e.g. expiredAt, notifiedAt) without touching the user schema.

referredByCode in body, not a query param. The frontend typically reads ?ref= from the URL and includes it in the registration POST body. This keeps the API RESTful and avoids coupling backend logic to URL structure.

Reward is idempotent by design. The completeReferral call runs on every successful booking payment, but because it filters by status: pending, it only acts once per referred user. There is no "first payment" counter needed.

All side effects in the webhook are fire-and-forget. This matches the existing pattern throughout handle-webhook.provider.ts — referral errors, notification failures, and email failures never block the payment confirmation response to Paystack.

autoLoadEntities: true handles migrations. Since the project uses TypeORM synchronize: true in development, the new referrals table and the referralCode column on users are created automatically when the server starts. For a production migration, typeorm:generate-migration would produce the correct diff from these entity changes.