### PR TITLE
feat: visitor management module — full backend rebuild [BE-53]

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,62 +1,49 @@
-import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
-import { AppController } from './app.controller';
-import { AppService } from './app.service';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { AuthModule } from './auth/auth.module';
-import { UsersModule } from './users/users.module';
-import { APP_GUARD } from '@nestjs/core';
-import { JwtAuthGuard } from './auth/guard/jwt.auth.guard';
-import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
-import { BullModule } from '@nestjs/bull';
-import { ScheduleModule } from '@nestjs/schedule';
-import { NewsletterModule } from './newsletter/newsletter.module';
-import { EmailModule } from './email/email.module';
-import { DashboardModule } from './dashboard/dashboard.module';
-import { ContactModule } from './contact/contact.module';
-import { WorkspacesModule } from './workspaces/workspaces.module';
-import { BookingsModule } from './bookings/bookings.module';
-import { PaymentsModule } from './payments/payments.module';
-import { InvoicesModule } from './invoices/invoices.module';
-import { NotificationsModule } from './notifications/notifications.module';
-import { WorkspaceTrackingModule } from './workspace-tracking/workspace-tracking.module';
+import { Module, NestModule, MiddlewareConsumer } from "@nestjs/common";
+import { AppController } from "./app.controller";
+import { AppService } from "./app.service";
+import { ConfigModule, ConfigService } from "@nestjs/config";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { AuthModule } from "./auth/auth.module";
+import { UsersModule } from "./users/users.module";
+import { APP_GUARD } from "@nestjs/core";
+import { JwtAuthGuard } from "./auth/guard/jwt.auth.guard";
+import { ThrottlerModule, ThrottlerGuard } from "@nestjs/throttler";
+import { BullModule } from "@nestjs/bull";
+import { ScheduleModule } from "@nestjs/schedule";
+import { NewsletterModule } from "./newsletter/newsletter.module";
+import { EmailModule } from "./email/email.module";
+import { DashboardModule } from "./dashboard/dashboard.module";
+import { ContactModule } from "./contact/contact.module";
+import { WorkspacesModule } from "./workspaces/workspaces.module";
+import { BookingsModule } from "./bookings/bookings.module";
+import { PaymentsModule } from "./payments/payments.module";
+import { InvoicesModule } from "./invoices/invoices.module";
+import { NotificationsModule } from "./notifications/notifications.module";
+import { WorkspaceTrackingModule } from "./workspace-tracking/workspace-tracking.module";
+import { VisitorsModule } from "./visitors/visitors.module";
 
 @Module({
   imports: [
-    ConfigModule.forRoot({
-      isGlobal: true,
-    }),
+    ConfigModule.forRoot({ isGlobal: true }),
     ScheduleModule.forRoot(),
     ThrottlerModule.forRoot([
-      {
-        name: 'short',
-        ttl: 1000, // 1 second
-        limit: 3, // 3 requests per second
-      },
-      {
-        name: 'medium',
-        ttl: 10000, // 10 seconds
-        limit: 20, // 20 requests per 10 seconds
-      },
-      {
-        name: 'long',
-        ttl: 60000, // 1 minute
-        limit: 100, // 100 requests per minute
-      },
-      { name: 'newsletter', ttl: 60_000, limit: 10 },
-      { name: 'contact', ttl: 60_000, limit: 5 },
-      { name: 'feedback', ttl: 60_000, limit: 10 },
+      { name: "short",      ttl: 1000,   limit: 3   },
+      { name: "medium",     ttl: 10000,  limit: 20  },
+      { name: "long",       ttl: 60000,  limit: 100 },
+      { name: "newsletter", ttl: 60_000, limit: 10  },
+      { name: "contact",    ttl: 60_000, limit: 5   },
+      { name: "feedback",   ttl: 60_000, limit: 10  },
     ]),
     BullModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => {
-        const tls = configService.get<string>('REDIS_TLS') === 'true';
+        const tls = configService.get<string>("REDIS_TLS") === "true";
         return {
           redis: {
-            host: configService.get<string>('REDIS_HOST') || 'localhost',
-            port: configService.get<number>('REDIS_PORT') || 6379,
-            password: configService.get<string>('REDIS_PASSWORD'),
-            db: configService.get<number>('REDIS_DB') || 0,
+            host: configService.get<string>("REDIS_HOST") || "localhost",
+            port: configService.get<number>("REDIS_PORT") || 6379,
+            password: configService.get<string>("REDIS_PASSWORD"),
+            db: configService.get<number>("REDIS_DB") || 0,
             ...(tls && { tls: {} }),
           },
         };
@@ -67,19 +54,19 @@ import { WorkspaceTrackingModule } from './workspace-tracking/workspace-tracking
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const host = configService.get<string>('DATABASE_HOST');
+        const host = configService.get<string>("DATABASE_HOST");
         const sslRequired =
-          configService.get<string>('NODE_ENV') === 'production' ||
-          configService.get<string>('PGSSLMODE') === 'require' ||
-          configService.get<string>('DATABASE_SSL') === 'true' ||
-          (host ? host.includes('neon.tech') : false);
+          configService.get<string>("NODE_ENV") === "production" ||
+          configService.get<string>("PGSSLMODE") === "require" ||
+          configService.get<string>("DATABASE_SSL") === "true" ||
+          (host ? host.includes("neon.tech") : false);
 
         return {
-          type: 'postgres',
-          database: configService.get('DATABASE_NAME'),
-          password: configService.get('DATABASE_PASSWORD'),
-          username: configService.get('DATABASE_USERNAME'),
-          port: +configService.get('DATABASE_PORT'),
+          type: "postgres",
+          database: configService.get("DATABASE_NAME"),
+          password: configService.get("DATABASE_PASSWORD"),
+          username: configService.get("DATABASE_USERNAME"),
+          port: +configService.get("DATABASE_PORT"),
           host,
           autoLoadEntities: true,
           synchronize: true,
@@ -99,18 +86,13 @@ import { WorkspaceTrackingModule } from './workspace-tracking/workspace-tracking
     InvoicesModule,
     NotificationsModule,
     WorkspaceTrackingModule,
+    VisitorsModule,
   ],
   controllers: [AppController],
   providers: [
     AppService,
-    {
-      provide: APP_GUARD,
-      useClass: JwtAuthGuard,
-    },
-    {
-      provide: APP_GUARD,
-      useClass: ThrottlerGuard,
-    },
+    { provide: APP_GUARD, useClass: JwtAuthGuard },
+    { provide: APP_GUARD, useClass: ThrottlerGuard },
   ],
 })
 export class AppModule {}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,49 +1,63 @@
-import { Module, NestModule, MiddlewareConsumer } from "@nestjs/common";
-import { AppController } from "./app.controller";
-import { AppService } from "./app.service";
-import { ConfigModule, ConfigService } from "@nestjs/config";
-import { TypeOrmModule } from "@nestjs/typeorm";
-import { AuthModule } from "./auth/auth.module";
-import { UsersModule } from "./users/users.module";
-import { APP_GUARD } from "@nestjs/core";
-import { JwtAuthGuard } from "./auth/guard/jwt.auth.guard";
-import { ThrottlerModule, ThrottlerGuard } from "@nestjs/throttler";
-import { BullModule } from "@nestjs/bull";
-import { ScheduleModule } from "@nestjs/schedule";
-import { NewsletterModule } from "./newsletter/newsletter.module";
-import { EmailModule } from "./email/email.module";
-import { DashboardModule } from "./dashboard/dashboard.module";
-import { ContactModule } from "./contact/contact.module";
-import { WorkspacesModule } from "./workspaces/workspaces.module";
-import { BookingsModule } from "./bookings/bookings.module";
-import { PaymentsModule } from "./payments/payments.module";
-import { InvoicesModule } from "./invoices/invoices.module";
-import { NotificationsModule } from "./notifications/notifications.module";
-import { WorkspaceTrackingModule } from "./workspace-tracking/workspace-tracking.module";
-import { VisitorsModule } from "./visitors/visitors.module";
+import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuthModule } from './auth/auth.module';
+import { UsersModule } from './users/users.module';
+import { APP_GUARD } from '@nestjs/core';
+import { JwtAuthGuard } from './auth/guard/jwt.auth.guard';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { BullModule } from '@nestjs/bull';
+import { ScheduleModule } from '@nestjs/schedule';
+import { NewsletterModule } from './newsletter/newsletter.module';
+import { EmailModule } from './email/email.module';
+import { DashboardModule } from './dashboard/dashboard.module';
+import { ContactModule } from './contact/contact.module';
+import { WorkspacesModule } from './workspaces/workspaces.module';
+import { BookingsModule } from './bookings/bookings.module';
+import { PaymentsModule } from './payments/payments.module';
+import { InvoicesModule } from './invoices/invoices.module';
+import { NotificationsModule } from './notifications/notifications.module';
+import { WorkspaceTrackingModule } from './workspace-tracking/workspace-tracking.module';
+import { VisitorsModule } from './visitors/visitors.module';
 
 @Module({
   imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
+    ConfigModule.forRoot({
+      isGlobal: true,
+    }),
     ScheduleModule.forRoot(),
     ThrottlerModule.forRoot([
-      { name: "short",      ttl: 1000,   limit: 3   },
-      { name: "medium",     ttl: 10000,  limit: 20  },
-      { name: "long",       ttl: 60000,  limit: 100 },
-      { name: "newsletter", ttl: 60_000, limit: 10  },
-      { name: "contact",    ttl: 60_000, limit: 5   },
-      { name: "feedback",   ttl: 60_000, limit: 10  },
+      {
+        name: 'short',
+        ttl: 1000, // 1 second
+        limit: 3, // 3 requests per second
+      },
+      {
+        name: 'medium',
+        ttl: 10000, // 10 seconds
+        limit: 20, // 20 requests per 10 seconds
+      },
+      {
+        name: 'long',
+        ttl: 60000, // 1 minute
+        limit: 100, // 100 requests per minute
+      },
+      { name: 'newsletter', ttl: 60_000, limit: 10 },
+      { name: 'contact', ttl: 60_000, limit: 5 },
+      { name: 'feedback', ttl: 60_000, limit: 10 },
     ]),
     BullModule.forRootAsync({
       imports: [ConfigModule],
       useFactory: async (configService: ConfigService) => {
-        const tls = configService.get<string>("REDIS_TLS") === "true";
+        const tls = configService.get<string>('REDIS_TLS') === 'true';
         return {
           redis: {
-            host: configService.get<string>("REDIS_HOST") || "localhost",
-            port: configService.get<number>("REDIS_PORT") || 6379,
-            password: configService.get<string>("REDIS_PASSWORD"),
-            db: configService.get<number>("REDIS_DB") || 0,
+            host: configService.get<string>('REDIS_HOST') || 'localhost',
+            port: configService.get<number>('REDIS_PORT') || 6379,
+            password: configService.get<string>('REDIS_PASSWORD'),
+            db: configService.get<number>('REDIS_DB') || 0,
             ...(tls && { tls: {} }),
           },
         };
@@ -54,19 +68,19 @@ import { VisitorsModule } from "./visitors/visitors.module";
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => {
-        const host = configService.get<string>("DATABASE_HOST");
+        const host = configService.get<string>('DATABASE_HOST');
         const sslRequired =
-          configService.get<string>("NODE_ENV") === "production" ||
-          configService.get<string>("PGSSLMODE") === "require" ||
-          configService.get<string>("DATABASE_SSL") === "true" ||
-          (host ? host.includes("neon.tech") : false);
+          configService.get<string>('NODE_ENV') === 'production' ||
+          configService.get<string>('PGSSLMODE') === 'require' ||
+          configService.get<string>('DATABASE_SSL') === 'true' ||
+          (host ? host.includes('neon.tech') : false);
 
         return {
-          type: "postgres",
-          database: configService.get("DATABASE_NAME"),
-          password: configService.get("DATABASE_PASSWORD"),
-          username: configService.get("DATABASE_USERNAME"),
-          port: +configService.get("DATABASE_PORT"),
+          type: 'postgres',
+          database: configService.get('DATABASE_NAME'),
+          password: configService.get('DATABASE_PASSWORD'),
+          username: configService.get('DATABASE_USERNAME'),
+          port: +configService.get('DATABASE_PORT'),
           host,
           autoLoadEntities: true,
           synchronize: true,
@@ -91,8 +105,14 @@ import { VisitorsModule } from "./visitors/visitors.module";
   controllers: [AppController],
   providers: [
     AppService,
-    { provide: APP_GUARD, useClass: JwtAuthGuard },
-    { provide: APP_GUARD, useClass: ThrottlerGuard },
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
   ],
 })
 export class AppModule {}

--- a/backend/src/visitors/dto/create-visitor.dto.ts
+++ b/backend/src/visitors/dto/create-visitor.dto.ts
@@ -1,0 +1,47 @@
+import {
+  IsDateString,
+  IsEmail,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateVisitorDto {
+  @ApiProperty({ example: 'John Doe' })
+  @IsString()
+  @MaxLength(255)
+  visitorName: string;
+
+  @ApiPropertyOptional({ example: 'john@example.com' })
+  @IsOptional()
+  @IsEmail()
+  visitorEmail?: string;
+
+  @ApiPropertyOptional({ example: '+2348012345678' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(30)
+  visitorPhone?: string;
+
+  @ApiPropertyOptional({ example: 'Acme Corp' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  company?: string;
+
+  @ApiPropertyOptional({ example: 'Partnership meeting' })
+  @IsOptional()
+  @IsString()
+  purpose?: string;
+
+  @ApiPropertyOptional({ example: '2026-07-20T10:00:00Z' })
+  @IsOptional()
+  @IsDateString()
+  expectedArrival?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  notes?: string;
+}

--- a/backend/src/visitors/dto/visitor-query.dto.ts
+++ b/backend/src/visitors/dto/visitor-query.dto.ts
@@ -1,0 +1,22 @@
+import { IsDateString, IsEnum, IsOptional } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { PaginationQueryDto } from '../../config/pagination/dto/pagination-query.dto';
+import { VisitorStatus } from '../enums/visitor-status.enum';
+
+export class VisitorQueryDto extends PaginationQueryDto {
+  @ApiPropertyOptional({ enum: VisitorStatus })
+  @IsOptional()
+  @IsEnum(VisitorStatus)
+  status?: VisitorStatus;
+
+  @ApiPropertyOptional({ example: '2026-07-01' })
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @ApiPropertyOptional({ example: '2026-07-31' })
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+}

--- a/backend/src/visitors/entities/visitor.entity.ts
+++ b/backend/src/visitors/entities/visitor.entity.ts
@@ -1,0 +1,63 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { VisitorStatus } from '../enums/visitor-status.enum';
+
+@Entity('visitors')
+@Index(['hostUserId'])
+@Index(['status'])
+export class Visitor {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  hostUserId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'hostUserId' })
+  host: User;
+
+  @Column({ type: 'varchar', length: 255 })
+  visitorName: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  visitorEmail?: string;
+
+  @Column({ type: 'varchar', length: 30, nullable: true })
+  visitorPhone?: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  company?: string;
+
+  @Column({ type: 'text', nullable: true })
+  purpose?: string;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  expectedArrival?: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  actualArrival?: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  actualDeparture?: Date;
+
+  @Column({
+    type: 'enum',
+    enum: VisitorStatus,
+    default: VisitorStatus.EXPECTED,
+  })
+  status: VisitorStatus;
+
+  @Column({ type: 'text', nullable: true })
+  notes?: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/visitors/enums/visitor-status.enum.ts
+++ b/backend/src/visitors/enums/visitor-status.enum.ts
@@ -1,0 +1,6 @@
+export enum VisitorStatus {
+  EXPECTED   = 'expected',
+  CHECKED_IN = 'checked_in',
+  CHECKED_OUT = 'checked_out',
+  CANCELLED  = 'cancelled',
+}

--- a/backend/src/visitors/visitors.controller.ts
+++ b/backend/src/visitors/visitors.controller.ts
@@ -1,0 +1,99 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+import { VisitorsService } from './visitors.service';
+import { CreateVisitorDto } from './dto/create-visitor.dto';
+import { VisitorQueryDto } from './dto/visitor-query.dto';
+import { GetCurrentUser } from '../auth/decorators/getCurrentUser.decorator';
+import { Roles } from '../auth/decorators/roles.decorators';
+import { RolesGuard } from '../auth/guard/roles.guard';
+import { UserRole } from '../users/enums/userRoles.enum';
+
+@ApiTags('Visitors')
+@ApiBearerAuth()
+@UseGuards(RolesGuard)
+@Controller('visitors')
+export class VisitorsController {
+  constructor(private readonly visitorsService: VisitorsService) {}
+
+  /** POST /visitors — host pre-registers a visitor */
+  @Post()
+  @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Pre-register an expected visitor' })
+  async create(
+    @Body() dto: CreateVisitorDto,
+    @GetCurrentUser('id') userId: string,
+  ) {
+    const data = await this.visitorsService.create(userId, dto);
+    return { message: 'Visitor registered successfully', data };
+  }
+
+  /** GET /visitors/mine — authenticated member's own visitors */
+  @Get('mine')
+  @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Get my visitors (paginated)' })
+  async findMine(
+    @GetCurrentUser('id') userId: string,
+    @Query() query: VisitorQueryDto,
+  ) {
+    const result = await this.visitorsService.findMine(userId, query);
+    return { message: 'Visitors retrieved', ...result };
+  }
+
+  /** GET /visitors — admin/staff view all visitors */
+  @Get()
+  @Roles(UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Get all visitors — admin/staff only (filterable)' })
+  async findAll(@Query() query: VisitorQueryDto) {
+    const result = await this.visitorsService.findAll(query);
+    return { message: 'All visitors retrieved', ...result };
+  }
+
+  /** POST /visitors/:id/check-in — staff marks visitor as arrived */
+  @Post(':id/check-in')
+  @Roles(UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Check in a visitor (staff only)' })
+  async checkIn(@Param('id', ParseUUIDPipe) id: string) {
+    const data = await this.visitorsService.checkIn(id);
+    return { message: 'Visitor checked in', data };
+  }
+
+  /** POST /visitors/:id/check-out — staff marks visitor departure */
+  @Post(':id/check-out')
+  @Roles(UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Check out a visitor (staff only)' })
+  async checkOut(@Param('id', ParseUUIDPipe) id: string) {
+    const data = await this.visitorsService.checkOut(id);
+    return { message: 'Visitor checked out', data };
+  }
+
+  /** PATCH /visitors/:id/cancel — host cancels expected visit */
+  @Patch(':id/cancel')
+  @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Cancel an expected visitor (host only)' })
+  async cancel(
+    @Param('id', ParseUUIDPipe) id: string,
+    @GetCurrentUser('id') userId: string,
+  ) {
+    const data = await this.visitorsService.cancel(id, userId);
+    return { message: 'Visitor cancelled', data };
+  }
+}

--- a/backend/src/visitors/visitors.module.ts
+++ b/backend/src/visitors/visitors.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Visitor } from './entities/visitor.entity';
+import { VisitorsService } from './visitors.service';
+import { VisitorsController } from './visitors.controller';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { EmailModule } from '../email/email.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Visitor]),
+    NotificationsModule,
+    EmailModule,
+  ],
+  controllers: [VisitorsController],
+  providers: [VisitorsService],
+  exports: [VisitorsService],
+})
+export class VisitorsModule {}

--- a/backend/src/visitors/visitors.service.ts
+++ b/backend/src/visitors/visitors.service.ts
@@ -1,0 +1,191 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Visitor } from './entities/visitor.entity';
+import { VisitorStatus } from './enums/visitor-status.enum';
+import { CreateVisitorDto } from './dto/create-visitor.dto';
+import { VisitorQueryDto } from './dto/visitor-query.dto';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/enums/notification-type.enum';
+import { EmailService } from '../email/email.service';
+
+@Injectable()
+export class VisitorsService {
+  constructor(
+    @InjectRepository(Visitor)
+    private readonly visitorsRepository: Repository<Visitor>,
+    private readonly notificationsService: NotificationsService,
+    private readonly emailService: EmailService,
+  ) {}
+
+  /** Host pre-registers a visitor. Sends confirmation email if email provided. */
+  async create(
+    hostUserId: string,
+    dto: CreateVisitorDto,
+  ): Promise<Visitor> {
+    const visitor = this.visitorsRepository.create({
+      hostUserId,
+      visitorName: dto.visitorName,
+      visitorEmail: dto.visitorEmail,
+      visitorPhone: dto.visitorPhone,
+      company: dto.company,
+      purpose: dto.purpose,
+      expectedArrival: dto.expectedArrival
+        ? new Date(dto.expectedArrival)
+        : undefined,
+      notes: dto.notes,
+      status: VisitorStatus.EXPECTED,
+    });
+
+    const saved = await this.visitorsRepository.save(visitor);
+
+    if (saved.visitorEmail) {
+      await this.emailService.sendTemplateEmail(
+        saved.visitorEmail,
+        'You have been registered as a visitor',
+        'visitor-check-in',
+        {
+          visitorName: saved.visitorName,
+          company: saved.company ?? '',
+          expectedArrival: saved.expectedArrival?.toISOString() ?? 'TBD',
+        },
+      );
+    }
+
+    return saved;
+  }
+
+  /** Authenticated member views their own visitors (paginated). */
+  async findMine(
+    hostUserId: string,
+    query: VisitorQueryDto,
+  ) {
+    const { page = 1, perPage = 10, status, dateFrom, dateTo } = query;
+
+    const qb = this.visitorsRepository
+      .createQueryBuilder('visitor')
+      .where('visitor.hostUserId = :hostUserId', { hostUserId })
+      .orderBy('visitor.createdAt', 'DESC')
+      .skip((page - 1) * perPage)
+      .take(perPage);
+
+    if (status) {
+      qb.andWhere('visitor.status = :status', { status });
+    }
+    if (dateFrom) {
+      qb.andWhere('visitor.expectedArrival >= :dateFrom', {
+        dateFrom: new Date(dateFrom),
+      });
+    }
+    if (dateTo) {
+      qb.andWhere('visitor.expectedArrival <= :dateTo', {
+        dateTo: new Date(dateTo),
+      });
+    }
+
+    const [data, total] = await qb.getManyAndCount();
+    return { data, total, page, perPage };
+  }
+
+  /** Admin/staff view all visitors (filterable, paginated). */
+  async findAll(query: VisitorQueryDto) {
+    const { page = 1, perPage = 10, status, dateFrom, dateTo } = query;
+
+    const qb = this.visitorsRepository
+      .createQueryBuilder('visitor')
+      .leftJoinAndSelect('visitor.host', 'host')
+      .orderBy('visitor.createdAt', 'DESC')
+      .skip((page - 1) * perPage)
+      .take(perPage);
+
+    if (status) {
+      qb.andWhere('visitor.status = :status', { status });
+    }
+    if (dateFrom) {
+      qb.andWhere('visitor.expectedArrival >= :dateFrom', {
+        dateFrom: new Date(dateFrom),
+      });
+    }
+    if (dateTo) {
+      qb.andWhere('visitor.expectedArrival <= :dateTo', {
+        dateTo: new Date(dateTo),
+      });
+    }
+
+    const [data, total] = await qb.getManyAndCount();
+    return { data, total, page, perPage };
+  }
+
+  /** Staff marks visitor as arrived. Notifies the host in-app. */
+  async checkIn(id: string): Promise<Visitor> {
+    const visitor = await this.findById(id);
+
+    if (visitor.status !== VisitorStatus.EXPECTED) {
+      throw new BadRequestException(
+        `Cannot check in a visitor with status ${visitor.status}`,
+      );
+    }
+
+    visitor.actualArrival = new Date();
+    visitor.status = VisitorStatus.CHECKED_IN;
+    const saved = await this.visitorsRepository.save(visitor);
+
+    await this.notificationsService.create({
+      userId: visitor.hostUserId,
+      type: NotificationType.GENERAL,
+      title: 'Your visitor has arrived',
+      message: `Your visitor ${visitor.visitorName} has arrived.`,
+      metadata: { visitorId: visitor.id },
+    });
+
+    return saved;
+  }
+
+  /** Staff marks visitor departure. */
+  async checkOut(id: string): Promise<Visitor> {
+    const visitor = await this.findById(id);
+
+    if (visitor.status !== VisitorStatus.CHECKED_IN) {
+      throw new BadRequestException(
+        `Cannot check out a visitor with status ${visitor.status}`,
+      );
+    }
+
+    visitor.actualDeparture = new Date();
+    visitor.status = VisitorStatus.CHECKED_OUT;
+    return this.visitorsRepository.save(visitor);
+  }
+
+  /** Host cancels expected visit. */
+  async cancel(id: string, requestingUserId: string): Promise<Visitor> {
+    const visitor = await this.findById(id);
+
+    if (visitor.hostUserId !== requestingUserId) {
+      throw new ForbiddenException(
+        'Only the host can cancel this visitor entry',
+      );
+    }
+
+    if (visitor.status !== VisitorStatus.EXPECTED) {
+      throw new BadRequestException(
+        `Cannot cancel a visitor with status ${visitor.status}`,
+      );
+    }
+
+    visitor.status = VisitorStatus.CANCELLED;
+    return this.visitorsRepository.save(visitor);
+  }
+
+  private async findById(id: string): Promise<Visitor> {
+    const visitor = await this.visitorsRepository.findOne({ where: { id } });
+    if (!visitor) {
+      throw new NotFoundException(`Visitor ${id} not found`);
+    }
+    return visitor;
+  }
+}

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -584,9 +584,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -585,8 +585,7 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 [[package]]
 name = "ethnum"
 version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
+source = "git+https://github.com/nlordell/ethnum-rs?tag=v1.5.3#712d6393b07a1f2cf2eb31d6a9edad1ea2a32159"
 
 [[package]]
 name = "ff"

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -585,7 +585,8 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 [[package]]
 name = "ethnum"
 version = "1.5.3"
-source = "git+https://github.com/nlordell/ethnum-rs?tag=v1.5.3#712d6393b07a1f2cf2eb31d6a9edad1ea2a32159"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -15,11 +15,6 @@ soroban-sdk = "23.4.1"
 common_types = { path = "common_types" }
 membership_token = { path = "membership_token" }
 
-# ethnum 1.5.2 has a transmute bug (E0512) on current stable rustc.
-# Patch to 1.5.3 via git which contains the fix.
-[patch.crates-io]
-ethnum = { git = "https://github.com/nlordell/ethnum-rs", tag = "v1.5.3" }
-
 [profile.release]
 opt-level = "z"
 overflow-checks = true

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -15,6 +15,11 @@ soroban-sdk = "23.4.1"
 common_types = { path = "common_types" }
 membership_token = { path = "membership_token" }
 
+# ethnum 1.5.2 has a transmute bug that breaks on current stable rustc (E0512).
+# Pin to 1.5.3 which fixes it.
+[patch.crates-io]
+ethnum = { version = "1.5.3" }
+
 [profile.release]
 opt-level = "z"
 overflow-checks = true

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -15,11 +15,6 @@ soroban-sdk = "23.4.1"
 common_types = { path = "common_types" }
 membership_token = { path = "membership_token" }
 
-# ethnum 1.5.2 has a transmute bug that breaks on current stable rustc (E0512).
-# Pin to 1.5.3 which fixes it.
-[patch.crates-io]
-ethnum = { version = "1.5.3" }
-
 [profile.release]
 opt-level = "z"
 overflow-checks = true

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -15,6 +15,11 @@ soroban-sdk = "23.4.1"
 common_types = { path = "common_types" }
 membership_token = { path = "membership_token" }
 
+# ethnum 1.5.2 has a transmute bug (E0512) on current stable rustc.
+# Patch to 1.5.3 via git which contains the fix.
+[patch.crates-io]
+ethnum = { git = "https://github.com/nlordell/ethnum-rs", tag = "v1.5.3" }
+
 [profile.release]
 opt-level = "z"
 overflow-checks = true


### PR DESCRIPTION
## Summary

Rebuilds the deleted `backend/src/visitors/` module from scratch, implementing all required endpoints for visitor pre-registration, check-in, check-out, and cancellation.

## Files Created

| File | Description |
|------|-------------|
| `visitors/enums/visitor-status.enum.ts` | `EXPECTED / CHECKED_IN / CHECKED_OUT / CANCELLED` |
| `visitors/entities/visitor.entity.ts` | Full entity with all fields from the issue spec |
| `visitors/dto/create-visitor.dto.ts` | Validated DTO for pre-registration |
| `visitors/dto/visitor-query.dto.ts` | Extends `PaginationQueryDto`; adds status, dateFrom, dateTo filters |
| `visitors/visitors.service.ts` | Business logic for all operations |
| `visitors/visitors.controller.ts` | All 6 endpoints |
| `visitors/visitors.module.ts` | Module wiring |

## Files Modified

- `backend/src/app.module.ts` — registers `VisitorsModule`

## Endpoints

| Method | Path | Roles | Description |
|--------|------|-------|-------------|
| POST | /visitors | USER+ | Pre-register visitor; sends confirmation email if email provided |
| GET | /visitors/mine | USER+ | Own visitors, paginated |
| GET | /visitors | STAFF+ | All visitors, filterable by status / date range |
| POST | /visitors/:id/check-in | STAFF+ | Mark arrived; in-app notification to host |
| POST | /visitors/:id/check-out | STAFF+ | Mark departed |
| PATCH | /visitors/:id/cancel | USER+ | Cancel (host only, enforced in service) |

## Notes

- Host arrival notification uses `NotificationsService.create()` with `NotificationType.GENERAL`
- Confirmation email uses the existing `visitor-check-in.hbs` template via `EmailService.sendTemplateEmail()`
- `synchronize: true` in TypeORM config auto-creates the `visitors` table

closes #1291