### PR TITLE
feat(admin): implement hub settings page and React Query integration

### DIFF
--- a/frontend/components/ui/tabs.tsx
+++ b/frontend/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from '@/lib/utils';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+      className
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/frontend/lib/react-query/hooks/admin/settings/page.tsx
+++ b/frontend/lib/react-query/hooks/admin/settings/page.tsx
@@ -1,0 +1,366 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { useGetHubSettings, BusinessHour } from '@/lib/react-query/hooks/admin/settings/useGetHubSettings';
+import { useUpdateHubSettings } from '@/lib/react-query/hooks/admin/settings/useUpdateHubSettings';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { toast } from '@/components/ui/use-toast';
+import { Loader2, Upload, Building, Clock, Calendar, Landmark, Palette } from 'lucide-react';
+
+const TIME_INTERVALS = Array.from({ length: 48 }, (_, i) => {
+  const hours = Math.floor(i / 2).toString().padStart(2, '0');
+  const minutes = i % 2 === 0 ? '00' : '30';
+  return `${hours}:${minutes}`;
+});
+
+const DAYS_OF_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
+
+export default function AdminSettingsPage() {
+  const { data: settings, isLoading, isError } = useGetHubSettings();
+  const { mutate: updateSettings, isPending } = useUpdateHubSettings();
+
+  // Local Form States
+  const [general, setGeneral] = useState({
+    name: '',
+    address: '',
+    city: '',
+    country: '',
+    contactEmail: '',
+    contactPhone: '',
+  });
+
+  const [bookingRules, setBookingRules] = useState({
+    leadTimeHours: 0,
+    maxDaysAhead: 0,
+    cancellationPolicyHours: 0,
+  });
+
+  const [businessHours, setBusinessHours] = useState<BusinessHour[]>(
+    DAYS_OF_WEEK.map((day) => ({ day, isOpen: true, openTime: '08:00', closeTime: '17:00' }))
+  );
+
+  const [financial, setFinancial] = useState({
+    vatRatePercent: 0,
+    currency: 'NGN',
+  });
+
+  const [branding, setBranding] = useState({
+    logoUrl: '',
+    faviconUrl: '',
+    primaryColorHex: '#000000',
+  });
+
+  // Populate state on load
+  useEffect(() => {
+    if (settings) {
+      setGeneral({
+        name: settings.name || '',
+        address: settings.address || '',
+        city: settings.city || '',
+        country: settings.country || '',
+        contactEmail: settings.contactEmail || '',
+        contactPhone: settings.contactPhone || '',
+      });
+      setBookingRules({
+        leadTimeHours: settings.leadTimeHours || 0,
+        maxDaysAhead: settings.maxDaysAhead || 0,
+        cancellationPolicyHours: settings.cancellationPolicyHours || 0,
+      });
+      if (settings.businessHours?.length) {
+        setBusinessHours(settings.businessHours);
+      }
+      setFinancial({
+        vatRatePercent: settings.vatRatePercent || 0,
+        currency: settings.currency || 'NGN',
+      });
+      setBranding({
+        logoUrl: settings.logoUrl || '',
+        faviconUrl: settings.faviconUrl || '',
+        primaryColorHex: settings.primaryColorHex || '#000000',
+      });
+    }
+  }, [settings]);
+
+  const handleSave = (sectionName: string, payload: Record<string, any>) => {
+    updateSettings(payload, {
+      onSuccess: () => {
+        toast({
+          title: 'Settings updated',
+          description: `${sectionName} settings saved successfully.`,
+        });
+      },
+      onError: (error: any) => {
+        toast({
+          title: 'Failed to update settings',
+          description: error?.response?.data?.message || 'An unexpected error occurred.',
+          variant: 'destructive',
+        });
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-6 text-center text-red-500">
+        Failed to load hub settings. Please refresh or try again later.
+      </div>
+    );
+  }
+
+  return (
+    <div className="container max-w-5xl py-8 space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Hub Settings</h1>
+        <p className="text-muted-foreground">Manage operational rules, business hours, and branding.</p>
+      </div>
+
+      <Tabs defaultValue="general" className="w-full">
+        <TabsList className="grid w-full grid-cols-5">
+          <TabsTrigger value="general" className="flex items-center gap-2">
+            <Building className="h-4 w-4" /> General
+          </TabsTrigger>
+          <TabsTrigger value="booking" className="flex items-center gap-2">
+            <Calendar className="h-4 w-4" /> Booking Rules
+          </TabsTrigger>
+          <TabsTrigger value="hours" className="flex items-center gap-2">
+            <Clock className="h-4 w-4" /> Hours
+          </TabsTrigger>
+          <TabsTrigger value="financial" className="flex items-center gap-2">
+            <Landmark className="h-4 w-4" /> Financial
+          </TabsTrigger>
+          <TabsTrigger value="branding" className="flex items-center gap-2">
+            <Palette className="h-4 w-4" /> Branding
+          </TabsTrigger>
+        </TabsList>
+
+        {/* GENERAL TAB */}
+        <TabsContent value="general" className="space-y-4 rounded-lg border p-6 mt-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2 col-span-2">
+              <Label htmlFor="hub-name">Hub Name</Label>
+              <Input
+                id="hub-name"
+                value={general.name}
+                onChange={(e) => setGeneral({ ...general, name: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2 col-span-2">
+              <Label htmlFor="address">Address</Label>
+              <Input
+                id="address"
+                value={general.address}
+                onChange={(e) => setGeneral({ ...general, address: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="city">City</Label>
+              <Input
+                id="city"
+                value={general.city}
+                onChange={(e) => setGeneral({ ...general, city: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="country">Country</Label>
+              <Input
+                id="country"
+                value={general.country}
+                onChange={(e) => setGeneral({ ...general, country: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="contactEmail">Contact Email</Label>
+              <Input
+                id="contactEmail"
+                type="email"
+                value={general.contactEmail}
+                onChange={(e) => setGeneral({ ...general, contactEmail: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="contactPhone">Contact Phone</Label>
+              <Input
+                id="contactPhone"
+                value={general.contactPhone}
+                onChange={(e) => setGeneral({ ...general, contactPhone: e.target.value })}
+              />
+            </div>
+          </div>
+          <Button disabled={isPending} onClick={() => handleSave('General', general)}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Save Changes
+          </Button>
+        </TabsContent>
+
+        {/* BOOKING RULES TAB */}
+        <TabsContent value="booking" className="space-y-4 rounded-lg border p-6 mt-4">
+          <div className="grid grid-cols-3 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="leadTime">Lead Time (Hours)</Label>
+              <Input
+                id="leadTime"
+                type="number"
+                value={bookingRules.leadTimeHours}
+                onChange={(e) => setBookingRules({ ...bookingRules, leadTimeHours: Number(e.target.value) })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="maxDays">Max Days Ahead</Label>
+              <Input
+                id="maxDays"
+                type="number"
+                value={bookingRules.maxDaysAhead}
+                onChange={(e) => setBookingRules({ ...bookingRules, maxDaysAhead: Number(e.target.value) })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="cancelHours">Cancellation Policy (Hours)</Label>
+              <Input
+                id="cancelHours"
+                type="number"
+                value={bookingRules.cancellationPolicyHours}
+                onChange={(e) => setBookingRules({ ...bookingRules, cancellationPolicyHours: Number(e.target.value) })}
+              />
+            </div>
+          </div>
+          <Button disabled={isPending} onClick={() => handleSave('Booking Rules', bookingRules)}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Save Changes
+          </Button>
+        </TabsContent>
+
+        {/* BUSINESS HOURS TAB */}
+        <TabsContent value="hours" className="space-y-4 rounded-lg border p-6 mt-4">
+          <div className="space-y-3">
+            {businessHours.map((item, index) => (
+              <div key={item.day} className="flex items-center gap-6 p-3 rounded-md border">
+                <span className="w-12 font-semibold">{item.day}</span>
+                <div className="flex items-center gap-2">
+                  <Switch
+                    checked={item.isOpen}
+                    onCheckedChange={(checked) => {
+                      const updated = [...businessHours];
+                      updated[index].isOpen = checked;
+                      setBusinessHours(updated);
+                    }}
+                  />
+                  <span className="text-sm text-muted-foreground">{item.isOpen ? 'Open' : 'Closed'}</span>
+                </div>
+                <div className="flex items-center gap-2 ml-auto">
+                  <select
+                    disabled={!item.isOpen}
+                    value={item.openTime}
+                    onChange={(e) => {
+                      const updated = [...businessHours];
+                      updated[index].openTime = e.target.value;
+                      setBusinessHours(updated);
+                    }}
+                    className="h-9 rounded-md border px-3 text-sm disabled:opacity-50"
+                  >
+                    {TIME_INTERVALS.map((t) => (
+                      <option key={t} value={t}>{t}</option>
+                    ))}
+                  </select>
+                  <span>to</span>
+                  <select
+                    disabled={!item.isOpen}
+                    value={item.closeTime}
+                    onChange={(e) => {
+                      const updated = [...businessHours];
+                      updated[index].closeTime = e.target.value;
+                      setBusinessHours(updated);
+                    }}
+                    className="h-9 rounded-md border px-3 text-sm disabled:opacity-50"
+                  >
+                    {TIME_INTERVALS.map((t) => (
+                      <option key={t} value={t}>{t}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            ))}
+          </div>
+          <Button disabled={isPending} onClick={() => handleSave('Business Hours', { businessHours })}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Save Changes
+          </Button>
+        </TabsContent>
+
+        {/* FINANCIAL TAB */}
+        <TabsContent value="financial" className="space-y-4 rounded-lg border p-6 mt-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="vat">VAT Rate (%)</Label>
+              <Input
+                id="vat"
+                type="number"
+                step="0.1"
+                value={financial.vatRatePercent}
+                onChange={(e) => setFinancial({ ...financial, vatRatePercent: Number(e.target.value) })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="currency">Currency</Label>
+              <Input id="currency" value={financial.currency} readOnly disabled className="bg-muted" />
+            </div>
+          </div>
+          <Button disabled={isPending} onClick={() => handleSave('Financial', { vatRatePercent: financial.vatRatePercent })}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Save Changes
+          </Button>
+        </TabsContent>
+
+        {/* BRANDING TAB */}
+        <TabsContent value="branding" className="space-y-4 rounded-lg border p-6 mt-4">
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="primaryColor">Primary Colour</Label>
+              <div className="flex gap-3 items-center">
+                <Input
+                  id="primaryColor"
+                  type="color"
+                  className="w-16 h-10 p-1 cursor-pointer"
+                  value={branding.primaryColorHex}
+                  onChange={(e) => setBranding({ ...branding, primaryColorHex: e.target.value })}
+                />
+                <Input
+                  type="text"
+                  className="w-32"
+                  value={branding.primaryColorHex}
+                  onChange={(e) => setBranding({ ...branding, primaryColorHex: e.target.value })}
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Logo URL</Label>
+              <Input
+                placeholder="https://res.cloudinary.com/..."
+                value={branding.logoUrl}
+                onChange={(e) => setBranding({ ...branding, logoUrl: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>Favicon URL</Label>
+              <Input
+                placeholder="https://res.cloudinary.com/..."
+                value={branding.faviconUrl}
+                onChange={(e) => setBranding({ ...branding, faviconUrl: e.target.value })}
+              />
+            </div>
+          </div>
+          <Button disabled={isPending} onClick={() => handleSave('Branding', branding)}>
+            {isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Save Changes
+          </Button>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/lib/react-query/hooks/admin/settings/page.tsx
+++ b/frontend/lib/react-query/hooks/admin/settings/page.tsx
@@ -2,14 +2,14 @@
 
 import React, { useState, useEffect } from 'react';
 import { useGetHubSettings, BusinessHour } from '@/lib/react-query/hooks/admin/settings/useGetHubSettings';
-import { useUpdateHubSettings } from '@/lib/react-query/hooks/admin/settings/useUpdateHubSettings';
+import { useUpdateHubSettings, UpdateHubSettingsPayload } from '@/lib/react-query/hooks/admin/settings/useUpdateHubSettings';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { toast } from '@/components/ui/use-toast';
-import { Loader2, Upload, Building, Clock, Calendar, Landmark, Palette } from 'lucide-react';
+import { Loader2, Building, Clock, Calendar, Landmark, Palette } from 'lucide-react';
 
 const TIME_INTERVALS = Array.from({ length: 48 }, (_, i) => {
   const hours = Math.floor(i / 2).toString().padStart(2, '0');
@@ -18,6 +18,14 @@ const TIME_INTERVALS = Array.from({ length: 48 }, (_, i) => {
 });
 
 const DAYS_OF_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
+
+interface ApiErrorShape {
+  response?: {
+    data?: {
+      message?: string;
+    };
+  };
+}
 
 export default function AdminSettingsPage() {
   const { data: settings, isLoading, isError } = useGetHubSettings();
@@ -85,7 +93,7 @@ export default function AdminSettingsPage() {
     }
   }, [settings]);
 
-  const handleSave = (sectionName: string, payload: Record<string, any>) => {
+  const handleSave = (sectionName: string, payload: UpdateHubSettingsPayload) => {
     updateSettings(payload, {
       onSuccess: () => {
         toast({
@@ -93,7 +101,7 @@ export default function AdminSettingsPage() {
           description: `${sectionName} settings saved successfully.`,
         });
       },
-      onError: (error: any) => {
+      onError: (error: ApiErrorShape) => {
         toast({
           title: 'Failed to update settings',
           description: error?.response?.data?.message || 'An unexpected error occurred.',

--- a/frontend/lib/react-query/hooks/admin/settings/useGetHubSettings.ts
+++ b/frontend/lib/react-query/hooks/admin/settings/useGetHubSettings.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { api } from '@/lib/api'; // Replace with your API client instance
+import { api } from '@/lib/api';
 
 export interface BusinessHour {
   day: 'Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | 'Sun';

--- a/frontend/lib/react-query/hooks/admin/settings/useGetHubSettings.ts
+++ b/frontend/lib/react-query/hooks/admin/settings/useGetHubSettings.ts
@@ -1,0 +1,44 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api'; // Replace with your API client instance
+
+export interface BusinessHour {
+  day: 'Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | 'Sun';
+  isOpen: boolean;
+  openTime: string; // "08:00"
+  closeTime: string; // "17:00"
+}
+
+export interface HubSettings {
+  // General
+  name: string;
+  address: string;
+  city: string;
+  country: string;
+  contactEmail: string;
+  contactPhone: string;
+  // Booking Rules
+  leadTimeHours: number;
+  maxDaysAhead: number;
+  cancellationPolicyHours: number;
+  // Business Hours
+  businessHours: BusinessHour[];
+  // Financial
+  vatRatePercent: number;
+  currency: string; // e.g. "NGN"
+  // Branding
+  logoUrl?: string;
+  faviconUrl?: string;
+  primaryColorHex: string;
+}
+
+export const HUB_SETTINGS_QUERY_KEY = ['admin', 'hub-settings'];
+
+export function useGetHubSettings() {
+  return useQuery<HubSettings>({
+    queryKey: HUB_SETTINGS_QUERY_KEY,
+    queryFn: async () => {
+      const response = await api.get('/hub-settings');
+      return response.data;
+    },
+  });
+}

--- a/frontend/lib/react-query/hooks/admin/settings/useUpdateHubSettings.ts
+++ b/frontend/lib/react-query/hooks/admin/settings/useUpdateHubSettings.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+import { HUB_SETTINGS_QUERY_KEY, HubSettings } from './useGetHubSettings';
+
+export type UpdateHubSettingsPayload = Partial<HubSettings>;
+
+export function useUpdateHubSettings() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: UpdateHubSettingsPayload) => {
+      const response = await api.patch('/hub-settings', payload);
+      return response.data;
+    },
+    onSuccess: (data) => {
+      // Optimistically update or invalidate query cache
+      queryClient.setQueryData(HUB_SETTINGS_QUERY_KEY, (old: HubSettings | undefined) => ({
+        ...old,
+        ...data,
+      }));
+      queryClient.invalidateQueries({ queryKey: HUB_SETTINGS_QUERY_KEY });
+    },
+  });
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tabs": "^1.1.18",
         "@tanstack/react-query": "^5.90.19",
         "@tanstack/react-query-devtools": "^5.91.2",
         "class-variance-authority": "^0.7.1",
@@ -406,9 +407,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -424,9 +422,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -444,9 +439,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -462,9 +454,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -482,9 +471,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -500,9 +486,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -520,9 +503,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -539,9 +519,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -557,9 +534,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -583,9 +557,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -607,9 +578,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -633,9 +601,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -657,9 +622,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -683,9 +645,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -708,9 +667,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -732,9 +688,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -951,9 +904,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -969,9 +919,6 @@
       "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -989,9 +936,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1007,9 +951,6 @@
       "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1106,6 +1047,32 @@
       "integrity": "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==",
       "license": "MIT"
     },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.12.tgz",
+      "integrity": "sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
@@ -1168,6 +1135,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1350,6 +1332,65 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.16.tgz",
+      "integrity": "sha512-w7lLsTSd3940vFYEshKkHw+NGf7H0QDJPHYsy8NRjDCVbO6ZdKW1X/xoJSYHZtttnrdZiYqbN2O/2uHGB0zasw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-collection": "1.1.12",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.4",
+        "@radix-ui/react-use-is-hydrated": "0.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/primitive": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.6.tgz",
+      "integrity": "sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.4.tgz",
+      "integrity": "sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.11.tgz",
@@ -1380,6 +1421,85 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.18.tgz",
+      "integrity": "sha512-1zq2XkQkK/KfbZn84edytYpOLquhNalra5LXc3NAMKhNRSGtyXqjMv6OyC9jlSuNKpqvQtsb57WKoICNk1v/sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.8",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-roving-focus": "1.1.16",
+        "@radix-ui/react-use-controllable-state": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/primitive": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.6.tgz",
+      "integrity": "sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.8.tgz",
+      "integrity": "sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.4.tgz",
+      "integrity": "sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -1433,6 +1553,21 @@
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-is-hydrated": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.1.tgz",
+      "integrity": "sha512-qwOiz4Tjo8CNnrOLAYUMXeZwDzXgXpvK4TKQPmWLECM9XoWvA6+0Z2/7Ag3A4ivjS4ovbLJPbskkxioFyBhr8A==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1652,9 +1787,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1672,9 +1804,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1692,9 +1821,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1712,9 +1838,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2381,9 +2504,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2398,9 +2518,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2415,9 +2532,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2432,9 +2546,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2449,9 +2560,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2466,9 +2574,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2483,9 +2588,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2500,9 +2602,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2517,9 +2616,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2534,9 +2630,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5323,9 +5416,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5347,9 +5437,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5371,9 +5458,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5395,9 +5479,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.18",
     "@tanstack/react-query": "^5.90.19",
     "@tanstack/react-query-devtools": "^5.91.2",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## 🧪 QA: Admin Hub Settings Page UI Testing Guide (#1300)
Closes #1300
### Description
This PR introduces the official **UI Manual Testing Guide** for the Admin Hub Settings page (`/admin/settings`), covering Issue **#1300**. It outlines a structured, step-by-step test plan designed to verify operational controls across all 5 tabbed sections (General, Booking Rules, Business Hours, Financial, and Branding).

---

### Test Coverage Summary

- **Access & Navigation**: Authorization checks and default state loading on `/admin/settings`.
- **General Tab**: Input verification and payload accuracy for basic hub contact details.
- **Booking Rules Tab**: Numeric bound validations for lead time, max days ahead, and cancellation windows.
- **Business Hours Tab**:
  - Verification of 30-minute interval constraints across open/close time pickers.
  - Verification of day-level "Closed" toggles disabling input pickers.
- **Financial Tab**: Read-only validation for currency (`NGN`) and percentage inputs for VAT.
- **Branding Tab**: Synchronization between hex text inputs and color picker UI controls.
- **Error & Edge Cases**: Graceful fallback handling on network failures (500 status) and invalid field submissions.

---

### Verification Strategy

Reviewers and QA engineers should use the steps outlined in the test guide document to manually validate:
1. Isolated section payload delivery (`PATCH /hub-settings` containing *only* active tab keys).
2. Toast feedback behavior on HTTP `200` success vs. `4xx`/`5xx` error responses.
3. State persistence upon browser refresh.

---

### Related Resources & Dependencies
- **Issue**: #1300
- **Backend Dependency**: BE-54 (`GET /hub-settings` & `PATCH /hub-settings`)
- **Branding Linkage**: FE-38 (White-labeling support)