### PR TITLE
Feat/fe 44 admin membership plans

### DIFF
--- a/frontend/app/admin/plans/page.tsx
+++ b/frontend/app/admin/plans/page.tsx
@@ -1,0 +1,373 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import {
+  useGetMembershipPlans,
+  useCreatePlan,
+  useUpdatePlan,
+  MembershipPlan,
+  PlanFormPayload,
+} from '@/lib/react-query/hooks/membership/useMembershipPlans';
+import { Plus, Edit2, Archive, Loader2, X, Check, Users } from 'lucide-react';
+
+export default function AdminPlansPage() {
+  const { data: plans = [], isLoading } = useGetMembershipPlans(true);
+  const createPlanMutation = useCreatePlan();
+  const updatePlanMutation = useUpdatePlan();
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editingPlan, setEditingPlan] = useState<MembershipPlan | null>(null);
+
+  // Form State
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [priceNgn, setPriceNgn] = useState<number | ''>('');
+  const [billingCycle, setBillingCycle] = useState<'MONTHLY' | 'QUARTERLY' | 'YEARLY'>('MONTHLY');
+  const [features, setFeatures] = useState<string[]>([]);
+  const [featureInput, setFeatureInput] = useState('');
+  const [bookingHours, setBookingHours] = useState<number>(0);
+  const [guestPasses, setGuestPasses] = useState<number>(0);
+  const [displayOrder, setDisplayOrder] = useState<number>(1);
+  const [isActive, setIsActive] = useState(true);
+
+  const openCreateModal = () => {
+    setEditingPlan(null);
+    setName('');
+    setDescription('');
+    setPriceNgn('');
+    setBillingCycle('MONTHLY');
+    setFeatures([]);
+    setFeatureInput('');
+    setBookingHours(0);
+    setGuestPasses(0);
+    setDisplayOrder(plans.length + 1);
+    setIsActive(true);
+    setIsModalOpen(true);
+  };
+
+  const openEditModal = (plan: MembershipPlan) => {
+    setEditingPlan(plan);
+    setName(plan.name);
+    setDescription(plan.description);
+    setPriceNgn(plan.priceKobo / 100);
+    setBillingCycle(plan.billingCycle);
+    setFeatures(plan.features || []);
+    setFeatureInput('');
+    setBookingHours(plan.bookingHoursIncluded || 0);
+    setGuestPasses(plan.guestPassesPerMonth || 0);
+    setDisplayOrder(plan.displayOrder || 1);
+    setIsActive(plan.isActive);
+    setIsModalOpen(true);
+  };
+
+  const handleAddFeature = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && featureInput.trim()) {
+      e.preventDefault();
+      if (!features.includes(featureInput.trim())) {
+        setFeatures([...features, featureInput.trim()]);
+      }
+      setFeatureInput('');
+    }
+  };
+
+  const handleRemoveFeature = (index: number) => {
+    setFeatures(features.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const payload: PlanFormPayload = {
+      name,
+      description,
+      priceNgn: Number(priceNgn),
+      billingCycle,
+      features,
+      bookingHoursIncluded: bookingHours,
+      guestPassesPerMonth: guestPasses,
+      displayOrder,
+      isActive,
+    };
+
+    if (editingPlan) {
+      updatePlanMutation.mutate(
+        { id: editingPlan.id, payload },
+        { onSuccess: () => setIsModalOpen(false) }
+      );
+    } else {
+      createPlanMutation.mutate(payload, { onSuccess: () => setIsModalOpen(false) });
+    }
+  };
+
+  const handleArchive = (plan: MembershipPlan) => {
+    if (plan.activeSubscribersCount > 0) return;
+    updatePlanMutation.mutate({ id: plan.id, payload: { isActive: false } });
+  };
+
+  return (
+    <div className="container max-w-6xl py-8 space-y-6 mx-auto px-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900 dark:text-white">
+            Membership Plans
+          </h1>
+          <p className="text-gray-500 dark:text-gray-400">
+            Create and manage pricing tiers for hub members.
+          </p>
+        </div>
+        <button
+          onClick={openCreateModal}
+          className="flex items-center gap-2 px-4 py-2.5 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium text-sm transition-colors"
+        >
+          <Plus className="h-4 w-4" /> Create Plan
+        </button>
+      </div>
+
+      {/* Plans Table */}
+      <div className="rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden bg-white dark:bg-gray-900 shadow-sm">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-800 text-gray-500 font-semibold">
+            <tr>
+              <th className="px-6 py-3.5">Display Order</th>
+              <th className="px-6 py-3.5">Name</th>
+              <th className="px-6 py-3.5">Price (NGN)</th>
+              <th className="px-6 py-3.5">Billing Cycle</th>
+              <th className="px-6 py-3.5">Features</th>
+              <th className="px-6 py-3.5">Subscribers</th>
+              <th className="px-6 py-3.5">Status</th>
+              <th className="px-6 py-3.5 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+            {isLoading ? (
+              <tr>
+                <td colSpan={8} className="py-12 text-center">
+                  <Loader2 className="h-6 w-6 animate-spin text-gray-400 mx-auto" />
+                </td>
+              </tr>
+            ) : plans.length === 0 ? (
+              <tr>
+                <td colSpan={8} className="py-12 text-center text-gray-400">
+                  No membership plans found. Click "Create Plan" to add one.
+                </td>
+              </tr>
+            ) : (
+              plans.map((plan) => (
+                <tr key={plan.id} className="hover:bg-gray-50/50 dark:hover:bg-gray-800/30">
+                  <td className="px-6 py-4 font-mono font-medium">{plan.displayOrder}</td>
+                  <td className="px-6 py-4 font-semibold text-gray-900 dark:text-white">
+                    {plan.name}
+                  </td>
+                  <td className="px-6 py-4 font-medium">
+                    ₦{(plan.priceKobo / 100).toLocaleString()}
+                  </td>
+                  <td className="px-6 py-4 capitalize text-gray-600 dark:text-gray-400">
+                    {plan.billingCycle.toLowerCase()}
+                  </td>
+                  <td className="px-6 py-4 text-gray-500">
+                    {plan.features?.length || 0} features
+                  </td>
+                  <td className="px-6 py-4">
+                    <Link
+                      href={`/admin/members?plan=${plan.id}`}
+                      className="inline-flex items-center gap-1.5 text-blue-600 hover:underline font-medium"
+                    >
+                      <Users className="h-3.5 w-3.5" />
+                      {plan.activeSubscribersCount || 0}
+                    </Link>
+                  </td>
+                  <td className="px-6 py-4">
+                    <span
+                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold ${
+                        plan.isActive
+                          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                          : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+                      }`}
+                    >
+                      {plan.isActive ? 'Active' : 'Inactive'}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4 text-right space-x-2">
+                    <button
+                      onClick={() => openEditModal(plan)}
+                      className="p-1.5 text-gray-600 hover:text-blue-600 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800"
+                    >
+                      <Edit2 className="h-4 w-4" />
+                    </button>
+                    {plan.activeSubscribersCount === 0 && plan.isActive && (
+                      <button
+                        onClick={() => handleArchive(plan)}
+                        title="Archive Plan"
+                        className="p-1.5 text-gray-600 hover:text-red-600 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800"
+                      >
+                        <Archive className="h-4 w-4" />
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Plan Form Modal */}
+      {isModalOpen && (
+        <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
+          <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-2xl w-full max-w-xl p-6 space-y-5 shadow-xl max-h-[90vh] overflow-y-auto">
+            <div className="flex justify-between items-center border-b pb-3">
+              <h2 className="text-xl font-bold">
+                {editingPlan ? 'Edit Membership Plan' : 'Create Membership Plan'}
+              </h2>
+              <button onClick={() => setIsModalOpen(false)} className="text-gray-400 hover:text-gray-600">
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-1">
+                <label className="text-xs font-bold uppercase text-gray-500">Plan Name</label>
+                <input
+                  required
+                  className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                />
+              </div>
+
+              <div className="space-y-1">
+                <label className="text-xs font-bold uppercase text-gray-500">Description</label>
+                <textarea
+                  rows={2}
+                  className="w-full p-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-1">
+                  <label className="text-xs font-bold uppercase text-gray-500">Price (NGN)</label>
+                  <input
+                    required
+                    type="number"
+                    min="0"
+                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                    value={priceNgn}
+                    onChange={(e) => setPriceNgn(e.target.value === '' ? '' : Number(e.target.value))}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs font-bold uppercase text-gray-500">Billing Cycle</label>
+                  <select
+                    value={billingCycle}
+                    onChange={(e) => setBillingCycle(e.target.value as any)}
+                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                  >
+                    <option value="MONTHLY">Monthly</option>
+                    <option value="QUARTERLY">Quarterly</option>
+                    <option value="YEARLY">Yearly</option>
+                  </select>
+                </div>
+              </div>
+
+              {/* Feature Chips */}
+              <div className="space-y-1">
+                <label className="text-xs font-bold uppercase text-gray-500">
+                  Features (Press Enter to Add)
+                </label>
+                <input
+                  type="text"
+                  value={featureInput}
+                  onChange={(e) => setFeatureInput(e.target.value)}
+                  onKeyDown={handleAddFeature}
+                  placeholder="e.g. 24/7 Access, Free Coffee"
+                  className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                />
+                <div className="flex flex-wrap gap-2 pt-2">
+                  {features.map((feat, idx) => (
+                    <span
+                      key={idx}
+                      className="inline-flex items-center gap-1.5 px-3 py-1 bg-blue-50 text-blue-700 text-xs font-semibold rounded-full border border-blue-200"
+                    >
+                      {feat}
+                      <button type="button" onClick={() => handleRemoveFeature(idx)}>
+                        <X className="h-3 w-3 hover:text-red-600" />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-3 gap-3">
+                <div className="space-y-1">
+                  <label className="text-xs font-bold uppercase text-gray-500">Booking Hours (0=Unlimited)</label>
+                  <input
+                    type="number"
+                    min="0"
+                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                    value={bookingHours}
+                    onChange={(e) => setBookingHours(Number(e.target.value))}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs font-bold uppercase text-gray-500">Guest Passes / Mo</label>
+                  <input
+                    type="number"
+                    min="0"
+                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                    value={guestPasses}
+                    onChange={(e) => setGuestPasses(Number(e.target.value))}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className="text-xs font-bold uppercase text-gray-500">Display Order</label>
+                  <input
+                    type="number"
+                    min="1"
+                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                    value={displayOrder}
+                    onChange={(e) => setDisplayOrder(Number(e.target.value))}
+                  />
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2 pt-2">
+                <input
+                  type="checkbox"
+                  id="activeToggle"
+                  checked={isActive}
+                  onChange={(e) => setIsActive(e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600"
+                />
+                <label htmlFor="activeToggle" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Active (Visible on public pricing page)
+                </label>
+              </div>
+
+              <div className="flex justify-end gap-3 pt-4 border-t">
+                <button
+                  type="button"
+                  onClick={() => setIsModalOpen(false)}
+                  className="px-4 py-2 border rounded-lg text-sm font-medium hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={createPlanMutation.isPending || updatePlanMutation.isPending}
+                  className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 flex items-center gap-2"
+                >
+                  {(createPlanMutation.isPending || updatePlanMutation.isPending) && (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  )}
+                  {editingPlan ? 'Save Changes' : 'Create Plan'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/admin/plans/page.tsx
+++ b/frontend/app/admin/plans/page.tsx
@@ -9,7 +9,7 @@ import {
   MembershipPlan,
   PlanFormPayload,
 } from '@/lib/react-query/hooks/membership/useMembershipPlans';
-import { Plus, Edit2, Archive, Loader2, X, Check, Users } from 'lucide-react';
+import { Plus, Edit2, Archive, Loader2, X, Users } from 'lucide-react';
 
 export default function AdminPlansPage() {
   const { data: plans = [], isLoading } = useGetMembershipPlans(true);
@@ -61,11 +61,12 @@ export default function AdminPlansPage() {
     setIsModalOpen(true);
   };
 
-  const handleAddFeature = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && featureInput.trim()) {
+  const handleAddFeature = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
       e.preventDefault();
-      if (!features.includes(featureInput.trim())) {
-        setFeatures([...features, featureInput.trim()]);
+      const trimmed = featureInput.trim();
+      if (trimmed && !features.includes(trimmed)) {
+        setFeatures([...features, trimmed]);
       }
       setFeatureInput('');
     }
@@ -100,7 +101,9 @@ export default function AdminPlansPage() {
   };
 
   const handleArchive = (plan: MembershipPlan) => {
-    if (plan.activeSubscribersCount > 0) return;
+    // Safely check subscriber count with fallback
+    const subscriberCount = plan.activeSubscribersCount ?? 0;
+    if (subscriberCount > 0) return;
     updatePlanMutation.mutate({ id: plan.id, payload: { isActive: false } });
   };
 
@@ -126,7 +129,7 @@ export default function AdminPlansPage() {
       {/* Plans Table */}
       <div className="rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden bg-white dark:bg-gray-900 shadow-sm">
         <table className="w-full text-left text-sm">
-          <thead className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-800 text-gray-500 font-semibold">
+          <thead className="bg-gray-50 dark:bg-gray-800/50 border-b border-gray-200 dark:border-gray-800 text-gray-500 dark:text-gray-400 font-semibold">
             <tr>
               <th className="px-6 py-3.5">Display Order</th>
               <th className="px-6 py-3.5">Name</th>
@@ -152,60 +155,64 @@ export default function AdminPlansPage() {
                 </td>
               </tr>
             ) : (
-              plans.map((plan) => (
-                <tr key={plan.id} className="hover:bg-gray-50/50 dark:hover:bg-gray-800/30">
-                  <td className="px-6 py-4 font-mono font-medium">{plan.displayOrder}</td>
-                  <td className="px-6 py-4 font-semibold text-gray-900 dark:text-white">
-                    {plan.name}
-                  </td>
-                  <td className="px-6 py-4 font-medium">
-                    ₦{(plan.priceKobo / 100).toLocaleString()}
-                  </td>
-                  <td className="px-6 py-4 capitalize text-gray-600 dark:text-gray-400">
-                    {plan.billingCycle.toLowerCase()}
-                  </td>
-                  <td className="px-6 py-4 text-gray-500">
-                    {plan.features?.length || 0} features
-                  </td>
-                  <td className="px-6 py-4">
-                    <Link
-                      href={`/admin/members?plan=${plan.id}`}
-                      className="inline-flex items-center gap-1.5 text-blue-600 hover:underline font-medium"
-                    >
-                      <Users className="h-3.5 w-3.5" />
-                      {plan.activeSubscribersCount || 0}
-                    </Link>
-                  </td>
-                  <td className="px-6 py-4">
-                    <span
-                      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold ${
-                        plan.isActive
-                          ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-                          : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-                      }`}
-                    >
-                      {plan.isActive ? 'Active' : 'Inactive'}
-                    </span>
-                  </td>
-                  <td className="px-6 py-4 text-right space-x-2">
-                    <button
-                      onClick={() => openEditModal(plan)}
-                      className="p-1.5 text-gray-600 hover:text-blue-600 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800"
-                    >
-                      <Edit2 className="h-4 w-4" />
-                    </button>
-                    {plan.activeSubscribersCount === 0 && plan.isActive && (
-                      <button
-                        onClick={() => handleArchive(plan)}
-                        title="Archive Plan"
-                        className="p-1.5 text-gray-600 hover:text-red-600 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800"
+              plans.map((plan) => {
+                const subCount = plan.activeSubscribersCount ?? 0;
+
+                return (
+                  <tr key={plan.id} className="hover:bg-gray-50/50 dark:hover:bg-gray-800/30">
+                    <td className="px-6 py-4 font-mono font-medium">{plan.displayOrder}</td>
+                    <td className="px-6 py-4 font-semibold text-gray-900 dark:text-white">
+                      {plan.name}
+                    </td>
+                    <td className="px-6 py-4 font-medium">
+                      ₦{(plan.priceKobo / 100).toLocaleString()}
+                    </td>
+                    <td className="px-6 py-4 capitalize text-gray-600 dark:text-gray-400">
+                      {plan.billingCycle.toLowerCase()}
+                    </td>
+                    <td className="px-6 py-4 text-gray-500 dark:text-gray-400">
+                      {plan.features?.length || 0} features
+                    </td>
+                    <td className="px-6 py-4">
+                      <Link
+                        href={`/admin/members?plan=${plan.id}`}
+                        className="inline-flex items-center gap-1.5 text-blue-600 hover:underline font-medium"
                       >
-                        <Archive className="h-4 w-4" />
+                        <Users className="h-3.5 w-3.5" />
+                        {subCount}
+                      </Link>
+                    </td>
+                    <td className="px-6 py-4">
+                      <span
+                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold ${
+                          plan.isActive
+                            ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                            : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+                        }`}
+                      >
+                        {plan.isActive ? 'Active' : 'Inactive'}
+                      </span>
+                    </td>
+                    <td className="px-6 py-4 text-right space-x-2">
+                      <button
+                        onClick={() => openEditModal(plan)}
+                        className="p-1.5 text-gray-600 hover:text-blue-600 rounded-md hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
+                      >
+                        <Edit2 className="h-4 w-4" />
                       </button>
-                    )}
-                  </td>
-                </tr>
-              ))
+                      {subCount === 0 && plan.isActive && (
+                        <button
+                          onClick={() => handleArchive(plan)}
+                          title="Archive Plan"
+                          className="p-1.5 text-gray-600 hover:text-red-600 rounded-md hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
+                        >
+                          <Archive className="h-4 w-4" />
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })
             )}
           </tbody>
         </table>
@@ -215,31 +222,38 @@ export default function AdminPlansPage() {
       {isModalOpen && (
         <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center p-4">
           <div className="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 rounded-2xl w-full max-w-xl p-6 space-y-5 shadow-xl max-h-[90vh] overflow-y-auto">
-            <div className="flex justify-between items-center border-b pb-3">
-              <h2 className="text-xl font-bold">
+            <div className="flex justify-between items-center border-b border-gray-200 dark:border-gray-800 pb-3">
+              <h2 className="text-xl font-bold text-gray-900 dark:text-white">
                 {editingPlan ? 'Edit Membership Plan' : 'Create Membership Plan'}
               </h2>
-              <button onClick={() => setIsModalOpen(false)} className="text-gray-400 hover:text-gray-600">
+              <button
+                onClick={() => setIsModalOpen(false)}
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+              >
                 <X className="h-5 w-5" />
               </button>
             </div>
 
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="space-y-1">
-                <label className="text-xs font-bold uppercase text-gray-500">Plan Name</label>
+                <label className="text-xs font-bold uppercase text-gray-500 dark:text-gray-400">
+                  Plan Name
+                </label>
                 <input
                   required
-                  className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                  className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                 />
               </div>
 
               <div className="space-y-1">
-                <label className="text-xs font-bold uppercase text-gray-500">Description</label>
+                <label className="text-xs font-bold uppercase text-gray-500 dark:text-gray-400">
+                  Description
+                </label>
                 <textarea
                   rows={2}
-                  className="w-full p-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                  className="w-full p-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm"
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                 />
@@ -247,22 +261,28 @@ export default function AdminPlansPage() {
 
               <div className="grid grid-cols-2 gap-4">
                 <div className="space-y-1">
-                  <label className="text-xs font-bold uppercase text-gray-500">Price (NGN)</label>
+                  <label className="text-xs font-bold uppercase text-gray-500 dark:text-gray-400">
+                    Price (NGN)
+                  </label>
                   <input
                     required
                     type="number"
                     min="0"
-                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm"
                     value={priceNgn}
                     onChange={(e) => setPriceNgn(e.target.value === '' ? '' : Number(e.target.value))}
                   />
                 </div>
                 <div className="space-y-1">
-                  <label className="text-xs font-bold uppercase text-gray-500">Billing Cycle</label>
+                  <label className="text-xs font-bold uppercase text-gray-500 dark:text-gray-400">
+                    Billing Cycle
+                  </label>
                   <select
                     value={billingCycle}
-                    onChange={(e) => setBillingCycle(e.target.value as any)}
-                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                    onChange={(e) =>
+                      setBillingCycle(e.target.value as 'MONTHLY' | 'QUARTERLY' | 'YEARLY')
+                    }
+                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm"
                   >
                     <option value="MONTHLY">Monthly</option>
                     <option value="QUARTERLY">Quarterly</option>
@@ -273,7 +293,7 @@ export default function AdminPlansPage() {
 
               {/* Feature Chips */}
               <div className="space-y-1">
-                <label className="text-xs font-bold uppercase text-gray-500">
+                <label className="text-xs font-bold uppercase text-gray-500 dark:text-gray-400">
                   Features (Press Enter to Add)
                 </label>
                 <input
@@ -282,13 +302,13 @@ export default function AdminPlansPage() {
                   onChange={(e) => setFeatureInput(e.target.value)}
                   onKeyDown={handleAddFeature}
                   placeholder="e.g. 24/7 Access, Free Coffee"
-                  className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                  className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm"
                 />
                 <div className="flex flex-wrap gap-2 pt-2">
                   {features.map((feat, idx) => (
                     <span
                       key={idx}
-                      className="inline-flex items-center gap-1.5 px-3 py-1 bg-blue-50 text-blue-700 text-xs font-semibold rounded-full border border-blue-200"
+                      className="inline-flex items-center gap-1.5 px-3 py-1 bg-blue-50 dark:bg-blue-950 text-blue-700 dark:text-blue-300 text-xs font-semibold rounded-full border border-blue-200 dark:border-blue-800"
                     >
                       {feat}
                       <button type="button" onClick={() => handleRemoveFeature(idx)}>
@@ -301,31 +321,37 @@ export default function AdminPlansPage() {
 
               <div className="grid grid-cols-3 gap-3">
                 <div className="space-y-1">
-                  <label className="text-xs font-bold uppercase text-gray-500">Booking Hours (0=Unlimited)</label>
+                  <label className="text-xs font-bold uppercase text-gray-500 dark:text-gray-400">
+                    Booking Hours (0=Unlimited)
+                  </label>
                   <input
                     type="number"
                     min="0"
-                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm"
                     value={bookingHours}
                     onChange={(e) => setBookingHours(Number(e.target.value))}
                   />
                 </div>
                 <div className="space-y-1">
-                  <label className="text-xs font-bold uppercase text-gray-500">Guest Passes / Mo</label>
+                  <label className="text-xs font-bold uppercase text-gray-500 dark:text-gray-400">
+                    Guest Passes / Mo
+                  </label>
                   <input
                     type="number"
                     min="0"
-                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm"
                     value={guestPasses}
                     onChange={(e) => setGuestPasses(Number(e.target.value))}
                   />
                 </div>
                 <div className="space-y-1">
-                  <label className="text-xs font-bold uppercase text-gray-500">Display Order</label>
+                  <label className="text-xs font-bold uppercase text-gray-500 dark:text-gray-400">
+                    Display Order
+                  </label>
                   <input
                     type="number"
                     min="1"
-                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent text-sm"
+                    className="w-full h-10 px-3 rounded-lg border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm"
                     value={displayOrder}
                     onChange={(e) => setDisplayOrder(Number(e.target.value))}
                   />
@@ -338,25 +364,28 @@ export default function AdminPlansPage() {
                   id="activeToggle"
                   checked={isActive}
                   onChange={(e) => setIsActive(e.target.checked)}
-                  className="h-4 w-4 rounded border-gray-300 text-blue-600"
+                  className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
                 />
-                <label htmlFor="activeToggle" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                <label
+                  htmlFor="activeToggle"
+                  className="text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer"
+                >
                   Active (Visible on public pricing page)
                 </label>
               </div>
 
-              <div className="flex justify-end gap-3 pt-4 border-t">
+              <div className="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-800">
                 <button
                   type="button"
                   onClick={() => setIsModalOpen(false)}
-                  className="px-4 py-2 border rounded-lg text-sm font-medium hover:bg-gray-50"
+                  className="px-4 py-2 border border-gray-300 dark:border-gray-700 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800"
                 >
                   Cancel
                 </button>
                 <button
                   type="submit"
                   disabled={createPlanMutation.isPending || updatePlanMutation.isPending}
-                  className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 flex items-center gap-2"
+                  className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
                 >
                   {(createPlanMutation.isPending || updatePlanMutation.isPending) && (
                     <Loader2 className="h-4 w-4 animate-spin" />

--- a/frontend/app/kiosk/layout.tsx
+++ b/frontend/app/kiosk/layout.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export const metadata = {
+  title: 'Visitor Kiosk | Hub Reception',
+  description: 'Reception kiosk for visitor check-in and check-out',
+};
+
+export default function KioskLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen w-screen bg-white text-gray-900 flex flex-col items-center justify-between p-8 select-none">
+      {/* Header with Centered Hub Logo */}
+      <header className="w-full flex justify-center py-4 border-b border-gray-100">
+        <div className="flex items-center gap-3">
+          <div className="h-12 w-12 rounded-xl bg-blue-600 flex items-center justify-center text-white text-2xl font-black shadow-md">
+            H
+          </div>
+          <span className="text-2xl font-bold tracking-tight text-gray-900">Hub Reception</span>
+        </div>
+      </header>
+
+      {/* Main Kiosk Content Area */}
+      <main className="w-full max-w-4xl my-auto flex flex-col items-center justify-center py-6">
+        {children}
+      </main>
+
+      {/* Touchscreen Footer Note */}
+      <footer className="text-center text-sm font-medium text-gray-400 py-2">
+        Touchscreen Reception Kiosk • Tap choices to proceed
+      </footer>
+    </div>
+  );
+}

--- a/frontend/app/kiosk/page.tsx
+++ b/frontend/app/kiosk/page.tsx
@@ -1,0 +1,410 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import {
+  useGetTodayVisitors,
+  useSearchMembers,
+  useVisitorCheckIn,
+  useCreateAndCheckInWalkIn,
+  useVisitorCheckOut,
+  Visitor,
+  Member,
+} from '@/lib/react-query/hooks/visitors/useVisitorCheckIn';
+import { Loader2, CheckCircle2, UserCheck, UserPlus, LogOut, Search, User } from 'lucide-react';
+
+type KioskMode = 'HOME' | 'EXPECTED' | 'WALKIN' | 'CHECKOUT' | 'SUCCESS';
+
+export default function KioskPage() {
+  const [mode, setMode] = useState<KioskMode>('HOME');
+
+  // Success screen state
+  const [successDetails, setSuccessDetails] = useState<{ visitorName: string; hostName: string; action: 'IN' | 'OUT' } | null>(null);
+
+  // Search/Filter states
+  const [expectedQuery, setExpectedQuery] = useState('');
+  const [checkoutQuery, setCheckoutQuery] = useState('');
+
+  // Walk-in form states
+  const [walkInName, setWalkInName] = useState('');
+  const [memberSearchQuery, setMemberSearchQuery] = useState('');
+  const [selectedMember, setSelectedMember] = useState<Member | null>(null);
+  const [purpose, setPurpose] = useState('Meeting');
+
+  // React Query API hooks
+  const { data: todayVisitors = [], isLoading: loadingVisitors } = useGetTodayVisitors();
+  const { data: memberResults = [], isLoading: loadingMembers } = useSearchMembers(memberSearchQuery);
+
+  const checkInMutation = useVisitorCheckIn();
+  const walkInMutation = useCreateAndCheckInWalkIn();
+  const checkOutMutation = useVisitorCheckOut();
+
+  // Auto-reset timer for success screen (8 seconds)
+  useEffect(() => {
+    if (mode === 'SUCCESS') {
+      const timer = setTimeout(() => {
+        resetToHome();
+      }, 8000);
+      return () => clearTimeout(timer);
+    }
+  }, [mode]);
+
+  const resetToHome = () => {
+    setMode('HOME');
+    setSuccessDetails(null);
+    setExpectedQuery('');
+    setCheckoutQuery('');
+    setWalkInName('');
+    setMemberSearchQuery('');
+    setSelectedMember(null);
+    setPurpose('Meeting');
+  };
+
+  const handleExpectedCheckIn = (visitor: Visitor) => {
+    checkInMutation.mutate(visitor.id, {
+      onSuccess: () => {
+        setSuccessDetails({
+          visitorName: visitor.fullName,
+          hostName: visitor.hostName,
+          action: 'IN',
+        });
+        setMode('SUCCESS');
+      },
+    });
+  };
+
+  const handleWalkInSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!walkInName || !selectedMember) return;
+
+    walkInMutation.mutate(
+      {
+        fullName: walkInName,
+        hostId: selectedMember.id,
+        purpose,
+      },
+      {
+        onSuccess: () => {
+          setSuccessDetails({
+            visitorName: walkInName,
+            hostName: selectedMember.name,
+            action: 'IN',
+          });
+          setMode('SUCCESS');
+        },
+      }
+    );
+  };
+
+  const handleCheckOut = (visitor: Visitor) => {
+    checkOutMutation.mutate(visitor.id, {
+      onSuccess: () => {
+        setSuccessDetails({
+          visitorName: visitor.fullName,
+          hostName: visitor.hostName,
+          action: 'OUT',
+        });
+        setMode('SUCCESS');
+      },
+    });
+  };
+
+  // Filter expected visitors (status = PENDING)
+  const filteredExpected = todayVisitors.filter(
+    (v) =>
+      v.status === 'PENDING' &&
+      v.fullName.toLowerCase().includes(expectedQuery.toLowerCase())
+  );
+
+  // Filter checked-in visitors (status = CHECKED_IN)
+  const filteredCheckedIn = todayVisitors.filter(
+    (v) =>
+      v.status === 'CHECKED_IN' &&
+      v.fullName.toLowerCase().includes(checkoutQuery.toLowerCase())
+  );
+
+  return (
+    <div className="w-full">
+      {/* SUCCESS SCREEN */}
+      {mode === 'SUCCESS' && successDetails && (
+        <div className="flex flex-col items-center justify-center text-center space-y-6 py-12 animate-in fade-in zoom-in duration-300">
+          <div className="rounded-full bg-green-100 p-6 text-green-600">
+            <CheckCircle2 className="h-28 w-28" />
+          </div>
+          <div className="space-y-3">
+            <h1 className="text-4xl font-extrabold text-gray-900">
+              {successDetails.action === 'IN'
+                ? `Welcome, ${successDetails.visitorName}!`
+                : `Goodbye, ${successDetails.visitorName}!`}
+            </h1>
+            <p className="text-2xl text-gray-600 font-medium">
+              {successDetails.action === 'IN'
+                ? `${successDetails.hostName} has been notified of your arrival.`
+                : 'You have been checked out successfully.'}
+            </p>
+          </div>
+          <button
+            onClick={resetToHome}
+            className="mt-8 px-10 py-5 bg-gray-900 text-white rounded-2xl text-xl font-bold shadow-lg active:scale-95 transition-transform"
+          >
+            Done
+          </button>
+        </div>
+      )}
+
+      {/* HOME MODE */}
+      {mode === 'HOME' && (
+        <div className="space-y-10 text-center">
+          <div>
+            <h1 className="text-4xl font-extrabold text-gray-900">Welcome to the Hub</h1>
+            <p className="text-xl text-gray-500 mt-2">Please select an option to sign in or out</p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-6">
+            <button
+              onClick={() => setMode('EXPECTED')}
+              className="flex flex-col items-center justify-center p-10 bg-blue-50 border-2 border-blue-200 rounded-3xl hover:border-blue-500 active:scale-95 transition-all space-y-4"
+            >
+              <div className="p-5 bg-blue-600 text-white rounded-2xl shadow-md">
+                <UserCheck className="h-12 w-12" />
+              </div>
+              <span className="text-2xl font-bold text-gray-900">I'm an Expected Visitor</span>
+              <span className="text-sm text-gray-500">I have a pre-registered invitation</span>
+            </button>
+
+            <button
+              onClick={() => setMode('WALKIN')}
+              className="flex flex-col items-center justify-center p-10 bg-gray-50 border-2 border-gray-200 rounded-3xl hover:border-gray-400 active:scale-95 transition-all space-y-4"
+            >
+              <div className="p-5 bg-gray-900 text-white rounded-2xl shadow-md">
+                <UserPlus className="h-12 w-12" />
+              </div>
+              <span className="text-2xl font-bold text-gray-900">I'm a Walk-in Visitor</span>
+              <span className="text-sm text-gray-500">Register and notify host member</span>
+            </button>
+          </div>
+
+          <div className="pt-6 border-t border-gray-100">
+            <button
+              onClick={() => setMode('CHECKOUT')}
+              className="px-8 py-4 bg-red-50 text-red-600 border border-red-200 rounded-2xl font-bold text-lg flex items-center justify-center gap-3 mx-auto hover:bg-red-100 active:scale-95 transition-all"
+            >
+              <LogOut className="h-6 w-6" /> Check Out
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* EXPECTED VISITOR FLOW */}
+      {mode === 'EXPECTED' && (
+        <div className="space-y-6">
+          <div className="flex items-center justify-between border-b pb-4">
+            <h2 className="text-2xl font-bold text-gray-900">Find Your Sign-in</h2>
+            <button
+              onClick={resetToHome}
+              className="px-5 py-3 bg-gray-100 text-gray-700 rounded-xl font-bold active:scale-95"
+            >
+              Back
+            </button>
+          </div>
+
+          <div className="relative">
+            <Search className="absolute left-4 top-4 h-6 w-6 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Enter your name..."
+              value={expectedQuery}
+              onChange={(e) => setExpectedQuery(e.target.value)}
+              className="w-full pl-14 pr-4 py-4 rounded-2xl border-2 border-gray-300 text-xl focus:border-blue-600 focus:outline-none"
+            />
+          </div>
+
+          {loadingVisitors ? (
+            <div className="flex justify-center py-12">
+              <Loader2 className="h-10 w-10 animate-spin text-gray-400" />
+            </div>
+          ) : (
+            <div className="space-y-3 max-h-96 overflow-y-auto">
+              {filteredExpected.length === 0 ? (
+                <p className="text-center py-12 text-gray-400 text-lg">No pre-registered visitors found.</p>
+              ) : (
+                filteredExpected.map((v) => (
+                  <div
+                    key={v.id}
+                    className="flex items-center justify-between p-5 bg-gray-50 rounded-2xl border border-gray-200"
+                  >
+                    <div>
+                      <h3 className="text-xl font-bold text-gray-900">{v.fullName}</h3>
+                      <p className="text-base text-gray-500">
+                        Host: <span className="font-semibold text-gray-700">{v.hostName}</span> • Purpose:{' '}
+                        <span className="font-semibold text-gray-700">{v.purpose}</span>
+                      </p>
+                    </div>
+                    <button
+                      disabled={checkInMutation.isPending}
+                      onClick={() => handleExpectedCheckIn(v)}
+                      className="px-6 py-4 bg-blue-600 text-white rounded-xl font-bold text-lg shadow hover:bg-blue-700 active:scale-95 disabled:opacity-50"
+                    >
+                      {checkInMutation.isPending ? <Loader2 className="h-6 w-6 animate-spin" /> : 'Check In'}
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* WALK-IN FLOW */}
+      {mode === 'WALKIN' && (
+        <form onSubmit={handleWalkInSubmit} className="space-y-6">
+          <div className="flex items-center justify-between border-b pb-4">
+            <h2 className="text-2xl font-bold text-gray-900">Walk-in Sign-in</h2>
+            <button
+              type="button"
+              onClick={resetToHome}
+              className="px-5 py-3 bg-gray-100 text-gray-700 rounded-xl font-bold active:scale-95"
+            >
+              Back
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            <div>
+              <label className="block text-lg font-bold text-gray-700 mb-2">Your Full Name</label>
+              <input
+                required
+                type="text"
+                placeholder="e.g. Jane Doe"
+                value={walkInName}
+                onChange={(e) => setWalkInName(e.target.value)}
+                className="w-full px-5 py-4 rounded-2xl border-2 border-gray-300 text-xl focus:border-blue-600 focus:outline-none"
+              />
+            </div>
+
+            {/* Member Typeahead Search */}
+            <div className="relative">
+              <label className="block text-lg font-bold text-gray-700 mb-2">Host Member</label>
+              <input
+                type="text"
+                placeholder="Search member by name..."
+                value={selectedMember ? selectedMember.name : memberSearchQuery}
+                onChange={(e) => {
+                  setSelectedMember(null);
+                  setMemberSearchQuery(e.target.value);
+                }}
+                className="w-full px-5 py-4 rounded-2xl border-2 border-gray-300 text-xl focus:border-blue-600 focus:outline-none"
+              />
+
+              {loadingMembers && (
+                <div className="absolute right-4 top-12">
+                  <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+                </div>
+              )}
+
+              {/* Typeahead Dropdown List */}
+              {!selectedMember && memberResults.length > 0 && (
+                <div className="absolute z-10 w-full mt-2 bg-white rounded-2xl border-2 border-gray-200 shadow-xl max-h-60 overflow-y-auto">
+                  {memberResults.map((m) => (
+                    <button
+                      key={m.id}
+                      type="button"
+                      onClick={() => {
+                        setSelectedMember(m);
+                        setMemberSearchQuery(m.name);
+                      }}
+                      className="w-full text-left p-4 hover:bg-blue-50 border-b border-gray-100 flex items-center gap-3 text-lg font-semibold text-gray-800"
+                    >
+                      <User className="h-5 w-5 text-gray-400" />
+                      {m.name}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-lg font-bold text-gray-700 mb-2">Purpose of Visit</label>
+              <select
+                value={purpose}
+                onChange={(e) => setPurpose(e.target.value)}
+                className="w-full px-5 py-4 rounded-2xl border-2 border-gray-300 text-xl bg-white focus:border-blue-600 focus:outline-none"
+              >
+                <option value="Meeting">Meeting</option>
+                <option value="Interview">Interview</option>
+                <option value="Delivery">Delivery</option>
+                <option value="Other">Other</option>
+              </select>
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={!walkInName || !selectedMember || walkInMutation.isPending}
+            className="w-full py-5 bg-blue-600 text-white rounded-2xl text-2xl font-bold shadow-lg hover:bg-blue-700 active:scale-95 disabled:opacity-50 transition-all"
+          >
+            {walkInMutation.isPending ? <Loader2 className="h-8 w-8 animate-spin mx-auto" /> : 'Check In Now'}
+          </button>
+        </form>
+      )}
+
+      {/* CHECKOUT FLOW */}
+      {mode === 'CHECKOUT' && (
+        <div className="space-y-6">
+          <div className="flex items-center justify-between border-b pb-4">
+            <h2 className="text-2xl font-bold text-gray-900">Visitor Check Out</h2>
+            <button
+              onClick={resetToHome}
+              className="px-5 py-3 bg-gray-100 text-gray-700 rounded-xl font-bold active:scale-95"
+            >
+              Back
+            </button>
+          </div>
+
+          <div className="relative">
+            <Search className="absolute left-4 top-4 h-6 w-6 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Search your name to check out..."
+              value={checkoutQuery}
+              onChange={(e) => setCheckoutQuery(e.target.value)}
+              className="w-full pl-14 pr-4 py-4 rounded-2xl border-2 border-gray-300 text-xl focus:border-blue-600 focus:outline-none"
+            />
+          </div>
+
+          {loadingVisitors ? (
+            <div className="flex justify-center py-12">
+              <Loader2 className="h-10 w-10 animate-spin text-gray-400" />
+            </div>
+          ) : (
+            <div className="space-y-3 max-h-96 overflow-y-auto">
+              {filteredCheckedIn.length === 0 ? (
+                <p className="text-center py-12 text-gray-400 text-lg">No currently checked-in visitors match.</p>
+              ) : (
+                filteredCheckedIn.map((v) => (
+                  <div
+                    key={v.id}
+                    className="flex items-center justify-between p-5 bg-gray-50 rounded-2xl border border-gray-200"
+                  >
+                    <div>
+                      <h3 className="text-xl font-bold text-gray-900">{v.fullName}</h3>
+                      <p className="text-base text-gray-500">
+                        Host: <span className="font-semibold text-gray-700">{v.hostName}</span>
+                      </p>
+                    </div>
+                    <button
+                      disabled={checkOutMutation.isPending}
+                      onClick={() => handleCheckOut(v)}
+                      className="px-6 py-4 bg-red-600 text-white rounded-xl font-bold text-lg shadow hover:bg-red-700 active:scale-95 disabled:opacity-50"
+                    >
+                      {checkOutMutation.isPending ? <Loader2 className="h-6 w-6 animate-spin" /> : 'Check Out'}
+                    </button>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/pricing/page.tsx
+++ b/frontend/app/pricing/page.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import React from 'react';
+import { useGetMembershipPlans, useSubscribeToPlan } from '@/lib/react-query/hooks/membership/useMembershipPlans';
+import { Check, Loader2, Sparkles } from 'lucide-react';
+
+export default function PublicPricingPage() {
+  const { data: plans = [], isLoading } = useGetMembershipPlans(false);
+  const subscribeMutation = useSubscribeToPlan();
+
+  // Sort plans by displayOrder
+  const sortedPlans = [...plans].sort((a, b) => a.displayOrder - b.displayOrder);
+
+  const handleSubscribe = (planId: string) => {
+    subscribeMutation.mutate(planId, {
+      onSuccess: (data) => {
+        if (data?.checkoutUrl) {
+          window.location.href = data.checkoutUrl;
+        } else {
+          alert('Subscribed successfully!');
+        }
+      },
+      onError: (err: any) => {
+        alert(err?.response?.data?.message || 'Failed to initiate subscription');
+      },
+    });
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950 py-16 px-4">
+      <div className="max-w-6xl mx-auto space-y-12">
+        <div className="text-center space-y-4 max-w-2xl mx-auto">
+          <h1 className="text-4xl font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-5xl">
+            Flexible Membership Plans
+          </h1>
+          <p className="text-xl text-gray-600 dark:text-gray-400">
+            Choose the perfect plan for your workflow and join our hub community.
+          </p>
+        </div>
+
+        {isLoading ? (
+          <div className="flex justify-center py-20">
+            <Loader2 className="h-10 w-10 animate-spin text-blue-600" />
+          </div>
+        ) : (
+          <div className="grid md:grid-cols-3 gap-8 items-stretch">
+            {sortedPlans.map((plan, index) => {
+              const isPopular = index === 1; // Highlight middle plan
+              return (
+                <div
+                  key={plan.id}
+                  className={`relative flex flex-col justify-between p-8 bg-white dark:bg-gray-900 rounded-3xl border ${
+                    isPopular
+                      ? 'border-blue-600 ring-2 ring-blue-600 shadow-2xl scale-105 z-10'
+                      : 'border-gray-200 dark:border-gray-800 shadow-sm'
+                  }`}
+                >
+                  {isPopular && (
+                    <div className="absolute -top-4 left-1/2 -translate-x-1/2 px-4 py-1 bg-blue-600 text-white text-xs font-bold rounded-full flex items-center gap-1 shadow-md">
+                      <Sparkles className="h-3.5 w-3.5" /> Most Popular
+                    </div>
+                  )}
+
+                  <div className="space-y-6">
+                    <div>
+                      <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+                        {plan.name}
+                      </h2>
+                      <p className="text-gray-500 text-sm mt-2">{plan.description}</p>
+                    </div>
+
+                    <div className="flex items-baseline gap-1">
+                      <span className="text-4xl font-extrabold text-gray-900 dark:text-white">
+                        ₦{(plan.priceKobo / 100).toLocaleString()}
+                      </span>
+                      <span className="text-gray-500 font-medium">
+                        / {plan.billingCycle.toLowerCase()}
+                      </span>
+                    </div>
+
+                    <ul className="space-y-3 pt-4 border-t border-gray-100 dark:border-gray-800">
+                      {plan.bookingHoursIncluded > 0 ? (
+                        <li className="flex items-center gap-3 text-sm text-gray-700 dark:text-gray-300">
+                          <Check className="h-4 w-4 text-blue-600" />
+                          <span>{plan.bookingHoursIncluded} hrs included bookings</span>
+                        </li>
+                      ) : (
+                        <li className="flex items-center gap-3 text-sm text-gray-700 dark:text-gray-300">
+                          <Check className="h-4 w-4 text-blue-600" />
+                          <span>Unlimited room bookings</span>
+                        </li>
+                      )}
+
+                      {plan.guestPassesPerMonth > 0 && (
+                        <li className="flex items-center gap-3 text-sm text-gray-700 dark:text-gray-300">
+                          <Check className="h-4 w-4 text-blue-600" />
+                          <span>{plan.guestPassesPerMonth} guest passes / month</span>
+                        </li>
+                      )}
+
+                      {plan.features?.map((feature, i) => (
+                        <li key={i} className="flex items-center gap-3 text-sm text-gray-700 dark:text-gray-300">
+                          <Check className="h-4 w-4 text-blue-600" />
+                          <span>{feature}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  <button
+                    disabled={subscribeMutation.isPending}
+                    onClick={() => handleSubscribe(plan.id)}
+                    className={`mt-8 w-full py-4 rounded-xl font-bold transition-all text-center flex items-center justify-center gap-2 ${
+                      isPopular
+                        ? 'bg-blue-600 hover:bg-blue-700 text-white shadow-lg'
+                        : 'bg-gray-900 hover:bg-gray-800 text-white dark:bg-white dark:text-gray-900'
+                    }`}
+                  >
+                    {subscribeMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+                    Subscribe Now
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/react-query/hooks/membership/useMembershipPlans.ts
+++ b/frontend/lib/react-query/hooks/membership/useMembershipPlans.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { apiClient } from '@/lib/apiClient';
 
 export interface MembershipPlan {
   id: string;
@@ -27,32 +27,29 @@ export interface PlanFormPayload {
   isActive: boolean;
 }
 
-// 1. Fetch All Membership Plans (Admin or Public)
+// Fetch All Membership Plans
 export function useGetMembershipPlans(includeInactive = false) {
   return useQuery<MembershipPlan[]>({
     queryKey: ['membership-plans', { includeInactive }],
-    queryFn: async () => {
-      const response = await api.get('/membership-plans', {
-        params: { includeInactive },
-      });
-      return response.data;
-    },
+    queryFn: () =>
+      apiClient.get<MembershipPlan[]>(
+        `/membership-plans${includeInactive ? '?includeInactive=true' : ''}`
+      ),
   });
 }
 
-// 2. Create Plan Mutation (Converts NGN to Kobo)
+// Create Plan Mutation (Converts NGN to Kobo)
 export function useCreatePlan() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (payload: PlanFormPayload) => {
+    mutationFn: (payload: PlanFormPayload) => {
       const { priceNgn, ...rest } = payload;
       const body = {
         ...rest,
         priceKobo: Math.round(priceNgn * 100),
       };
-      const response = await api.post('/membership-plans', body);
-      return response.data;
+      return apiClient.post<MembershipPlan, typeof body>('/membership-plans', body);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['membership-plans'] });
@@ -60,19 +57,18 @@ export function useCreatePlan() {
   });
 }
 
-// 3. Update Plan Mutation
+// Update Plan Mutation
 export function useUpdatePlan() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ id, payload }: { id: string; payload: Partial<PlanFormPayload> }) => {
+    mutationFn: ({ id, payload }: { id: string; payload: Partial<PlanFormPayload> }) => {
       const { priceNgn, ...rest } = payload;
       const body = {
         ...rest,
         ...(priceNgn !== undefined && { priceKobo: Math.round(priceNgn * 100) }),
       };
-      const response = await api.patch(`/membership-plans/${id}`, body);
-      return response.data;
+      return apiClient.patch<MembershipPlan, typeof body>(`/membership-plans/${id}`, body);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['membership-plans'] });
@@ -80,12 +76,10 @@ export function useUpdatePlan() {
   });
 }
 
-// 4. Public Subscribe Mutation
+// Public Subscribe Mutation
 export function useSubscribeToPlan() {
   return useMutation({
-    mutationFn: async (planId: string) => {
-      const response = await api.post(`/membership-plans/${planId}/subscribe`);
-      return response.data;
-    },
+    mutationFn: (planId: string) =>
+      apiClient.post<{ checkoutUrl?: string }>(`/membership-plans/${planId}/subscribe`),
   });
 }

--- a/frontend/lib/react-query/hooks/membership/useMembershipPlans.ts
+++ b/frontend/lib/react-query/hooks/membership/useMembershipPlans.ts
@@ -1,0 +1,91 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+export interface MembershipPlan {
+  id: string;
+  name: string;
+  description: string;
+  priceKobo: number;
+  billingCycle: 'MONTHLY' | 'QUARTERLY' | 'YEARLY';
+  features: string[];
+  bookingHoursIncluded: number;
+  guestPassesPerMonth: number;
+  displayOrder: number;
+  isActive: boolean;
+  activeSubscribersCount: number;
+}
+
+export interface PlanFormPayload {
+  name: string;
+  description: string;
+  priceNgn: number;
+  billingCycle: 'MONTHLY' | 'QUARTERLY' | 'YEARLY';
+  features: string[];
+  bookingHoursIncluded: number;
+  guestPassesPerMonth: number;
+  displayOrder: number;
+  isActive: boolean;
+}
+
+// 1. Fetch All Membership Plans (Admin or Public)
+export function useGetMembershipPlans(includeInactive = false) {
+  return useQuery<MembershipPlan[]>({
+    queryKey: ['membership-plans', { includeInactive }],
+    queryFn: async () => {
+      const response = await api.get('/membership-plans', {
+        params: { includeInactive },
+      });
+      return response.data;
+    },
+  });
+}
+
+// 2. Create Plan Mutation (Converts NGN to Kobo)
+export function useCreatePlan() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: PlanFormPayload) => {
+      const { priceNgn, ...rest } = payload;
+      const body = {
+        ...rest,
+        priceKobo: Math.round(priceNgn * 100),
+      };
+      const response = await api.post('/membership-plans', body);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['membership-plans'] });
+    },
+  });
+}
+
+// 3. Update Plan Mutation
+export function useUpdatePlan() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, payload }: { id: string; payload: Partial<PlanFormPayload> }) => {
+      const { priceNgn, ...rest } = payload;
+      const body = {
+        ...rest,
+        ...(priceNgn !== undefined && { priceKobo: Math.round(priceNgn * 100) }),
+      };
+      const response = await api.patch(`/membership-plans/${id}`, body);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['membership-plans'] });
+    },
+  });
+}
+
+// 4. Public Subscribe Mutation
+export function useSubscribeToPlan() {
+  return useMutation({
+    mutationFn: async (planId: string) => {
+      const response = await api.post(`/membership-plans/${planId}/subscribe`);
+      return response.data;
+    },
+  });
+}

--- a/frontend/lib/react-query/hooks/membership/useMembershipPlans.ts
+++ b/frontend/lib/react-query/hooks/membership/useMembershipPlans.ts
@@ -1,93 +1,105 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from '@/lib/apiClient';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
-export interface Visitor {
-  id: string;
-  fullName: string;
-  email: string;
-  phone: string;
-  company?: string;
-  hostName?: string;
-  checkInTime?: string;
-  checkOutTime?: string;
-  status: 'EXPECTED' | 'CHECKED_IN' | 'CHECKED_OUT';
-}
+// --- TYPES ---
 
-export interface Member {
+export type BillingCycle = 'MONTHLY' | 'QUARTERLY' | 'YEARLY';
+
+export interface MembershipPlan {
   id: string;
   name: string;
-  email?: string;
+  description: string;
+  priceKobo: number;
+  billingCycle: BillingCycle;
+  features: string[];
+  bookingHoursIncluded: number;
+  guestPassesPerMonth: number;
+  displayOrder: number;
+  isActive: boolean;
+  activeSubscribersCount?: number; // Added to fix the TypeScript error
+  createdAt?: string;
+  updatedAt?: string;
 }
 
-export interface CheckInPayload {
-  fullName: string;
-  email: string;
-  phone: string;
-  company?: string;
-  hostName?: string;
+export interface PlanFormPayload {
+  name?: string;
+  description?: string;
+  priceNgn?: number;
+  priceKobo?: number;
+  billingCycle?: BillingCycle;
+  features?: string[];
+  bookingHoursIncluded?: number;
+  guestPassesPerMonth?: number;
+  displayOrder?: number;
+  isActive?: boolean;
 }
 
-export interface WalkInPayload {
-  fullName: string;
-  email: string;
-  phone: string;
-  company?: string;
-  hostName?: string;
-  purpose?: string;
-}
+// --- QUERY & MUTATION HOOKS ---
 
-// 1. Fetch Today's Visitors
-export function useGetTodayVisitors() {
-  return useQuery({
-    queryKey: ['visitors', 'today'],
-    queryFn: () => apiClient.get<Visitor[]>('/visitors/today'),
-  });
-}
+export const MEMBERSHIP_PLANS_QUERY_KEY = ['membership-plans'];
 
-// 2. Member Typeahead Search
-export function useSearchMembers(query: string) {
-  return useQuery({
-    queryKey: ['members-search', query],
-    queryFn: () => apiClient.get<Member[]>(`/members/search?q=${encodeURIComponent(query)}`),
-    enabled: query.length >= 2,
-  });
-}
-
-// 3. Expected Visitor Check-In
-export function useVisitorCheckIn() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (visitorId: string) =>
-      apiClient.post<Visitor>(`/visitors/${visitorId}/check-in`),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['visitors'] });
+export function useGetMembershipPlans(includeInactive: boolean = false) {
+  return useQuery<MembershipPlan[]>({
+    queryKey: [...MEMBERSHIP_PLANS_QUERY_KEY, { includeInactive }],
+    queryFn: async () => {
+      const res = await fetch(`/api/admin/membership-plans?includeInactive=${includeInactive}`);
+      if (!res.ok) throw new Error('Failed to fetch membership plans');
+      return res.json();
     },
   });
 }
 
-// 4. Create & Check-In Walk-In Visitor
-export function useCreateAndCheckInWalkIn() {
+export function useCreatePlan() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (payload: WalkInPayload) =>
-      apiClient.post<Visitor, WalkInPayload>('/visitors/walk-in', payload),
+    mutationFn: async (payload: PlanFormPayload) => {
+      const res = await fetch('/api/admin/membership-plans', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error('Failed to create membership plan');
+      return res.json();
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['visitors'] });
+      queryClient.invalidateQueries({ queryKey: MEMBERSHIP_PLANS_QUERY_KEY });
     },
   });
 }
 
-// 5. Visitor Check-Out
-export function useVisitorCheckOut() {
+export function useUpdatePlan() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (visitorId: string) =>
-      apiClient.post<Visitor>(`/visitors/${visitorId}/check-out`),
+    mutationFn: async ({ id, payload }: { id: string; payload: PlanFormPayload }) => {
+      const res = await fetch(`/api/admin/membership-plans/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error('Failed to update membership plan');
+      return res.json();
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['visitors'] });
+      queryClient.invalidateQueries({ queryKey: MEMBERSHIP_PLANS_QUERY_KEY });
+    },
+  });
+}
+
+export function useSubscribeToPlan() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (planId: string) => {
+      const res = await fetch(`/api/membership-plans/${planId}/subscribe`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      if (!res.ok) throw new Error('Failed to subscribe to plan');
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: MEMBERSHIP_PLANS_QUERY_KEY });
     },
   });
 }

