### PR TITLE
feat(jobs): auto-cancel PENDING bookings that outlive their payment TTL

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,3 +52,7 @@ EMAIL_RATE_LIMIT_PER_HOUR=100
 SENDGRID_WEBHOOK_SECRET=your_sendgrid_webhook_secret
 MAILGUN_WEBHOOK_SECRET=your_mailgun_webhook_secret
 SES_SNS_TOPIC_ARN=your_ses_sns_topic_arn
+
+# Scheduled Jobs
+# Minutes a PENDING booking may wait for payment before it is auto-cancelled
+BOOKING_PAYMENT_TTL_MINUTES=120

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { HubSettingsModule } from './hub-settings/hub-settings.module';
 import { MembershipPlansModule } from './membership-plans/membership-plans.module';
 import { ParkingModule } from './parking/parking.module';
 import { VisitorsModule } from './visitors/visitors.module';
+import { JobsModule } from './jobs/jobs.module';
 
 @Module({
   imports: [
@@ -92,6 +93,7 @@ import { VisitorsModule } from './visitors/visitors.module';
     MembershipPlansModule,
     ParkingModule,
     VisitorsModule,
+    JobsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/jobs/jobs.module.ts
+++ b/backend/src/jobs/jobs.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Booking } from '../bookings/entities/booking.entity';
+import { Payment } from '../payments/entities/payment.entity';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { ExpirePendingBookingsProvider } from './providers/expire-pending-bookings.provider';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Booking, Payment]), NotificationsModule],
+  providers: [ExpirePendingBookingsProvider],
+})
+export class JobsModule {}

