### PR TITLE
feat: hub settings management module — singleton entity with auto-seed [BE-54]

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -20,32 +20,19 @@ import { PaymentsModule } from './payments/payments.module';
 import { InvoicesModule } from './invoices/invoices.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { WorkspaceTrackingModule } from './workspace-tracking/workspace-tracking.module';
+import { HubSettingsModule } from './hub-settings/hub-settings.module';
 
 @Module({
   imports: [
-    ConfigModule.forRoot({
-      isGlobal: true,
-    }),
+    ConfigModule.forRoot({ isGlobal: true }),
     ScheduleModule.forRoot(),
     ThrottlerModule.forRoot([
-      {
-        name: 'short',
-        ttl: 1000, // 1 second
-        limit: 3, // 3 requests per second
-      },
-      {
-        name: 'medium',
-        ttl: 10000, // 10 seconds
-        limit: 20, // 20 requests per 10 seconds
-      },
-      {
-        name: 'long',
-        ttl: 60000, // 1 minute
-        limit: 100, // 100 requests per minute
-      },
-      { name: 'newsletter', ttl: 60_000, limit: 10 },
-      { name: 'contact', ttl: 60_000, limit: 5 },
-      { name: 'feedback', ttl: 60_000, limit: 10 },
+      { name: 'short',      ttl: 1000,   limit: 3   },
+      { name: 'medium',     ttl: 10000,  limit: 20  },
+      { name: 'long',       ttl: 60000,  limit: 100 },
+      { name: 'newsletter', ttl: 60_000, limit: 10  },
+      { name: 'contact',    ttl: 60_000, limit: 5   },
+      { name: 'feedback',   ttl: 60_000, limit: 10  },
     ]),
     BullModule.forRootAsync({
       imports: [ConfigModule],
@@ -73,7 +60,6 @@ import { WorkspaceTrackingModule } from './workspace-tracking/workspace-tracking
           configService.get<string>('PGSSLMODE') === 'require' ||
           configService.get<string>('DATABASE_SSL') === 'true' ||
           (host ? host.includes('neon.tech') : false);
-
         return {
           type: 'postgres',
           database: configService.get('DATABASE_NAME'),
@@ -99,18 +85,13 @@ import { WorkspaceTrackingModule } from './workspace-tracking/workspace-tracking
     InvoicesModule,
     NotificationsModule,
     WorkspaceTrackingModule,
+    HubSettingsModule,
   ],
   controllers: [AppController],
   providers: [
     AppService,
-    {
-      provide: APP_GUARD,
-      useClass: JwtAuthGuard,
-    },
-    {
-      provide: APP_GUARD,
-      useClass: ThrottlerGuard,
-    },
+    { provide: APP_GUARD, useClass: JwtAuthGuard },
+    { provide: APP_GUARD, useClass: ThrottlerGuard },
   ],
 })
 export class AppModule {}

--- a/backend/src/hub-settings/dto/update-hub-settings.dto.ts
+++ b/backend/src/hub-settings/dto/update-hub-settings.dto.ts
@@ -1,0 +1,110 @@
+import {
+  IsEmail,
+  IsHexColor,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Max,
+  MaxLength,
+  Min,
+  IsObject,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateHubSettingsDto {
+  @ApiPropertyOptional({ example: 'My Coworking Hub' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(255)
+  hubName?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  address?: string;
+
+  @ApiPropertyOptional({ example: 'Lagos' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  city?: string;
+
+  @ApiPropertyOptional({ example: 'Nigeria' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  country?: string;
+
+  /** IANA timezone string — validated against Intl.supportedValuesOf in service */
+  @ApiPropertyOptional({ example: 'Africa/Lagos' })
+  @IsOptional()
+  @IsString()
+  timezone?: string;
+
+  @ApiPropertyOptional({ example: 'NGN' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(3)
+  currency?: string;
+
+  @ApiPropertyOptional({ example: 7.5 })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  vatRatePercent?: number;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsObject()
+  businessHours?: Record<
+    string,
+    { open?: string; close?: string; closed: boolean }
+  >;
+
+  @ApiPropertyOptional({ example: 'admin@hub.com' })
+  @IsOptional()
+  @IsEmail()
+  contactEmail?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  @MaxLength(30)
+  contactPhone?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUrl()
+  logoUrl?: string;
+
+  @ApiPropertyOptional({ example: '#1a56db' })
+  @IsOptional()
+  @IsHexColor()
+  primaryColor?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUrl()
+  faviconUrl?: string;
+
+  @ApiPropertyOptional({ example: 1 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  bookingLeadTimeHours?: number;
+
+  @ApiPropertyOptional({ example: 90 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  maxBookingDaysAhead?: number;
+
+  @ApiPropertyOptional({ example: 24 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  cancellationPolicyHours?: number;
+}

--- a/backend/src/hub-settings/entities/hub-settings.entity.ts
+++ b/backend/src/hub-settings/entities/hub-settings.entity.ts
@@ -1,0 +1,81 @@
+import {
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * HubSettings — singleton entity (always exactly one row).
+ * Seeded on app startup if the table is empty.
+ */
+@Entity('hub_settings')
+export class HubSettings {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 255, default: 'ManageHub' })
+  hubName: string;
+
+  @Column({ type: 'text', nullable: true })
+  address?: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  city?: string;
+
+  @Column({ type: 'varchar', length: 100, nullable: true })
+  country?: string;
+
+  /** IANA timezone string e.g. "Africa/Lagos" */
+  @Column({ type: 'varchar', length: 100, default: 'Africa/Lagos' })
+  timezone: string;
+
+  /** ISO 4217 currency code */
+  @Column({ type: 'varchar', length: 3, default: 'NGN' })
+  currency: string;
+
+  /** VAT rate as a percentage e.g. 7.5 */
+  @Column({ type: 'decimal', precision: 5, scale: 2, default: 7.5 })
+  vatRatePercent: number;
+
+  /**
+   * Business hours JSONB.
+   * Shape: { mon: { open: '09:00', close: '18:00', closed: false }, ..., sun: { closed: true } }
+   */
+  @Column({ type: 'jsonb', nullable: true })
+  businessHours?: Record<
+    string,
+    { open?: string; close?: string; closed: boolean }
+  >;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  contactEmail?: string;
+
+  @Column({ type: 'varchar', length: 30, nullable: true })
+  contactPhone?: string;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  logoUrl?: string;
+
+  /** Hex colour string e.g. "#1a56db" */
+  @Column({ type: 'varchar', length: 7, nullable: true })
+  primaryColor?: string;
+
+  @Column({ type: 'varchar', length: 500, nullable: true })
+  faviconUrl?: string;
+
+  /** Minimum hours before a booking can be made */
+  @Column({ type: 'int', default: 1 })
+  bookingLeadTimeHours: number;
+
+  /** Maximum days in advance a booking can be made */
+  @Column({ type: 'int', default: 90 })
+  maxBookingDaysAhead: number;
+
+  /** Hours before booking start within which cancellation is penalised */
+  @Column({ type: 'int', default: 24 })
+  cancellationPolicyHours: number;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/src/hub-settings/hub-settings.controller.ts
+++ b/backend/src/hub-settings/hub-settings.controller.ts
@@ -1,0 +1,49 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Patch,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { HubSettingsService } from './hub-settings.service';
+import { UpdateHubSettingsDto } from './dto/update-hub-settings.dto';
+import { Public } from '../auth/decorators/public.decorator';
+import { Roles } from '../auth/decorators/roles.decorators';
+import { RolesGuard } from '../auth/guard/roles.guard';
+import { UserRole } from '../users/enums/userRoles.enum';
+
+@ApiTags('Hub Settings')
+@ApiBearerAuth()
+@UseGuards(RolesGuard)
+@Controller('hub-settings')
+export class HubSettingsController {
+  constructor(private readonly service: HubSettingsService) {}
+
+  /**
+   * GET /hub-settings — public, no auth required.
+   * Needed for white-labeling (FE-38) on every page load.
+   */
+  @Get()
+  @Public()
+  @ApiOperation({ summary: 'Get hub settings (public — used for white-labeling)' })
+  async getSettings() {
+    const data = await this.service.getSettings();
+    return { message: 'Hub settings retrieved', data };
+  }
+
+  /**
+   * PATCH /hub-settings — super_admin only.
+   * Partial update; validates timezone against IANA list.
+   */
+  @Patch()
+  @Roles(UserRole.SUPER_ADMIN)
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Update hub settings (super_admin only)' })
+  async updateSettings(@Body() dto: UpdateHubSettingsDto) {
+    const data = await this.service.updateSettings(dto);
+    return { message: 'Hub settings updated', data };
+  }
+}

--- a/backend/src/hub-settings/hub-settings.module.ts
+++ b/backend/src/hub-settings/hub-settings.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { HubSettings } from './entities/hub-settings.entity';
+import { HubSettingsService } from './hub-settings.service';
+import { HubSettingsController } from './hub-settings.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([HubSettings])],
+  controllers: [HubSettingsController],
+  providers: [HubSettingsService],
+  exports: [HubSettingsService],
+})
+export class HubSettingsModule {}

--- a/backend/src/hub-settings/hub-settings.service.ts
+++ b/backend/src/hub-settings/hub-settings.service.ts
@@ -1,0 +1,83 @@
+import { BadRequestException, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { HubSettings } from './entities/hub-settings.entity';
+import { UpdateHubSettingsDto } from './dto/update-hub-settings.dto';
+
+@Injectable()
+export class HubSettingsService implements OnModuleInit {
+  private readonly logger = new Logger(HubSettingsService.name);
+
+  constructor(
+    @InjectRepository(HubSettings)
+    private readonly repo: Repository<HubSettings>,
+  ) {}
+
+  /** Seed a default record on startup if the table is empty. */
+  async onModuleInit(): Promise<void> {
+    const count = await this.repo.count();
+    if (count === 0) {
+      await this.repo.save(
+        this.repo.create({
+          hubName: 'ManageHub',
+          timezone: 'Africa/Lagos',
+          currency: 'NGN',
+          vatRatePercent: 7.5,
+          bookingLeadTimeHours: 1,
+          maxBookingDaysAhead: 90,
+          cancellationPolicyHours: 24,
+          businessHours: {
+            mon: { open: '09:00', close: '18:00', closed: false },
+            tue: { open: '09:00', close: '18:00', closed: false },
+            wed: { open: '09:00', close: '18:00', closed: false },
+            thu: { open: '09:00', close: '18:00', closed: false },
+            fri: { open: '09:00', close: '18:00', closed: false },
+            sat: { open: '10:00', close: '15:00', closed: false },
+            sun: { closed: true },
+          },
+        }),
+      );
+      this.logger.log('Seeded default HubSettings record.');
+    }
+  }
+
+  /** Returns the singleton settings row. */
+  async getSettings(): Promise<HubSettings> {
+    const settings = await this.repo.findOne({ where: {} });
+    if (!settings) {
+      // Fallback: recreate if somehow missing
+      await this.onModuleInit();
+      return this.repo.findOne({ where: {} });
+    }
+    return settings;
+  }
+
+  /** Partial update — validates IANA timezone if provided. */
+  async updateSettings(dto: UpdateHubSettingsDto): Promise<HubSettings> {
+    if (dto.timezone) {
+      this.validateTimezone(dto.timezone);
+    }
+
+    const settings = await this.getSettings();
+    Object.assign(settings, dto);
+    return this.repo.save(settings);
+  }
+
+  private validateTimezone(tz: string): void {
+    try {
+      // Intl.supportedValuesOf is available in Node 20+
+      const supported: string[] = (Intl as any).supportedValuesOf('timeZone');
+      if (!supported.includes(tz)) {
+        throw new BadRequestException(`"${tz}" is not a valid IANA timezone`);
+      }
+    } catch (err) {
+      if (err instanceof BadRequestException) throw err;
+      // Fallback: attempt to create a formatter — throws RangeError for invalid tz
+      try {
+        Intl.DateTimeFormat(undefined, { timeZone: tz });
+      } catch {
+        throw new BadRequestException(`"${tz}" is not a valid IANA timezone`);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Rebuilds the deleted `backend/src/hub-settings/` module from scratch as a singleton-entity pattern with startup seeding, IANA timezone validation, and two endpoints.

## Files Created

| File | Description |
|------|-------------|
| `hub-settings/entities/hub-settings.entity.ts` | Full entity: branding, business hours (JSONB), booking rules, VAT, timezone |
| `hub-settings/dto/update-hub-settings.dto.ts` | Partial update DTO with `@IsHexColor`, `@IsUrl`, `@IsEmail`, etc. |
| `hub-settings/hub-settings.service.ts` | `OnModuleInit` seeds default row if table empty; `updateSettings` validates IANA timezone via `Intl.supportedValuesOf` with `Intl.DateTimeFormat` fallback |
| `hub-settings/hub-settings.controller.ts` | GET (public) + PATCH (super_admin) |
| `hub-settings/hub-settings.module.ts` | Module wiring; exports `HubSettingsService` |

## Files Modified
- `backend/src/app.module.ts` — registers `HubSettingsModule`

## Endpoints

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | /hub-settings | Public | Returns all settings — needed for white-labeling (FE-38) on every page load |
| PATCH | /hub-settings | super_admin | Partial update; validates `timezone` against IANA list |

## Notes
- Singleton pattern: `onModuleInit` runs once; if `hub_settings` table is empty it inserts the default record (Africa/Lagos, NGN, 7.5% VAT, standard business hours)
- `synchronize: true` auto-creates the table
- `HubSettingsService` is exported for use by `InvoicesModule` (VAT) and `BookingsModule` (lead time, cancellation policy)

closes #1292