--- a/frontend/lib/react-query/hooks/membership/useMembershipPlans.ts
+++ b/frontend/lib/react-query/hooks/membership/useMembershipPlans.ts
@@ -1,85 +1,93 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from '@/lib/apiClient';
 
-export interface MembershipPlan {
+export interface Visitor {
+  id: string;
+  fullName: string;
+  email: string;
+  phone: string;
+  company?: string;
+  hostName?: string;
+  checkInTime?: string;
+  checkOutTime?: string;
+  status: 'EXPECTED' | 'CHECKED_IN' | 'CHECKED_OUT';
+}
+
+export interface Member {
   id: string;
   name: string;
-  description: string;
-  priceKobo: number;
-  billingCycle: 'MONTHLY' | 'QUARTERLY' | 'YEARLY';
-  features: string[];
-  bookingHoursIncluded: number;
-  guestPassesPerMonth: number;
-  displayOrder: number;
-  isActive: boolean;
-  activeSubscribersCount: number;
+  email?: string;
 }
 
-export interface PlanFormPayload {
-  name: string;
-  description: string;
-  priceNgn: number;
-  billingCycle: 'MONTHLY' | 'QUARTERLY' | 'YEARLY';
-  features: string[];
-  bookingHoursIncluded: number;
-  guestPassesPerMonth: number;
-  displayOrder: number;
-  isActive: boolean;
+export interface CheckInPayload {
+  fullName: string;
+  email: string;
+  phone: string;
+  company?: string;
+  hostName?: string;
 }
 
-// Fetch All Membership Plans
-export function useGetMembershipPlans(includeInactive = false) {
-  return useQuery<MembershipPlan[]>({
-    queryKey: ['membership-plans', { includeInactive }],
-    queryFn: () =>
-      apiClient.get<MembershipPlan[]>(
-        `/membership-plans${includeInactive ? '?includeInactive=true' : ''}`
-      ),
+export interface WalkInPayload {
+  fullName: string;
+  email: string;
+  phone: string;
+  company?: string;
+  hostName?: string;
+  purpose?: string;
+}
+
+// 1. Fetch Today's Visitors
+export function useGetTodayVisitors() {
+  return useQuery({
+    queryKey: ['visitors', 'today'],
+    queryFn: () => apiClient.get<Visitor[]>('/visitors/today'),
   });
 }
 
-// Create Plan Mutation (Converts NGN to Kobo)
-export function useCreatePlan() {
+// 2. Member Typeahead Search
+export function useSearchMembers(query: string) {
+  return useQuery({
+    queryKey: ['members-search', query],
+    queryFn: () => apiClient.get<Member[]>(`/members/search?q=${encodeURIComponent(query)}`),
+    enabled: query.length >= 2,
+  });
+}
+
+// 3. Expected Visitor Check-In
+export function useVisitorCheckIn() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (payload: PlanFormPayload) => {
-      const { priceNgn, ...rest } = payload;
-      const body = {
-        ...rest,
-        priceKobo: Math.round(priceNgn * 100),
-      };
-      return apiClient.post<MembershipPlan, typeof body>('/membership-plans', body);
-    },
+    mutationFn: (visitorId: string) =>
+      apiClient.post<Visitor>(`/visitors/${visitorId}/check-in`),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['membership-plans'] });
+      queryClient.invalidateQueries({ queryKey: ['visitors'] });
     },
   });
 }
 
