### PR TITLE
feat(jobs): auto-complete bookings whose end date has passed [BE-04]

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { HubSettingsModule } from './hub-settings/hub-settings.module';
 import { MembershipPlansModule } from './membership-plans/membership-plans.module';
 import { ParkingModule } from './parking/parking.module';
 import { VisitorsModule } from './visitors/visitors.module';
+import { JobsModule } from './jobs/jobs.module';
 
 @Module({
   imports: [
@@ -92,6 +93,7 @@ import { VisitorsModule } from './visitors/visitors.module';
     MembershipPlansModule,
     ParkingModule,
     VisitorsModule,
+    JobsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/jobs/auto-complete-bookings.job.spec.ts
+++ b/backend/src/jobs/auto-complete-bookings.job.spec.ts
@@ -1,0 +1,121 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AutoCompleteBookingsJob } from './auto-complete-bookings.job';
+import { Booking } from '../bookings/entities/booking.entity';
+import { BookingStatus } from '../bookings/enums/booking-status.enum';
+import { CompleteBookingProvider } from '../bookings/providers/complete-booking.provider';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/enums/notification-type.enum';
+
+const mockBookingsRepository = {
+  find: jest.fn(),
+};
+
+const mockCompleteBookingProvider = {
+  complete: jest.fn(),
+};
+
+const mockNotificationsService = {
+  create: jest.fn(),
+};
+
+describe('AutoCompleteBookingsJob', () => {
+  let job: AutoCompleteBookingsJob;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AutoCompleteBookingsJob,
+        { provide: getRepositoryToken(Booking), useValue: mockBookingsRepository },
+        { provide: CompleteBookingProvider, useValue: mockCompleteBookingProvider },
+        { provide: NotificationsService, useValue: mockNotificationsService },
+      ],
+    }).compile();
+
+    job = module.get<AutoCompleteBookingsJob>(AutoCompleteBookingsJob);
+  });
+
+  it('should be defined', () => {
+    expect(job).toBeDefined();
+  });
+
+  it('should do nothing when no expired bookings exist', async () => {
+    mockBookingsRepository.find.mockResolvedValue([]);
+    await job.completeExpiredBookings();
+    expect(mockCompleteBookingProvider.complete).not.toHaveBeenCalled();
+    expect(mockNotificationsService.create).not.toHaveBeenCalled();
+  });
+
+  it('should complete expired bookings and send notifications', async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+    const expiredBooking: Partial<Booking> = {
+      id: 'booking-1',
+      userId: 'user-1',
+      workspaceId: 'ws-1',
+      status: BookingStatus.CONFIRMED,
+      endDate: yesterday,
+    };
+
+    mockBookingsRepository.find.mockResolvedValue([expiredBooking]);
+    mockCompleteBookingProvider.complete.mockResolvedValue({
+      ...expiredBooking,
+      status: BookingStatus.COMPLETED,
+    });
+    mockNotificationsService.create.mockResolvedValue({});
+
+    await job.completeExpiredBookings();
+
+    expect(mockCompleteBookingProvider.complete).toHaveBeenCalledWith('booking-1');
+    expect(mockNotificationsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        type: NotificationType.BOOKING_COMPLETED,
+        metadata: expect.objectContaining({ bookingId: 'booking-1' }),
+      }),
+    );
+  });
+
+  it('should skip notification for guest bookings (null userId)', async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+    const guestBooking: Partial<Booking> = {
+      id: 'booking-guest',
+      userId: null,
+      workspaceId: 'ws-1',
+      status: BookingStatus.CONFIRMED,
+      endDate: yesterday,
+      isGuestBooking: true,
+    };
+
+    mockBookingsRepository.find.mockResolvedValue([guestBooking]);
+    mockCompleteBookingProvider.complete.mockResolvedValue({});
+
+    await job.completeExpiredBookings();
+
+    expect(mockCompleteBookingProvider.complete).toHaveBeenCalledWith('booking-guest');
+    expect(mockNotificationsService.create).not.toHaveBeenCalled();
+  });
+
+  it('should continue processing remaining bookings when one fails', async () => {
+    const yesterday = new Date(Date.now() - 86400000).toISOString().split('T')[0];
+    const bookings: Partial<Booking>[] = [
+      { id: 'booking-fail', userId: 'user-1', workspaceId: 'ws-1', status: BookingStatus.CONFIRMED, endDate: yesterday },
+      { id: 'booking-ok', userId: 'user-2', workspaceId: 'ws-1', status: BookingStatus.CONFIRMED, endDate: yesterday },
+    ];
+
+    mockBookingsRepository.find.mockResolvedValue(bookings);
+    mockCompleteBookingProvider.complete
+      .mockRejectedValueOnce(new Error('DB error'))
+      .mockResolvedValueOnce({});
+    mockNotificationsService.create.mockResolvedValue({});
+
+    await job.completeExpiredBookings();
+
+    expect(mockCompleteBookingProvider.complete).toHaveBeenCalledTimes(2);
+    // Only the successful one should have a notification
+    expect(mockNotificationsService.create).toHaveBeenCalledTimes(1);
+    expect(mockNotificationsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'user-2' }),
+    );
+  });
+});

