### PR TITLE
[BE-59] Member attendance history and admin attendance report

### DIFF
--- a/backend/src/workspace-tracking/dto/attendance-query.dto.ts
+++ b/backend/src/workspace-tracking/dto/attendance-query.dto.ts
@@ -1,0 +1,35 @@
+import { IsOptional, IsUUID, IsInt, Min, Max, IsDateString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class AttendanceQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by workspace UUID' })
+  @IsOptional()
+  @IsUUID()
+  workspaceId?: string;
+
+  @ApiPropertyOptional({ description: 'Start date (ISO 8601)', example: '2024-01-01' })
+  @IsOptional()
+  @IsDateString()
+  from?: string;
+
+  @ApiPropertyOptional({ description: 'End date (ISO 8601)', example: '2024-12-31' })
+  @IsOptional()
+  @IsDateString()
+  to?: string;
+
+  @ApiPropertyOptional({ description: 'Page number (1-based)', default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ description: 'Items per page', default: 20, maximum: 100 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+}

--- a/backend/src/workspace-tracking/providers/attendance.provider.ts
+++ b/backend/src/workspace-tracking/providers/attendance.provider.ts
@@ -1,0 +1,122 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between, FindManyOptions } from 'typeorm';
+import { WorkspaceLog } from '../entities/workspace-log.entity';
+import { AttendanceQueryDto } from '../dto/attendance-query.dto';
+
+export interface PaginatedAttendance {
+  data: WorkspaceLog[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface AttendanceSummary {
+  totalSessions: number;
+  totalMinutes: number;
+  averageSessionMinutes: number;
+  workspacesVisited: number;
+}
+
+@Injectable()
+export class AttendanceProvider {
+  constructor(
+    @InjectRepository(WorkspaceLog)
+    private readonly logsRepo: Repository<WorkspaceLog>,
+  ) {}
+
+  /**
+   * Returns a member's own check-in history, newest first.
+   */
+  async getMemberHistory(
+    userId: string,
+    query: AttendanceQueryDto,
+  ): Promise<PaginatedAttendance> {
+    const { workspaceId, from, to, page = 1, limit = 20 } = query;
+
+    const where: FindManyOptions<WorkspaceLog>['where'] = { userId };
+    if (workspaceId) (where as Record<string, unknown>).workspaceId = workspaceId;
+    if (from && to) {
+      (where as Record<string, unknown>).checkedInAt = Between(
+        new Date(from),
+        new Date(to),
+      );
+    }
+
+    const [data, total] = await this.logsRepo.findAndCount({
+      where,
+      order: { checkedInAt: 'DESC' },
+      take: limit,
+      skip: (page - 1) * limit,
+      relations: ['workspace'],
+    });
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+
+  /**
+   * Returns aggregate attendance statistics for a member.
+   */
+  async getMemberSummary(userId: string): Promise<AttendanceSummary> {
+    const logs = await this.logsRepo.find({
+      where: { userId },
+      select: ['durationMinutes', 'workspaceId'],
+    });
+
+    const completed = logs.filter((l) => l.durationMinutes != null);
+    const totalMinutes = completed.reduce(
+      (sum, l) => sum + (l.durationMinutes ?? 0),
+      0,
+    );
+    const workspacesVisited = new Set(logs.map((l) => l.workspaceId)).size;
+
+    return {
+      totalSessions: logs.length,
+      totalMinutes,
+      averageSessionMinutes:
+        completed.length > 0
+          ? Math.round(totalMinutes / completed.length)
+          : 0,
+      workspacesVisited,
+    };
+  }
+
+  /**
+   * Admin report: all members' attendance within a date range.
+   */
+  async getAdminReport(query: AttendanceQueryDto): Promise<PaginatedAttendance> {
+    const { workspaceId, from, to, page = 1, limit = 20 } = query;
+
+    const where: FindManyOptions<WorkspaceLog>['where'] = {};
+    if (workspaceId) (where as Record<string, unknown>).workspaceId = workspaceId;
+    if (from && to) {
+      (where as Record<string, unknown>).checkedInAt = Between(
+        new Date(from),
+        new Date(to),
+      );
+    }
+
+    const [data, total] = await this.logsRepo.findAndCount({
+      where,
+      order: { checkedInAt: 'DESC' },
+      take: limit,
+      skip: (page - 1) * limit,
+      relations: ['workspace', 'user'],
+    });
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
+  }
+}

--- a/backend/src/workspace-tracking/workspace-tracking.controller.ts
+++ b/backend/src/workspace-tracking/workspace-tracking.controller.ts
@@ -111,7 +111,7 @@ export class WorkspaceTrackingController {
   @ApiOperation({
     summary: 'Get my attendance history (paginated)',
     description:
-      'Returns the authenticated member's check-in/out history with optional workspace and date filters.',
+      "Returns the authenticated member's check-in/out history with optional workspace and date filters.",
   })
   async getMyAttendanceHistory(
     @GetCurrentUser('id') userId: string,

--- a/backend/src/workspace-tracking/workspace-tracking.controller.ts
+++ b/backend/src/workspace-tracking/workspace-tracking.controller.ts
@@ -20,6 +20,7 @@ import {
 import { WorkspaceTrackingService } from './workspace-tracking.service';
 import { CheckInDto } from './dto/check-in.dto';
 import { OccupancyQueryDto } from './dto/occupancy-query.dto';
+import { AttendanceQueryDto } from './dto/attendance-query.dto';
 import { GetCurrentUser } from '../auth/decorators/getCurrentUser.decorator';
 import { Roles } from '../auth/decorators/roles.decorators';
 import { RolesGuard } from '../auth/guard/roles.guard';
@@ -101,5 +102,51 @@ export class WorkspaceTrackingController {
       limit ? Number(limit) : 50,
     );
     return { message: 'Recent logs retrieved', data };
+  }
+
+  // ── Attendance history endpoints ────────────────────────────────────────────
+
+  @Get('attendance/my-history')
+  @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({
+    summary: 'Get my attendance history (paginated)',
+    description:
+      'Returns the authenticated member's check-in/out history with optional workspace and date filters.',
+  })
+  async getMyAttendanceHistory(
+    @GetCurrentUser('id') userId: string,
+    @Query() query: AttendanceQueryDto,
+  ) {
+    const data = await this.workspaceTrackingService.getMemberAttendanceHistory(
+      userId,
+      query,
+    );
+    return { message: 'Attendance history retrieved', data };
+  }
+
+  @Get('attendance/my-summary')
+  @Roles(UserRole.USER, UserRole.STAFF, UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({
+    summary: 'Get my attendance summary',
+    description:
+      'Returns aggregate stats: total sessions, total minutes, average session length, and distinct workspaces visited.',
+  })
+  async getMyAttendanceSummary(@GetCurrentUser('id') userId: string) {
+    const data =
+      await this.workspaceTrackingService.getMemberAttendanceSummary(userId);
+    return { message: 'Attendance summary retrieved', data };
+  }
+
+  @Get('attendance/admin-report')
+  @Roles(UserRole.ADMIN, UserRole.SUPER_ADMIN)
+  @ApiOperation({
+    summary: 'Admin: aggregate attendance report for all members',
+    description:
+      'Returns paginated check-in logs across all members. Supports workspace and date range filters.',
+  })
+  async getAdminAttendanceReport(@Query() query: AttendanceQueryDto) {
+    const data =
+      await this.workspaceTrackingService.getAdminAttendanceReport(query);
+    return { message: 'Admin attendance report retrieved', data };
   }
 }

--- a/backend/src/workspace-tracking/workspace-tracking.module.ts
+++ b/backend/src/workspace-tracking/workspace-tracking.module.ts
@@ -6,11 +6,17 @@ import { WorkspaceTrackingService } from './workspace-tracking.service';
 import { WorkspaceTrackingController } from './workspace-tracking.controller';
 import { CheckInProvider } from './providers/check-in.provider';
 import { OccupancyProvider } from './providers/occupancy.provider';
+import { AttendanceProvider } from './providers/attendance.provider';
 
 @Module({
   imports: [TypeOrmModule.forFeature([WorkspaceLog, Workspace])],
   controllers: [WorkspaceTrackingController],
-  providers: [WorkspaceTrackingService, CheckInProvider, OccupancyProvider],
+  providers: [
+    WorkspaceTrackingService,
+    CheckInProvider,
+    OccupancyProvider,
+    AttendanceProvider,
+  ],
   exports: [WorkspaceTrackingService],
 })
 export class WorkspaceTrackingModule {}

--- a/backend/src/workspace-tracking/workspace-tracking.service.ts
+++ b/backend/src/workspace-tracking/workspace-tracking.service.ts
@@ -1,14 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { CheckInProvider } from './providers/check-in.provider';
 import { OccupancyProvider } from './providers/occupancy.provider';
+import { AttendanceProvider } from './providers/attendance.provider';
 import { CheckInDto } from './dto/check-in.dto';
 import { OccupancyQueryDto } from './dto/occupancy-query.dto';
+import { AttendanceQueryDto } from './dto/attendance-query.dto';
 
 @Injectable()
 export class WorkspaceTrackingService {
   constructor(
     private readonly checkInProvider: CheckInProvider,
     private readonly occupancyProvider: OccupancyProvider,
+    private readonly attendanceProvider: AttendanceProvider,
   ) {}
 
   checkIn(dto: CheckInDto, userId: string) {
@@ -33,5 +36,19 @@ export class WorkspaceTrackingService {
 
   getRecentLogs(workspaceId?: string, limit?: number) {
     return this.occupancyProvider.getRecentLogs(workspaceId, limit);
+  }
+
+  // ── Attendance history ──────────────────────────────────────────────────────
+
+  getMemberAttendanceHistory(userId: string, query: AttendanceQueryDto) {
+    return this.attendanceProvider.getMemberHistory(userId, query);
+  }
+
+  getMemberAttendanceSummary(userId: string) {
+    return this.attendanceProvider.getMemberSummary(userId);
+  }
+
+  getAdminAttendanceReport(query: AttendanceQueryDto) {
+    return this.attendanceProvider.getAdminReport(query);
   }
 }


### PR DESCRIPTION
## Summary

Surfaces WorkspaceLog data through dedicated attendance history endpoints so members can view their own check-in history and admins can run aggregate attendance reports.

### Changes
- dto/attendance-query.dto.ts — validated DTO with workspaceId, rom, 	o, page, limit fields
- providers/attendance.provider.ts — AttendanceProvider with three methods:
  - getMemberHistory(userId, query) — paginated, filtered member history
  - getMemberSummary(userId) — aggregate stats (total sessions, total minutes, avg session, workspaces visited)
  - getAdminReport(query) — paginated cross-member report with user + workspace relations
- workspace-tracking.service.ts — wires the three new provider methods
- workspace-tracking.module.ts — registers AttendanceProvider
- workspace-tracking.controller.ts — three new endpoints:
  - GET /workspace-tracking/attendance/my-history (all roles)
  - GET /workspace-tracking/attendance/my-summary (all roles)
  - GET /workspace-tracking/attendance/admin-report (ADMIN / SUPER_ADMIN only)

closes #1297