-// Update Plan Mutation
-export function useUpdatePlan() {
+// 4. Create & Check-In Walk-In Visitor
+export function useCreateAndCheckInWalkIn() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, payload }: { id: string; payload: Partial<PlanFormPayload> }) => {
-      const { priceNgn, ...rest } = payload;
-      const body = {
-        ...rest,
-        ...(priceNgn !== undefined && { priceKobo: Math.round(priceNgn * 100) }),
-      };
-      return apiClient.patch<MembershipPlan, typeof body>(`/membership-plans/${id}`, body);
-    },
+    mutationFn: (payload: WalkInPayload) =>
+      apiClient.post<Visitor, WalkInPayload>('/visitors/walk-in', payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['membership-plans'] });
+      queryClient.invalidateQueries({ queryKey: ['visitors'] });
     },
   });
 }
 
-// Public Subscribe Mutation
-export function useSubscribeToPlan() {
+// 5. Visitor Check-Out
+export function useVisitorCheckOut() {
+  const queryClient = useQueryClient();
+
   return useMutation({
-    mutationFn: (planId: string) =>
-      apiClient.post<{ checkoutUrl?: string }>(`/membership-plans/${planId}/subscribe`),
+    mutationFn: (visitorId: string) =>
+      apiClient.post<Visitor>(`/visitors/${visitorId}/check-out`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['visitors'] });
+    },
   });
 }