--- a/backend/src/jobs/providers/expire-pending-bookings.provider.spec.ts
+++ b/backend/src/jobs/providers/expire-pending-bookings.provider.spec.ts
@@ -1,0 +1,132 @@
+import { ConfigService } from '@nestjs/config';
+import { ExpirePendingBookingsProvider } from './expire-pending-bookings.provider';
+import { BookingStatus } from '../../bookings/enums/booking-status.enum';
+import { NotificationType } from '../../notifications/enums/notification-type.enum';
+
+function buildQueryBuilder(result: unknown[]) {
+  const qb: Record<string, jest.Mock> = {};
+  qb.leftJoinAndSelect = jest.fn().mockReturnValue(qb);
+  qb.where = jest.fn().mockReturnValue(qb);
+  qb.andWhere = jest.fn((condition) => {
+    if (typeof condition === 'function') {
+      condition(qb);
+    }
+    return qb;
+  });
+  qb.subQuery = jest.fn().mockReturnValue(qb);
+  qb.select = jest.fn().mockReturnValue(qb);
+  qb.from = jest.fn().mockReturnValue(qb);
+  qb.getQuery = jest.fn().mockReturnValue('SELECT 1');
+  qb.setParameter = jest.fn().mockReturnValue(qb);
+  qb.getMany = jest.fn().mockResolvedValue(result);
+  return qb;
+}
+
+describe('ExpirePendingBookingsProvider', () => {
+  const buildProvider = (bookings: unknown[], ttlEnv?: string) => {
+    const bookingsRepository = {
+      createQueryBuilder: jest
+        .fn()
+        .mockReturnValue(buildQueryBuilder(bookings)),
+      save: jest.fn().mockImplementation((booking) => Promise.resolve(booking)),
+    };
+    const configService = {
+      get: jest.fn().mockReturnValue(ttlEnv),
+    } as unknown as ConfigService;
+    const notificationsService = {
+      create: jest.fn().mockResolvedValue(undefined),
+    };
+    const emailService = {
+      sendBookingCancelledEmail: jest.fn().mockResolvedValue(true),
+    };
+
+    const provider = new ExpirePendingBookingsProvider(
+      bookingsRepository as any,
+      configService,
+      notificationsService as any,
+      emailService as any,
+    );
+
+    return { provider, bookingsRepository, notificationsService, emailService };
+  };
+
+  it('cancels expired PENDING bookings and notifies the user by email and in-app', async () => {
+    const booking = {
+      id: 'booking-1',
+      userId: 'user-1',
+      status: BookingStatus.PENDING,
+      startDate: '2026-01-01',
+      endDate: '2026-01-02',
+      user: { email: 'user@example.com', fullName: 'Jane Doe' },
+      workspace: { name: 'Lagos Hub' },
+    };
+
+    const { provider, bookingsRepository, notificationsService, emailService } =
+      buildProvider([booking]);
+
+    await provider.handleExpirePendingBookings();
+
+    expect(booking.status).toBe(BookingStatus.CANCELLED);
+    expect(bookingsRepository.save).toHaveBeenCalledWith(booking);
+    expect(notificationsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        type: NotificationType.BOOKING_CANCELLED,
+      }),
+    );
+    expect(emailService.sendBookingCancelledEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      'Jane Doe',
+      expect.objectContaining({ bookingId: 'booking-1' }),
+    );
+  });
+
+  it('does nothing when there are no expired bookings', async () => {
+    const { provider, bookingsRepository, notificationsService, emailService } =
+      buildProvider([]);
+
+    await provider.handleExpirePendingBookings();
+
+    expect(bookingsRepository.save).not.toHaveBeenCalled();
+    expect(notificationsService.create).not.toHaveBeenCalled();
+    expect(emailService.sendBookingCancelledEmail).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the default TTL when the env var is unset', async () => {
+    const { provider, bookingsRepository } = buildProvider([], undefined);
+
+    await provider.handleExpirePendingBookings();
+
+    expect(bookingsRepository.createQueryBuilder).toHaveBeenCalledWith(
+      'booking',
+    );
+  });
+
+  it('keeps going and logs an error if expiring one booking fails', async () => {
+    const failing = {
+      id: 'booking-fail',
+      userId: 'user-1',
+      status: BookingStatus.PENDING,
+      user: { email: 'a@example.com', fullName: 'A' },
+      workspace: { name: 'Hub' },
+    };
+    const ok = {
+      id: 'booking-ok',
+      userId: 'user-2',
+      status: BookingStatus.PENDING,
+      user: { email: 'b@example.com', fullName: 'B' },
+      workspace: { name: 'Hub' },
+    };
+
+    const { provider, bookingsRepository, notificationsService } =
+      buildProvider([failing, ok]);
+    bookingsRepository.save
+      .mockRejectedValueOnce(new Error('db down'))
+      .mockImplementationOnce((booking) => Promise.resolve(booking));
+
+    await provider.handleExpirePendingBookings();
+
+    expect(ok.status).toBe(BookingStatus.CANCELLED);
+    expect(notificationsService.create).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/jobs/providers/expire-pending-bookings.provider.ts
+++ b/backend/src/jobs/providers/expire-pending-bookings.provider.ts
@@ -1,0 +1,123 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Repository } from 'typeorm';
+import { Booking } from '../../bookings/entities/booking.entity';
+import { BookingStatus } from '../../bookings/enums/booking-status.enum';
+import { Payment } from '../../payments/entities/payment.entity';
+import { PaymentStatus } from '../../payments/enums/payment-status.enum';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { NotificationType } from '../../notifications/enums/notification-type.enum';
+import { EmailService } from '../../email/email.service';
+
+const DEFAULT_TTL_MINUTES = 120;
+
+/**
+ * Automatically cancels PENDING bookings whose payment window has expired,
+ * so their seats are released back to the availability pool.
+ *
+ * A booking is left alone if a PENDING payment attempt was created for it
+ * within the TTL window, since the user may still be mid-checkout.
+ */
+@Injectable()
+export class ExpirePendingBookingsProvider {
+  private readonly logger = new Logger(ExpirePendingBookingsProvider.name);
+
+  constructor(
+    @InjectRepository(Booking)
+    private readonly bookingsRepository: Repository<Booking>,
+    private readonly configService: ConfigService,
+    private readonly notificationsService: NotificationsService,
+    private readonly emailService: EmailService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_10_MINUTES)
+  async handleExpirePendingBookings(): Promise<void> {
+    const ttlMinutes = this.getTtlMinutes();
+    const cutoff = new Date(Date.now() - ttlMinutes * 60 * 1000);
+
+    const candidates = await this.findExpiredBookings(cutoff);
+    let expiredCount = 0;
+
+    for (const booking of candidates) {
+      try {
+        await this.expireBooking(booking);
+        expiredCount += 1;
+      } catch (error) {
+        this.logger.error(
+          `Failed to expire booking "${booking.id}": ${(error as Error).message}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Booking expiry run complete: ${expiredCount}/${candidates.length} PENDING booking(s) past the ${ttlMinutes}m TTL were cancelled.`,
+    );
+  }
+
+  private getTtlMinutes(): number {
+    const raw = this.configService.get<string>('BOOKING_PAYMENT_TTL_MINUTES');
+    const parsed = parseInt(raw ?? '', 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TTL_MINUTES;
+  }
+
+  private async findExpiredBookings(cutoff: Date): Promise<Booking[]> {
+    return this.bookingsRepository
+      .createQueryBuilder('booking')
+      .leftJoinAndSelect('booking.user', 'user')
+      .leftJoinAndSelect('booking.workspace', 'workspace')
+      .where('booking.status = :status', { status: BookingStatus.PENDING })
+      .andWhere('booking.createdAt < :cutoff', { cutoff })
+      .andWhere((qb) => {
+        const subQuery = qb
+          .subQuery()
+          .select('1')
+          .from(Payment, 'payment')
+          .where('payment.bookingId = booking.id')
+          .andWhere('payment.status = :paymentStatus')
+          .andWhere('payment.createdAt >= :cutoff')
+          .getQuery();
+        return `NOT EXISTS (${subQuery})`;
+      })
+      .setParameter('paymentStatus', PaymentStatus.PENDING)
+      .getMany();
+  }
+
+  private async expireBooking(booking: Booking): Promise<void> {
+    booking.status = BookingStatus.CANCELLED;
+    await this.bookingsRepository.save(booking);
+
+    if (!booking.userId || !booking.user) {
+      return;
+    }
+
+    const workspaceName = booking.workspace?.name ?? 'the requested workspace';
+
+    await this.notificationsService.create({
+      userId: booking.userId,
+      type: NotificationType.BOOKING_CANCELLED,
+      title: 'Booking Expired',
+      message: `Your booking for ${workspaceName} was cancelled because payment was not completed in time.`,
+      metadata: { bookingId: booking.id, reason: 'payment_ttl_expired' },
+    });
+
+    try {
+      await this.emailService.sendBookingCancelledEmail(
+        booking.user.email,
+        booking.user.fullName,
+        {
+          bookingId: booking.id,
+          workspaceName,
+          startDate: booking.startDate,
+          endDate: booking.endDate,
+          cancelledBy: 'System (payment not received in time)',
+        },
+      );
+    } catch (error) {
+      this.logger.warn(
+        `Failed to send cancellation email for booking "${booking.id}": ${(error as Error).message}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
Bookings created with status PENDING only became CONFIRMED via the Paystack webhook, but never got cleaned up if the user abandoned checkout — and since the booking-conflict query counts PENDING bookings, they permanently blocked seats for other members.

Adds a JobsModule with an ExpirePendingBookingsProvider that runs every 10 minutes (@Cron), cancels PENDING bookings older than BOOKING_PAYMENT_TTL_MINUTES (default 120, configurable via env) that have no recent PENDING payment attempt, and notifies the affected user via NotificationsService + the existing booking-cancelled email template. Logs a per-run summary of how many bookings were expired.

Reuses the existing CANCELLED status rather than introducing a new EXPIRED one, to avoid an enum/schema migration for this first pass — open to revisiting in review if a distinct status is preferred.

closes #1329 