--- a/backend/src/jobs/auto-complete-bookings.job.ts
+++ b/backend/src/jobs/auto-complete-bookings.job.ts
@@ -1,0 +1,81 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { LessThan, Repository } from 'typeorm';
+import { Booking } from '../../bookings/entities/booking.entity';
+import { BookingStatus } from '../../bookings/enums/booking-status.enum';
+import { CompleteBookingProvider } from '../../bookings/providers/complete-booking.provider';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { NotificationType } from '../../notifications/enums/notification-type.enum';
+
+@Injectable()
+export class AutoCompleteBookingsJob {
+  private readonly logger = new Logger(AutoCompleteBookingsJob.name);
+
+  constructor(
+    @InjectRepository(Booking)
+    private readonly bookingsRepository: Repository<Booking>,
+    private readonly completeBookingProvider: CompleteBookingProvider,
+    private readonly notificationsService: NotificationsService,
+  ) {}
+
+  /**
+   * Runs daily at 01:00 UTC.
+   * Finds all CONFIRMED bookings whose endDate has passed and marks them
+   * COMPLETED by delegating to CompleteBookingProvider — no logic duplication.
+   */
+  @Cron('0 1 * * *')
+  async completeExpiredBookings(): Promise<void> {
+    const today = new Date().toISOString().split('T')[0]; // 'YYYY-MM-DD'
+
+    const expiredBookings = await this.bookingsRepository.find({
+      where: {
+        status: BookingStatus.CONFIRMED,
+        endDate: LessThan(today) as any,
+      },
+    });
+
+    if (expiredBookings.length === 0) {
+      this.logger.log('AutoCompleteBookingsJob: no expired bookings found');
+      return;
+    }
+
+    this.logger.log(
+      `AutoCompleteBookingsJob: found ${expiredBookings.length} expired booking(s) to complete`,
+    );
+
+    let completed = 0;
+
+    for (const booking of expiredBookings) {
+      try {
+        // Reuse the existing provider — no logic duplication
+        await this.completeBookingProvider.complete(booking.id);
+
+        // Send booking_completed notification to the booking owner
+        if (booking.userId) {
+          await this.notificationsService.create({
+            userId: booking.userId,
+            type: NotificationType.BOOKING_COMPLETED,
+            title: 'Booking completed',
+            message: `Your booking (${booking.id}) has been automatically completed as the end date has passed.`,
+            metadata: {
+              bookingId: booking.id,
+              workspaceId: booking.workspaceId,
+              endDate: booking.endDate,
+            },
+          });
+        }
+
+        completed++;
+      } catch (err) {
+        this.logger.error(
+          `AutoCompleteBookingsJob: failed to complete booking ${booking.id}: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `AutoCompleteBookingsJob: completed ${completed}/${expiredBookings.length} booking(s)`,
+    );
+  }
+}

--- a/backend/src/jobs/jobs.module.ts
+++ b/backend/src/jobs/jobs.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Booking } from '../bookings/entities/booking.entity';
+import { WorkspaceLog } from '../workspace-tracking/entities/workspace-log.entity';
+import { BookingsModule } from '../bookings/bookings.module';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { AutoCompleteBookingsJob } from './auto-complete-bookings.job';
+
+/**
+ * Shared background-jobs module (BE-03).
+ *
+ * Register all scheduled jobs here. Each job is an @Injectable() that
+ * uses @Cron() decorators from @nestjs/schedule — no additional setup
+ * required beyond importing this module in AppModule.
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Booking, WorkspaceLog]),
+    BookingsModule,
+    NotificationsModule,
+  ],
+  providers: [AutoCompleteBookingsJob],
+})
+export class JobsModule {}


### PR DESCRIPTION
## Summary

Implements the daily background job that automatically completes bookings whose end date has passed, as described in the issue.

## Changes

### New: ackend/src/jobs/ (shared jobs module - BE-03)

- **jobs.module.ts** - Shared JobsModule that wires background job providers. This creates the BE-03 shared module so other job PRs can register jobs here.
- **uto-complete-bookings.job.ts** - AutoCompleteBookingsJob service with a @Cron('0 1 * * *') handler (daily at 01:00 UTC) that:
  1. Queries Booking rows with status = CONFIRMED and endDate < today.
  2. Delegates to CompleteBookingProvider.complete() for each - no logic duplication.
  3. Sends a BOOKING_COMPLETED notification to the booking owner via NotificationsService.create().
  4. Skips notification for guest bookings (userId = null).
  5. Catches per-booking errors and continues processing remaining bookings, logging failures.
  6. Logs a per-run summary count.
- **uto-complete-bookings.job.spec.ts** - Unit tests covering: no-op when no expired bookings, complete + notify on expired bookings, skip notification for guest bookings, continue processing remaining bookings when one fails.

### Updated files

- **ackend/src/app.module.ts** - Adds JobsModule to imports.

## Acceptance Criteria

- [x] CONFIRMED bookings with a past endDate are COMPLETED automatically within 24h (runs daily at 01:00 UTC)
- [x] The booking owner receives a BOOKING_COMPLETED notification
- [x] Manually completing a booking via the admin endpoint still works unchanged (CompleteBookingProvider is untouched)

closes #1330