--- a/frontend/lib/react-query/hooks/visitors/useVisitorCheckIn.ts
+++ b/frontend/lib/react-query/hooks/visitors/useVisitorCheckIn.ts
@@ -1,99 +1,55 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { api } from '@/lib/api';
+import { apiClient } from '@/lib/apiClient';
 
 export interface Visitor {
   id: string;
   fullName: string;
-  hostName: string;
-  hostId?: string;
-  purpose: string;
-  status: 'PENDING' | 'CHECKED_IN' | 'CHECKED_OUT';
+  email: string;
+  phone: string;
+  company?: string;
+  hostName?: string;
   checkInTime?: string;
+  checkOutTime?: string;
+  status: 'EXPECTED' | 'CHECKED_IN' | 'CHECKED_OUT';
 }
 
-export interface Member {
-  id: string;
-  name: string;
-  email?: string;
-}
-
-export interface CreateVisitorPayload {
+export interface CheckInPayload {
   fullName: string;
-  hostId: string;
-  purpose: string;
+  email: string;
+  phone: string;
+  company?: string;
+  hostName?: string;
 }
 
-// 1. Get Today's Expected / Checked-In Visitors
-export function useGetTodayVisitors(search?: string) {
-  return useQuery<Visitor[]>({
-    queryKey: ['visitors', 'today', search],
-    queryFn: async () => {
-      const response = await api.get('/visitors', {
-        params: { date: 'today', search },
-      });
-      return response.data;
-    },
-  });
-}
-
-// 2. Member Typeahead Search for Walk-ins
+// Member search for typeahead
 export function useSearchMembers(query: string) {
-  return useQuery<Member[]>({
-    queryKey: ['community', 'members', query],
-    queryFn: async () => {
-      if (!query || query.length < 2) return [];
-      const response = await api.get('/community/members', {
-        params: { search: query },
-      });
-      return response.data;
-    },
+  return useQuery({
+    queryKey: ['members-search', query],
+    queryFn: () => apiClient.get<Array<{ id: string; name: string }>>(`/members/search?q=${encodeURIComponent(query)}`),
     enabled: query.length >= 2,
   });
 }
 
-// 3. Check-In Mutation
+// Visitor check-in mutation
 export function useVisitorCheckIn() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (visitorId: string) => {
-      const response = await api.post(`/visitors/${visitorId}/check-in`);
-      return response.data;
-    },
+    mutationFn: (payload: CheckInPayload) =>
+      apiClient.post<Visitor, CheckInPayload>('/visitors/check-in', payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['visitors'] });
     },
   });
 }
 
-// 4. Create & Check-In Walk-In Mutation
-export function useCreateAndCheckInWalkIn() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async (payload: CreateVisitorPayload) => {
-      // Step A: Create Visitor
-      const createRes = await api.post('/visitors', payload);
-      const visitor = createRes.data;
-      // Step B: Immediately Check In
-      const checkInRes = await api.post(`/visitors/${visitor.id}/check-in`);
-      return checkInRes.data;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['visitors'] });
-    },
-  });
-}
-
-// 5. Check-Out Mutation
+// Visitor check-out mutation
 export function useVisitorCheckOut() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (visitorId: string) => {
-      const response = await api.post(`/visitors/${visitorId}/check-out`);
-      return response.data;
-    },
+    mutationFn: (visitorId: string) =>
+      apiClient.post<Visitor>(`/visitors/${visitorId}/check-out`),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['visitors'] });
     },

--- a/frontend/lib/react-query/hooks/visitors/useVisitorCheckIn.ts
+++ b/frontend/lib/react-query/hooks/visitors/useVisitorCheckIn.ts
@@ -1,0 +1,101 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+export interface Visitor {
+  id: string;
+  fullName: string;
+  hostName: string;
+  hostId?: string;
+  purpose: string;
+  status: 'PENDING' | 'CHECKED_IN' | 'CHECKED_OUT';
+  checkInTime?: string;
+}
+
+export interface Member {
+  id: string;
+  name: string;
+  email?: string;
+}
+
+export interface CreateVisitorPayload {
+  fullName: string;
+  hostId: string;
+  purpose: string;
+}
+
+// 1. Get Today's Expected / Checked-In Visitors
+export function useGetTodayVisitors(search?: string) {
+  return useQuery<Visitor[]>({
+    queryKey: ['visitors', 'today', search],
+    queryFn: async () => {
+      const response = await api.get('/visitors', {
+        params: { date: 'today', search },
+      });
+      return response.data;
+    },
+  });
+}
+
+// 2. Member Typeahead Search for Walk-ins
+export function useSearchMembers(query: string) {
+  return useQuery<Member[]>({
+    queryKey: ['community', 'members', query],
+    queryFn: async () => {
+      if (!query || query.length < 2) return [];
+      const response = await api.get('/community/members', {
+        params: { search: query },
+      });
+      return response.data;
+    },
+    enabled: query.length >= 2,
+  });
+}
+
+// 3. Check-In Mutation
+export function useVisitorCheckIn() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (visitorId: string) => {
+      const response = await api.post(`/visitors/${visitorId}/check-in`);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['visitors'] });
+    },
+  });
+}
+
+// 4. Create & Check-In Walk-In Mutation
+export function useCreateAndCheckInWalkIn() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: CreateVisitorPayload) => {
+      // Step A: Create Visitor
+      const createRes = await api.post('/visitors', payload);
+      const visitor = createRes.data;
+      // Step B: Immediately Check In
+      const checkInRes = await api.post(`/visitors/${visitor.id}/check-in`);
+      return checkInRes.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['visitors'] });
+    },
+  });
+}
+
+// 5. Check-Out Mutation
+export function useVisitorCheckOut() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (visitorId: string) => {
+      const response = await api.post(`/visitors/${visitorId}/check-out`);
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['visitors'] });
+    },
+  });
+}

--- a/frontend/lib/react-query/hooks/visitors/useVisitorCheckIn.ts
+++ b/frontend/lib/react-query/hooks/visitors/useVisitorCheckIn.ts
@@ -1,57 +1,134 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from '@/lib/apiClient';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 
 export interface Visitor {
   id: string;
   fullName: string;
-  email: string;
-  phone: string;
-  company?: string;
-  hostName?: string;
+  email?: string;
+  phone?: string;
+  purpose: string;
+  hostName: string;
   checkInTime?: string;
-  checkOutTime?: string;
-  status: 'EXPECTED' | 'CHECKED_IN' | 'CHECKED_OUT';
+  checkOutTime?: string | null;
+  status: 'PENDING' | 'CHECKED_IN' | 'CHECKED_OUT';
 }
 
-export interface CheckInPayload {
+// Kept for any other file still importing the old name
+export type VisitorLog = Visitor;
+
+export interface Member {
+  id: string;
+  name: string;
+  email?: string;
+  phone?: string;
+}
+
+export interface WalkInPayload {
   fullName: string;
-  email: string;
-  phone: string;
-  company?: string;
-  hostName?: string;
+  hostId: string;
+  purpose: string;
 }
 
-// Member search for typeahead
+export const VISITORS_QUERY_KEY = ['visitors'];
+export const TODAY_VISITORS_QUERY_KEY = ['visitors', 'today'];
+export const MEMBERS_SEARCH_QUERY_KEY = ['members', 'search'];
+
+export function useGetVisitors() {
+  return useQuery<Visitor[]>({
+    queryKey: VISITORS_QUERY_KEY,
+    queryFn: async () => {
+      const res = await fetch('/api/visitors');
+      if (!res.ok) throw new Error('Failed to fetch visitor logs');
+      return res.json();
+    },
+  });
+}
+
+// Kiosk polls today's visitor list (expected + checked-in)
+export function useGetTodayVisitors() {
+  return useQuery<Visitor[]>({
+    queryKey: TODAY_VISITORS_QUERY_KEY,
+    queryFn: async () => {
+      const res = await fetch('/api/visitors/today');
+      if (!res.ok) throw new Error("Failed to fetch today's visitors");
+      return res.json();
+    },
+    refetchInterval: 30_000,
+  });
+}
+
+// Typeahead search for host members in the walk-in flow
 export function useSearchMembers(query: string) {
-  return useQuery({
-    queryKey: ['members-search', query],
-    queryFn: () => apiClient.get<Array<{ id: string; name: string }>>(`/members/search?q=${encodeURIComponent(query)}`),
-    enabled: query.length >= 2,
+  return useQuery<Member[]>({
+    queryKey: [...MEMBERS_SEARCH_QUERY_KEY, query],
+    queryFn: async () => {
+      const res = await fetch(`/api/members/search?q=${encodeURIComponent(query)}`);
+      if (!res.ok) throw new Error('Failed to search members');
+      return res.json();
+    },
+    enabled: query.trim().length > 0,
   });
 }
 
-// Visitor check-in mutation
-export function useVisitorCheckIn() {
+// Checks in an existing/expected visitor by id
+export function useCheckInVisitor() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (payload: CheckInPayload) =>
-      apiClient.post<Visitor, CheckInPayload>('/visitors/check-in', payload),
+    mutationFn: async (visitorId: string) => {
+      const res = await fetch(`/api/visitors/${visitorId}/check-in`, {
+        method: 'PATCH',
+      });
+      if (!res.ok) throw new Error('Failed to check in visitor');
+      return res.json();
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['visitors'] });
+      queryClient.invalidateQueries({ queryKey: VISITORS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: TODAY_VISITORS_QUERY_KEY });
     },
   });
 }
 
-// Visitor check-out mutation
-export function useVisitorCheckOut() {
+// kiosk page imports this name instead of `useCheckInVisitor` — alias for compatibility
+export const useVisitorCheckIn = useCheckInVisitor;
+
+// Creates a walk-in visitor record AND checks them in immediately
+export function useCreateAndCheckInWalkIn() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (visitorId: string) =>
-      apiClient.post<Visitor>(`/visitors/${visitorId}/check-out`),
+    mutationFn: async (payload: WalkInPayload) => {
+      const res = await fetch('/api/visitors/walk-in', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error('Failed to create and check in walk-in visitor');
+      return res.json();
+    },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['visitors'] });
+      queryClient.invalidateQueries({ queryKey: VISITORS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: TODAY_VISITORS_QUERY_KEY });
     },
   });
 }
+
+export function useCheckOutVisitor() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (visitorId: string) => {
+      const res = await fetch(`/api/visitors/${visitorId}/check-out`, {
+        method: 'PATCH',
+      });
+      if (!res.ok) throw new Error('Failed to check out visitor');
+      return res.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: VISITORS_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: TODAY_VISITORS_QUERY_KEY });
+    },
+  });
+}
+
+// kiosk page imports this name instead of `useCheckOutVisitor` — alias for compatibility
+export const useVisitorCheckOut = useCheckOutVisitor;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -406,9 +406,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -424,9 +421,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -444,9 +438,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -462,9 +453,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -482,9 +470,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -500,9 +485,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -520,9 +502,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -539,9 +518,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -557,9 +533,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -583,9 +556,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -607,9 +577,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -633,9 +600,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -657,9 +621,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -683,9 +644,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -708,9 +666,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -732,9 +687,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -951,9 +903,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -969,9 +918,6 @@
       "integrity": "sha512-RQmDfeYBtXV2FSId7dfA1hE6M/T6+g7wdbYnFQ47tw/gUBwV+CccLVejNmCGa9yLDitk83foeg8hl/3DjfYQ5g==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -989,9 +935,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1007,9 +950,6 @@
       "integrity": "sha512-rAO5b7pKHvX+ExdmJskusDXTNbiNZfptifIPZItbUx+AOXxxTydVBsPt7Oz84DRd5mY8e0DcE8kvLj3AIfjE6w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1652,9 +1592,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1672,9 +1609,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1692,9 +1626,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1712,9 +1643,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2381,9 +2309,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2398,9 +2323,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2415,9 +2337,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2432,9 +2351,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2449,9 +2365,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2466,9 +2379,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2483,9 +2393,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2500,9 +2407,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2517,9 +2421,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2534,9 +2435,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5323,9 +5221,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5347,9 +5242,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5371,9 +5263,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5395,9 +5284,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
## 💳 FE-44: Admin Membership Plans (/admin/plans) + Public /pricing Page (#1302)

### Overview
Provides full membership tier lifecycle management for admins (`/admin/plans`) and introduces a public-facing pricing showcase page (`/pricing`) with subscription checkout call-to-actions.

Closes #1302
Closes #1301 

### Key Changes
- **Admin Management (`frontend/app/admin/plans/page.tsx`)**:
  - Full CRUD modal allowing admins to define plan names, NGN prices (automatically converted to kobo for backend processing), billing cycles, feature tag chips, booking hours, guest passes, display ordering, and active flags.
  - Interactive table displaying active subscriber counts linked directly to `/admin/members?plan=:id`.
  - Conditional archive/inactivate actions enforced when zero active subscribers exist.
- **Public Pricing Page (`frontend/app/pricing/page.tsx`)**:
  - Dynamically renders active membership plans ordered by `displayOrder`.
  - "Subscribe Now" CTA triggers `POST /membership-plans/:id/subscribe` and handles checkout redirects.
- **React Query Hooks (`useMembershipPlans.ts`)**: Custom hooks encapsulating API interactions for `GET`, `POST`, `PATCH`, and `subscribe`.

---

### Verification Steps
1. Navigate to `/admin/plans` and click **Create Plan**. Fill out details, add feature tags by pressing Enter, and submit.
2. Confirm the price input in NGN correctly posts as Kobo to the backend.
3. Click the subscriber count link to verify navigation to `/admin/members?plan=:id`.
4. Open `/pricing` to verify active plans render in proper display order with subscription CTAs.