### PR TITLE
implement issue Payment reconciliation job

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17099,7 +17099,6 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -17117,7 +17116,6 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -17131,18 +17129,15 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
     },
-
     "node_modules/webpack/node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/backend/src/jobs/jobs.module.ts
+++ b/backend/src/jobs/jobs.module.ts
@@ -5,9 +5,11 @@ import { Payment } from '../payments/entities/payment.entity';
 import { WorkspaceLog } from '../workspace-tracking/entities/workspace-log.entity';
 import { BookingsModule } from '../bookings/bookings.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { PaymentsModule } from '../payments/payments.module';
 import { StaleCheckinJob } from './stale-checkin.job';
 import { AutoCompleteBookingsJob } from './auto-complete-bookings.job';
 import { ExpirePendingBookingsProvider } from './providers/expire-pending-bookings.provider';
+import { ReconcilePendingPaymentsProvider } from './providers/reconcile-pending-payments.provider';
 
 /**
  * Shared background-jobs module.
@@ -21,7 +23,13 @@ import { ExpirePendingBookingsProvider } from './providers/expire-pending-bookin
     TypeOrmModule.forFeature([Booking, Payment, WorkspaceLog]),
     BookingsModule,
     NotificationsModule,
+    PaymentsModule,
   ],
-  providers: [StaleCheckinJob, AutoCompleteBookingsJob, ExpirePendingBookingsProvider],
+  providers: [
+    StaleCheckinJob,
+    AutoCompleteBookingsJob,
+    ExpirePendingBookingsProvider,
+    ReconcilePendingPaymentsProvider,
+  ],
 })
 export class JobsModule {}

--- a/backend/src/jobs/providers/reconcile-pending-payments.provider.spec.ts
+++ b/backend/src/jobs/providers/reconcile-pending-payments.provider.spec.ts
@@ -1,0 +1,102 @@
+import { ReconcilePendingPaymentsProvider } from './reconcile-pending-payments.provider';
+
+function buildProvider(payments: unknown[]) {
+  const paymentsRepository = {
+    find: jest
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(payments),
+  };
+  const paystackProvider = { verifyTransaction: jest.fn() };
+  const paymentOutcomeProvider = {
+    handleChargeSuccess: jest.fn().mockResolvedValue(undefined),
+    handleChargeFailed: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const provider = new ReconcilePendingPaymentsProvider(
+    paymentsRepository as any,
+    paystackProvider as any,
+    paymentOutcomeProvider as any,
+  );
+
+  return {
+    provider,
+    paymentsRepository,
+    paystackProvider,
+    paymentOutcomeProvider,
+  };
+}
+
+describe('ReconcilePendingPaymentsProvider', () => {
+  it('verifies pending Paystack payments and applies successful outcomes', async () => {
+    const payment = { id: 'pay-1', providerReference: 'ref-1' };
+    const { provider, paystackProvider, paymentOutcomeProvider } =
+      buildProvider([payment]);
+    paystackProvider.verifyTransaction.mockResolvedValue({
+      reference: 'ref-1',
+      status: 'success',
+    });
+
+    await provider.reconcilePendingPaystackPayments();
+
+    expect(paystackProvider.verifyTransaction).toHaveBeenCalledWith('ref-1');
+    expect(paymentOutcomeProvider.handleChargeSuccess).toHaveBeenCalledWith(
+      'ref-1',
+      expect.objectContaining({ status: 'success' }),
+      'paystack.reconciliation',
+    );
+  });
+
+  it('marks verified failed charges through the shared failed path', async () => {
+    const payment = { id: 'pay-1', providerReference: 'ref-1' };
+    const { provider, paystackProvider, paymentOutcomeProvider } =
+      buildProvider([payment]);
+    paystackProvider.verifyTransaction.mockResolvedValue({
+      reference: 'ref-1',
+      status: 'failed',
+    });
+
+    await provider.reconcilePendingPaystackPayments();
+
+    expect(paymentOutcomeProvider.handleChargeFailed).toHaveBeenCalledWith(
+      'ref-1',
+      'paystack.reconciliation',
+    );
+  });
+
+  it('leaves still-pending Paystack transactions untouched', async () => {
+    const payment = { id: 'pay-1', providerReference: 'ref-1' };
+    const { provider, paystackProvider, paymentOutcomeProvider } =
+      buildProvider([payment]);
+    paystackProvider.verifyTransaction.mockResolvedValue({
+      reference: 'ref-1',
+      status: 'pending',
+    });
+
+    await provider.reconcilePendingPaystackPayments();
+
+    expect(paymentOutcomeProvider.handleChargeSuccess).not.toHaveBeenCalled();
+    expect(paymentOutcomeProvider.handleChargeFailed).not.toHaveBeenCalled();
+  });
+
+  it('logs payments older than the manual-review cap before reconciling eligible payments', async () => {
+    const paymentsRepository = {
+      find: jest
+        .fn()
+        .mockResolvedValueOnce([{ id: 'stale-pay', providerReference: 'old' }])
+        .mockResolvedValueOnce([]),
+    };
+    const provider = new ReconcilePendingPaymentsProvider(
+      paymentsRepository as any,
+      { verifyTransaction: jest.fn() } as any,
+      {
+        handleChargeSuccess: jest.fn(),
+        handleChargeFailed: jest.fn(),
+      } as any,
+    );
+
+    await provider.reconcilePendingPaystackPayments();
+
+    expect(paymentsRepository.find).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend/src/jobs/providers/reconcile-pending-payments.provider.ts
+++ b/backend/src/jobs/providers/reconcile-pending-payments.provider.ts
@@ -1,0 +1,109 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, LessThan, Not, Repository, Between } from 'typeorm';
+import { Payment } from '../../payments/entities/payment.entity';
+import { PaymentProvider } from '../../payments/enums/payment-provider.enum';
+import { PaymentStatus } from '../../payments/enums/payment-status.enum';
+import { PaystackProvider } from '../../payments/providers/paystack.provider';
+import { PaymentOutcomeProvider } from '../../payments/providers/payment-outcome.provider';
+
+const VERIFY_AFTER_MINUTES = 15;
+const MANUAL_REVIEW_AFTER_HOURS = 24;
+
+@Injectable()
+export class ReconcilePendingPaymentsProvider {
+  private readonly logger = new Logger(ReconcilePendingPaymentsProvider.name);
+
+  constructor(
+    @InjectRepository(Payment)
+    private readonly paymentsRepository: Repository<Payment>,
+    private readonly paystackProvider: PaystackProvider,
+    private readonly paymentOutcomeProvider: PaymentOutcomeProvider,
+  ) {}
+
+  @Cron('*/15 * * * *')
+  async reconcilePendingPaystackPayments(): Promise<void> {
+    const now = Date.now();
+    const verifyCutoff = new Date(now - VERIFY_AFTER_MINUTES * 60 * 1000);
+    const manualReviewCutoff = new Date(
+      now - MANUAL_REVIEW_AFTER_HOURS * 60 * 60 * 1000,
+    );
+
+    await this.logManualReviewPayments(manualReviewCutoff);
+
+    const payments = await this.paymentsRepository.find({
+      where: {
+        provider: PaymentProvider.PAYSTACK,
+        status: PaymentStatus.PENDING,
+        providerReference: Not(IsNull()),
+        createdAt: Between(manualReviewCutoff, verifyCutoff),
+       
+      },
+      order: { createdAt: 'ASC' },
+    });
+
+    let reconciled = 0;
+
+    for (const payment of payments) {
+      try {
+        const reference = payment.providerReference;
+        if (!reference) continue;
+
+        const transaction = await this.paystackProvider.verifyTransaction(
+          reference,
+        );
+        const status = transaction.status;
+
+        if (status === 'success') {
+          await this.paymentOutcomeProvider.handleChargeSuccess(
+            reference,
+            transaction,
+            'paystack.reconciliation',
+          );
+          reconciled += 1;
+        } else if (this.isFailedStatus(status)) {
+          await this.paymentOutcomeProvider.handleChargeFailed(
+            reference,
+            'paystack.reconciliation',
+          );
+          reconciled += 1;
+        } else {
+          this.logger.log(
+            `Payment ${payment.id} remains pending after Paystack verify: ${String(status)}`,
+          );
+        }
+      } catch (error) {
+        this.logger.error(
+          `Failed to reconcile payment "${payment.id}": ${(error as Error).message}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Payment reconciliation run complete: ${reconciled}/${payments.length} pending payment(s) resolved.`,
+    );
+  }
+
+  private async logManualReviewPayments(cutoff: Date): Promise<void> {
+    const stalePayments = await this.paymentsRepository.find({
+      where: {
+        provider: PaymentProvider.PAYSTACK,
+        status: PaymentStatus.PENDING,
+        providerReference: Not(IsNull()),
+        createdAt: LessThan(cutoff),
+      },
+      order: { createdAt: 'ASC' },
+    });
+
+    for (const payment of stalePayments) {
+      this.logger.warn(
+        `Payment ${payment.id} has been PENDING for more than ${MANUAL_REVIEW_AFTER_HOURS}h and needs manual review.`,
+      );
+    }
+  }
+
+  private isFailedStatus(status: unknown): boolean {
+    return ['failed', 'abandoned', 'reversed'].includes(String(status));
+  }
+}

--- a/backend/src/payments/payments.module.ts
+++ b/backend/src/payments/payments.module.ts
@@ -11,6 +11,7 @@ import { InitializePaymentProvider } from './providers/initialize-payment.provid
 import { HandleWebhookProvider } from './providers/handle-webhook.provider';
 import { RefundPaymentProvider } from './providers/refund-payment.provider';
 import { FindPaymentsProvider } from './providers/find-payments.provider';
+import { PaymentOutcomeProvider } from './providers/payment-outcome.provider';
 import { BookingsModule } from '../bookings/bookings.module';
 import { InvoicesModule } from '../invoices/invoices.module';
 import { NotificationsModule } from '../notifications/notifications.module';
@@ -31,7 +32,13 @@ import { NotificationsModule } from '../notifications/notifications.module';
     HandleWebhookProvider,
     RefundPaymentProvider,
     FindPaymentsProvider,
+    PaymentOutcomeProvider,
   ],
-  exports: [PaymentsService, RefundPaymentProvider],
+  exports: [
+    PaymentsService,
+    RefundPaymentProvider,
+    PaystackProvider,
+    PaymentOutcomeProvider,
+  ],
 })
 export class PaymentsModule {}

--- a/backend/src/payments/providers/handle-webhook.provider.spec.ts
+++ b/backend/src/payments/providers/handle-webhook.provider.spec.ts
@@ -1,93 +1,64 @@
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
 import { HandleWebhookProvider } from './handle-webhook.provider';
-import { PaymentStatus } from '../enums/payment-status.enum';
 
-describe('HandleWebhookProvider — charge.success idempotency', () => {
+describe('HandleWebhookProvider', () => {
   let provider: HandleWebhookProvider;
 
-  const paymentsRepository = { findOne: jest.fn(), save: jest.fn() };
-  const bookingsRepository = { findOne: jest.fn(), update: jest.fn() };
-  const usersRepository = { findOne: jest.fn() };
   const paystackProvider = {
     verifyWebhookSignature: jest.fn().mockReturnValue(true),
   };
-  const sorobanEscrowProvider = { createEscrow: jest.fn() };
-  const bookingsService = { confirm: jest.fn() };
-  const invoicesService = {
-    generateForPayment: jest.fn().mockResolvedValue(undefined),
-  };
-  const notificationsService = {
-    create: jest.fn().mockResolvedValue(undefined),
-  };
-  const emailService = {
-    sendPaymentSuccessEmail: jest.fn().mockResolvedValue(true),
+  const paymentOutcomeProvider = {
+    handleChargeSuccess: jest.fn().mockResolvedValue(undefined),
+    handleChargeFailed: jest.fn().mockResolvedValue(undefined),
   };
 
-  const buildEvent = (reference: string) =>
-    Buffer.from(
-      JSON.stringify({ event: 'charge.success', data: { reference } }),
-    );
+  const buildEvent = (event: string, reference = 'ref-1') =>
+    Buffer.from(JSON.stringify({ event, data: { reference } }));
 
   beforeEach(() => {
     jest.clearAllMocks();
-    paymentsRepository.save.mockImplementation((p: unknown) =>
-      Promise.resolve(p),
-    );
-    usersRepository.findOne.mockResolvedValue(null);
-    bookingsRepository.findOne.mockResolvedValue(null);
+    paystackProvider.verifyWebhookSignature.mockReturnValue(true);
     provider = new HandleWebhookProvider(
-      paymentsRepository as any,
-      bookingsRepository as any,
-      usersRepository as any,
       paystackProvider as any,
-      sorobanEscrowProvider as any,
-      bookingsService as any,
-      invoicesService as any,
-      notificationsService as any,
-      emailService as any,
+      paymentOutcomeProvider as any,
     );
   });
 
-  it('confirms the booking for a fresh PENDING payment', async () => {
-    paymentsRepository.findOne.mockResolvedValue({
-      id: 'pay-1',
-      bookingId: 'booking-1',
-      status: PaymentStatus.PENDING,
-      amount: 100000,
-    });
-    bookingsService.confirm.mockResolvedValue({
-      id: 'booking-1',
-      planType: 'daily',
-    });
+  it('delegates charge.success events to the shared outcome provider', async () => {
+    await provider.handle(buildEvent('charge.success'), 'sig');
 
-    await provider.handle(buildEvent('ref-1'), 'sig');
-
-    expect(bookingsService.confirm).toHaveBeenCalledWith('booking-1');
-    expect(paymentsRepository.save).toHaveBeenCalled();
+    expect(paymentOutcomeProvider.handleChargeSuccess).toHaveBeenCalledWith(
+      'ref-1',
+      { reference: 'ref-1' },
+    );
   });
 
-  it('does not re-confirm a payment that is already SUCCESS', async () => {
-    paymentsRepository.findOne.mockResolvedValue({
-      id: 'pay-1',
-      bookingId: 'booking-1',
-      status: PaymentStatus.SUCCESS,
-    });
+  it('delegates charge.failed events to the shared outcome provider', async () => {
+    await provider.handle(buildEvent('charge.failed'), 'sig');
 
-    await provider.handle(buildEvent('ref-1'), 'sig');
-
-    expect(bookingsService.confirm).not.toHaveBeenCalled();
-    expect(paymentsRepository.save).not.toHaveBeenCalled();
+    expect(paymentOutcomeProvider.handleChargeFailed).toHaveBeenCalledWith(
+      'ref-1',
+    );
   });
 
-  it('does not resurrect a booking whose payment was already REFUNDED', async () => {
-    paymentsRepository.findOne.mockResolvedValue({
-      id: 'pay-1',
-      bookingId: 'booking-1',
-      status: PaymentStatus.REFUNDED,
-    });
+  it('does not delegate unhandled Paystack events', async () => {
+    await provider.handle(buildEvent('transfer.success'), 'sig');
 
-    await provider.handle(buildEvent('ref-1'), 'sig');
+    expect(paymentOutcomeProvider.handleChargeSuccess).not.toHaveBeenCalled();
+    expect(paymentOutcomeProvider.handleChargeFailed).not.toHaveBeenCalled();
+  });
 
-    expect(bookingsService.confirm).not.toHaveBeenCalled();
-    expect(paymentsRepository.save).not.toHaveBeenCalled();
+  it('rejects invalid webhook signatures', async () => {
+    paystackProvider.verifyWebhookSignature.mockReturnValue(false);
+
+    await expect(provider.handle(buildEvent('charge.success'), 'sig')).rejects.toThrow(
+      UnauthorizedException,
+    );
+  });
+
+  it('rejects malformed JSON payloads', async () => {
+    await expect(provider.handle(Buffer.from('{'), 'sig')).rejects.toThrow(
+      BadRequestException,
+    );
   });
 });

--- a/backend/src/payments/providers/handle-webhook.provider.ts
+++ b/backend/src/payments/providers/handle-webhook.provider.ts
@@ -4,44 +4,16 @@ import {
   Logger,
   UnauthorizedException,
 } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { Payment } from '../entities/payment.entity';
-import { PaymentStatus } from '../enums/payment-status.enum';
 import { PaystackProvider } from './paystack.provider';
-import { SorobanEscrowProvider } from './soroban-escrow.provider';
-import { BookingsService } from '../../bookings/bookings.service';
-import { Booking } from '../../bookings/entities/booking.entity';
-import { PlanType } from '../../bookings/enums/plan-type.enum';
-import { InvoicesService } from '../../invoices/invoices.service';
-import { NotificationsService } from '../../notifications/notifications.service';
-import { NotificationType } from '../../notifications/enums/notification-type.enum';
-import { User } from '../../users/entities/user.entity';
-import { EmailService } from '../../email/email.service';
-
-const LONG_TERM_PLANS = new Set([
-  PlanType.MONTHLY,
-  PlanType.QUARTERLY,
-  PlanType.YEARLY,
-]);
+import { PaymentOutcomeProvider } from './payment-outcome.provider';
 
 @Injectable()
 export class HandleWebhookProvider {
   private readonly logger = new Logger(HandleWebhookProvider.name);
 
   constructor(
-    @InjectRepository(Payment)
-    private readonly paymentsRepository: Repository<Payment>,
-    @InjectRepository(Booking)
-    private readonly bookingsRepository: Repository<Booking>,
-    @InjectRepository(User)
-    private readonly usersRepository: Repository<User>,
     private readonly paystackProvider: PaystackProvider,
-    private readonly sorobanEscrowProvider: SorobanEscrowProvider,
-    private readonly bookingsService: BookingsService,
-    private readonly invoicesService: InvoicesService,
-    private readonly notificationsService: NotificationsService,
-    private readonly emailService: EmailService,
+    private readonly paymentOutcomeProvider: PaymentOutcomeProvider,
   ) {}
 
   async handle(rawBody: Buffer, signature: string): Promise<void> {
@@ -65,216 +37,16 @@ export class HandleWebhookProvider {
     const reference = data?.reference as string;
 
     if (!reference) {
-      this.logger.warn(
-        `Webhook event "${eventType}" has no reference — skipped`,
-      );
+      this.logger.warn(`Webhook event "${eventType}" has no reference - skipped`);
       return;
     }
 
     if (eventType === 'charge.success') {
-      await this.handleChargeSuccess(reference, data);
+      await this.paymentOutcomeProvider.handleChargeSuccess(reference, data);
     } else if (eventType === 'charge.failed') {
-      await this.handleChargeFailed(reference);
+      await this.paymentOutcomeProvider.handleChargeFailed(reference);
     } else {
       this.logger.log(`Unhandled Paystack event: ${eventType}`);
-    }
-  }
-
-  private async handleChargeSuccess(
-    reference: string,
-    data: Record<string, unknown>,
-  ): Promise<void> {
-    const payment = await this.paymentsRepository.findOne({
-      where: { providerReference: reference },
-    });
-
-    if (!payment) {
-      this.logger.warn(
-        `charge.success: no payment found for reference ${reference}`,
-      );
-      return;
-    }
-
-    if (
-      payment.status === PaymentStatus.SUCCESS ||
-      payment.status === PaymentStatus.REFUNDED
-    ) {
-      // A refund may have already cancelled the booking; a late/replayed
-      // charge.success must not re-confirm it and undo the refund.
-      this.logger.log(
-        `charge.success: payment ${payment.id} already ${payment.status} — idempotent skip`,
-      );
-      return;
-    }
-
-    payment.status = PaymentStatus.SUCCESS;
-    payment.paidAt = new Date();
-    payment.metadata = data;
-    await this.paymentsRepository.save(payment);
-
-    // Confirm the booking
-    const booking = await this.bookingsService.confirm(payment.bookingId);
-
-    // For long-term bookings, record on-chain escrow
-    if (LONG_TERM_PLANS.has(booking.planType)) {
-      await this.recordSorobanEscrow(payment, booking);
-    }
-
-    // Generate invoice asynchronously — do not block payment confirmation
-    this.invoicesService.generateForPayment(payment.id).catch((err: Error) => {
-      this.logger.error(
-        `Failed to generate invoice for payment ${payment.id}: ${err.message}`,
-      );
-    });
-
-    // Send payment success email
-    this.usersRepository
-      .findOne({ where: { id: payment.userId } })
-      .then((user) => {
-        this.bookingsRepository
-          .findOne({ where: { id: payment.bookingId } })
-          .then((bk) => {
-            const emailRecipient =
-              user?.email ?? (bk?.isGuestBooking ? bk?.guestInfo?.email : null);
-            const displayName =
-              user?.fullName ??
-              (bk?.isGuestBooking ? bk?.guestInfo?.name : null);
-            if (!emailRecipient || !displayName) return;
-            this.emailService
-              .sendPaymentSuccessEmail(emailRecipient, displayName, {
-                bookingId: payment.bookingId,
-                workspaceName: bk?.workspaceId ?? '',
-                amountNaira: (payment.amount / 100).toFixed(2),
-                paidAt: payment.paidAt
-                  ? new Date(payment.paidAt).toLocaleString()
-                  : '',
-                invoiceNumber: '',
-              })
-              .catch(() => void 0);
-          })
-          .catch(() => void 0);
-      })
-      .catch(() => void 0);
-
-    // Notify user (skip for guest bookings which have no userId)
-    if (payment.userId) {
-      this.notificationsService
-        .create({
-          userId: payment.userId,
-          type: NotificationType.PAYMENT_SUCCESS,
-          title: 'Payment Successful',
-          message: `Your payment of ₦${(payment.amount / 100).toFixed(2)} has been confirmed and your booking is now active.`,
-          metadata: { paymentId: payment.id, bookingId: payment.bookingId },
-        })
-        .catch(() => void 0);
-    }
-
-    this.logger.log(
-      `charge.success: payment ${payment.id} succeeded, booking ${booking.id} confirmed`,
-    );
-  }
-
-  private async handleChargeFailed(reference: string): Promise<void> {
-    const payment = await this.paymentsRepository.findOne({
-      where: { providerReference: reference },
-    });
-
-    if (!payment) {
-      this.logger.warn(
-        `charge.failed: no payment found for reference ${reference}`,
-      );
-      return;
-    }
-
-    if (payment.status !== PaymentStatus.PENDING) {
-      return;
-    }
-
-    payment.status = PaymentStatus.FAILED;
-    await this.paymentsRepository.save(payment);
-
-    // Send payment failed email
-    if (payment.userId) {
-      this.usersRepository
-        .findOne({ where: { id: payment.userId } })
-        .then((user) => {
-          if (!user) return;
-          this.emailService
-            .sendPaymentFailedEmail(user.email, user.fullName, {
-              paymentReference: payment.providerReference ?? payment.id,
-              amountNaira: (payment.amount / 100).toFixed(2),
-            })
-            .catch(() => void 0);
-        })
-        .catch(() => void 0);
-    } else {
-      // Guest booking — look up email from booking guestInfo
-      this.bookingsRepository
-        .findOne({ where: { id: payment.bookingId } })
-        .then((bk) => {
-          if (!bk?.guestInfo?.email) return;
-          this.emailService
-            .sendPaymentFailedEmail(bk.guestInfo.email, bk.guestInfo.name, {
-              paymentReference: payment.providerReference ?? payment.id,
-              amountNaira: (payment.amount / 100).toFixed(2),
-            })
-            .catch(() => void 0);
-        })
-        .catch(() => void 0);
-    }
-
-    if (payment.userId) {
-      this.notificationsService
-        .create({
-          userId: payment.userId,
-          type: NotificationType.PAYMENT_FAILED,
-          title: 'Payment Failed',
-          message: 'Your payment could not be processed. Please try again.',
-          metadata: { paymentId: payment.id, bookingId: payment.bookingId },
-        })
-        .catch(() => void 0);
-    }
-
-    this.logger.log(`charge.failed: payment ${payment.id} marked FAILED`);
-  }
-
-  private async recordSorobanEscrow(
-    payment: Payment,
-    booking: Booking,
-  ): Promise<void> {
-    if (!this.sorobanEscrowProvider.isEnabled) {
-      this.logger.log(
-        `Soroban escrow disabled — skipping on-chain escrow for booking ${booking.id}`,
-      );
-      return;
-    }
-
-    try {
-      const beneficiary = this.sorobanEscrowProvider.beneficiary;
-      const releaseAfterUnix =
-        Math.floor(new Date(booking.endDate).getTime() / 1000) + 86400;
-
-      const txHash = await this.sorobanEscrowProvider.createEscrow(
-        booking.id,
-        payment.userId,
-        beneficiary,
-        payment.amount,
-        `Booking ${booking.id}`,
-        releaseAfterUnix,
-      );
-
-      await this.bookingsRepository.update(booking.id, {
-        sorobanEscrowId: txHash,
-      });
-
-      this.logger.log(
-        `Soroban escrow recorded for booking ${booking.id}: ${txHash}`,
-      );
-    } catch (err) {
-      // Non-critical — log but do not fail the payment confirmation
-      this.logger.error(
-        `Failed to record Soroban escrow for booking ${booking.id}: ${(err as Error).message}`,
-      );
     }
   }
 }

--- a/backend/src/payments/providers/payment-outcome.provider.spec.ts
+++ b/backend/src/payments/providers/payment-outcome.provider.spec.ts
@@ -1,0 +1,119 @@
+import { NotificationType } from '../../notifications/enums/notification-type.enum';
+import { PaymentStatus } from '../enums/payment-status.enum';
+import { PaymentOutcomeProvider } from './payment-outcome.provider';
+
+describe('PaymentOutcomeProvider', () => {
+  const paymentsRepository = { findOne: jest.fn(), save: jest.fn() };
+  const bookingsRepository = { findOne: jest.fn(), update: jest.fn() };
+  const usersRepository = { findOne: jest.fn() };
+  const sorobanEscrowProvider = { isEnabled: false, createEscrow: jest.fn() };
+  const bookingsService = { confirm: jest.fn() };
+  const invoicesService = {
+    generateForPayment: jest.fn().mockResolvedValue(undefined),
+  };
+  const notificationsService = {
+    create: jest.fn().mockResolvedValue(undefined),
+  };
+  const emailService = {
+    sendPaymentSuccessEmail: jest.fn().mockResolvedValue(true),
+    sendPaymentFailedEmail: jest.fn().mockResolvedValue(true),
+  };
+
+  let provider: PaymentOutcomeProvider;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    paymentsRepository.save.mockImplementation((payment) =>
+      Promise.resolve(payment),
+    );
+    usersRepository.findOne.mockResolvedValue(null);
+    bookingsRepository.findOne.mockResolvedValue(null);
+    provider = new PaymentOutcomeProvider(
+      paymentsRepository as any,
+      bookingsRepository as any,
+      usersRepository as any,
+      sorobanEscrowProvider as any,
+      bookingsService as any,
+      invoicesService as any,
+      notificationsService as any,
+      emailService as any,
+    );
+  });
+
+  it('confirms the booking for a fresh PENDING payment', async () => {
+    paymentsRepository.findOne.mockResolvedValue({
+      id: 'pay-1',
+      bookingId: 'booking-1',
+      userId: 'user-1',
+      status: PaymentStatus.PENDING,
+      amount: 100000,
+    });
+    bookingsService.confirm.mockResolvedValue({
+      id: 'booking-1',
+      planType: 'daily',
+    });
+
+    await provider.handleChargeSuccess('ref-1', { reference: 'ref-1' });
+
+    expect(bookingsService.confirm).toHaveBeenCalledWith('booking-1');
+    expect(paymentsRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ status: PaymentStatus.SUCCESS }),
+    );
+    expect(invoicesService.generateForPayment).toHaveBeenCalledWith('pay-1');
+    expect(notificationsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        type: NotificationType.PAYMENT_SUCCESS,
+      }),
+    );
+  });
+
+  it('does not re-confirm a payment that is already SUCCESS', async () => {
+    paymentsRepository.findOne.mockResolvedValue({
+      id: 'pay-1',
+      bookingId: 'booking-1',
+      status: PaymentStatus.SUCCESS,
+    });
+
+    await provider.handleChargeSuccess('ref-1', { reference: 'ref-1' });
+
+    expect(bookingsService.confirm).not.toHaveBeenCalled();
+    expect(paymentsRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('does not resurrect a booking whose payment was already REFUNDED', async () => {
+    paymentsRepository.findOne.mockResolvedValue({
+      id: 'pay-1',
+      bookingId: 'booking-1',
+      status: PaymentStatus.REFUNDED,
+    });
+
+    await provider.handleChargeSuccess('ref-1', { reference: 'ref-1' });
+
+    expect(bookingsService.confirm).not.toHaveBeenCalled();
+    expect(paymentsRepository.save).not.toHaveBeenCalled();
+  });
+
+  it('marks pending failed charges as FAILED and notifies the user', async () => {
+    paymentsRepository.findOne.mockResolvedValue({
+      id: 'pay-1',
+      bookingId: 'booking-1',
+      userId: 'user-1',
+      providerReference: 'ref-1',
+      status: PaymentStatus.PENDING,
+      amount: 100000,
+    });
+
+    await provider.handleChargeFailed('ref-1');
+
+    expect(paymentsRepository.save).toHaveBeenCalledWith(
+      expect.objectContaining({ status: PaymentStatus.FAILED }),
+    );
+    expect(notificationsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 'user-1',
+        type: NotificationType.PAYMENT_FAILED,
+      }),
+    );
+  });
+});

--- a/backend/src/payments/providers/payment-outcome.provider.ts
+++ b/backend/src/payments/providers/payment-outcome.provider.ts
@@ -1,0 +1,247 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Booking } from '../../bookings/entities/booking.entity';
+import { PlanType } from '../../bookings/enums/plan-type.enum';
+import { BookingsService } from '../../bookings/bookings.service';
+import { EmailService } from '../../email/email.service';
+import { InvoicesService } from '../../invoices/invoices.service';
+import { NotificationsService } from '../../notifications/notifications.service';
+import { NotificationType } from '../../notifications/enums/notification-type.enum';
+import { User } from '../../users/entities/user.entity';
+import { Payment } from '../entities/payment.entity';
+import { PaymentStatus } from '../enums/payment-status.enum';
+import { SorobanEscrowProvider } from './soroban-escrow.provider';
+
+const LONG_TERM_PLANS = new Set([
+  PlanType.MONTHLY,
+  PlanType.QUARTERLY,
+  PlanType.YEARLY,
+]);
+
+@Injectable()
+export class PaymentOutcomeProvider {
+  private readonly logger = new Logger(PaymentOutcomeProvider.name);
+
+  constructor(
+    @InjectRepository(Payment)
+    private readonly paymentsRepository: Repository<Payment>,
+    @InjectRepository(Booking)
+    private readonly bookingsRepository: Repository<Booking>,
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+    private readonly sorobanEscrowProvider: SorobanEscrowProvider,
+    private readonly bookingsService: BookingsService,
+    private readonly invoicesService: InvoicesService,
+    private readonly notificationsService: NotificationsService,
+    private readonly emailService: EmailService,
+  ) {}
+
+  async handleChargeSuccess(
+    reference: string,
+    data: Record<string, unknown>,
+    source = 'charge.success',
+  ): Promise<void> {
+    const payment = await this.paymentsRepository.findOne({
+      where: { providerReference: reference },
+    });
+
+    if (!payment) {
+      this.logger.warn(`${source}: no payment found for reference ${reference}`);
+      return;
+    }
+
+    if (
+      payment.status === PaymentStatus.SUCCESS ||
+      payment.status === PaymentStatus.REFUNDED
+    ) {
+      this.logger.log(
+        `${source}: payment ${payment.id} already ${payment.status} - idempotent skip`,
+      );
+      return;
+    }
+
+    payment.status = PaymentStatus.SUCCESS;
+    payment.paidAt = new Date();
+    payment.metadata = data;
+    await this.paymentsRepository.save(payment);
+
+    const booking = await this.bookingsService.confirm(payment.bookingId);
+
+    if (LONG_TERM_PLANS.has(booking.planType)) {
+      await this.recordSorobanEscrow(payment, booking);
+    }
+
+    this.invoicesService.generateForPayment(payment.id).catch((err: Error) => {
+      this.logger.error(
+        `Failed to generate invoice for payment ${payment.id}: ${err.message}`,
+      );
+    });
+
+    this.sendPaymentSuccessEmail(payment);
+    this.notifyPaymentSuccess(payment);
+
+    this.logger.log(
+      `${source}: payment ${payment.id} succeeded, booking ${booking.id} confirmed`,
+    );
+  }
+
+  async handleChargeFailed(
+    reference: string,
+    source = 'charge.failed',
+  ): Promise<void> {
+    const payment = await this.paymentsRepository.findOne({
+      where: { providerReference: reference },
+    });
+
+    if (!payment) {
+      this.logger.warn(`${source}: no payment found for reference ${reference}`);
+      return;
+    }
+
+    if (payment.status !== PaymentStatus.PENDING) {
+      this.logger.log(
+        `${source}: payment ${payment.id} already ${payment.status} - idempotent skip`,
+      );
+      return;
+    }
+
+    payment.status = PaymentStatus.FAILED;
+    await this.paymentsRepository.save(payment);
+
+    this.sendPaymentFailedEmail(payment);
+    this.notifyPaymentFailed(payment);
+
+    this.logger.log(`${source}: payment ${payment.id} marked FAILED`);
+  }
+
+  private sendPaymentSuccessEmail(payment: Payment): void {
+    this.usersRepository
+      .findOne({ where: { id: payment.userId } })
+      .then((user) => {
+        this.bookingsRepository
+          .findOne({ where: { id: payment.bookingId } })
+          .then((booking) => {
+            const emailRecipient =
+              user?.email ??
+              (booking?.isGuestBooking ? booking?.guestInfo?.email : null);
+            const displayName =
+              user?.fullName ??
+              (booking?.isGuestBooking ? booking?.guestInfo?.name : null);
+            if (!emailRecipient || !displayName) return;
+
+            this.emailService
+              .sendPaymentSuccessEmail(emailRecipient, displayName, {
+                bookingId: payment.bookingId,
+                workspaceName: booking?.workspaceId ?? '',
+                amountNaira: (payment.amount / 100).toFixed(2),
+                paidAt: payment.paidAt
+                  ? new Date(payment.paidAt).toLocaleString()
+                  : '',
+                invoiceNumber: '',
+              })
+              .catch(() => void 0);
+          })
+          .catch(() => void 0);
+      })
+      .catch(() => void 0);
+  }
+
+  private sendPaymentFailedEmail(payment: Payment): void {
+    if (payment.userId) {
+      this.usersRepository
+        .findOne({ where: { id: payment.userId } })
+        .then((user) => {
+          if (!user) return;
+          this.emailService
+            .sendPaymentFailedEmail(user.email, user.fullName, {
+              paymentReference: payment.providerReference ?? payment.id,
+              amountNaira: (payment.amount / 100).toFixed(2),
+            })
+            .catch(() => void 0);
+        })
+        .catch(() => void 0);
+      return;
+    }
+
+    this.bookingsRepository
+      .findOne({ where: { id: payment.bookingId } })
+      .then((booking) => {
+        if (!booking?.guestInfo?.email) return;
+        this.emailService
+          .sendPaymentFailedEmail(booking.guestInfo.email, booking.guestInfo.name, {
+            paymentReference: payment.providerReference ?? payment.id,
+            amountNaira: (payment.amount / 100).toFixed(2),
+          })
+          .catch(() => void 0);
+      })
+      .catch(() => void 0);
+  }
+
+  private notifyPaymentSuccess(payment: Payment): void {
+    if (!payment.userId) return;
+
+    this.notificationsService
+      .create({
+        userId: payment.userId,
+        type: NotificationType.PAYMENT_SUCCESS,
+        title: 'Payment Successful',
+        message: `Your payment of NGN ${(payment.amount / 100).toFixed(2)} has been confirmed and your booking is now active.`,
+        metadata: { paymentId: payment.id, bookingId: payment.bookingId },
+      })
+      .catch(() => void 0);
+  }
+
+  private notifyPaymentFailed(payment: Payment): void {
+    if (!payment.userId) return;
+
+    this.notificationsService
+      .create({
+        userId: payment.userId,
+        type: NotificationType.PAYMENT_FAILED,
+        title: 'Payment Failed',
+        message: 'Your payment could not be processed. Please try again.',
+        metadata: { paymentId: payment.id, bookingId: payment.bookingId },
+      })
+      .catch(() => void 0);
+  }
+
+  private async recordSorobanEscrow(
+    payment: Payment,
+    booking: Booking,
+  ): Promise<void> {
+    if (!this.sorobanEscrowProvider.isEnabled) {
+      this.logger.log(
+        `Soroban escrow disabled - skipping on-chain escrow for booking ${booking.id}`,
+      );
+      return;
+    }
+
+    try {
+      const beneficiary = this.sorobanEscrowProvider.beneficiary;
+      const releaseAfterUnix =
+        Math.floor(new Date(booking.endDate).getTime() / 1000) + 86400;
+
+      const txHash = await this.sorobanEscrowProvider.createEscrow(
+        booking.id,
+        payment.userId,
+        beneficiary,
+        payment.amount,
+        `Booking ${booking.id}`,
+        releaseAfterUnix,
+      );
+
+      await this.bookingsRepository.update(booking.id, {
+        sorobanEscrowId: txHash,
+      });
+
+      this.logger.log(
+        `Soroban escrow recorded for booking ${booking.id}: ${txHash}`,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Failed to record Soroban escrow for booking ${booking.id}: ${(err as Error).message}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
Summary
Implements a payment reconciliation job to recover PENDING Paystack payments when webhooks are missed. This ensures successful payments are eventually confirmed and failed payments are updated appropriately.

Changes
Added verifyTransaction(reference) to PaystackProvider.
Extracted payment success/failure handling into a shared PaymentOutcomeProvider used by both the webhook and reconciliation flow.
Added a cron job (runs every 15 minutes) to verify pending Paystack payments older than 15 minutes.
Limited reconciliation to payments between 15 minutes and 24 hours old.
Added logging for payments pending for more than 24 hours to support manual review.
Preserved idempotency by skipping payments that have already been processed.
Result
Missed Paystack webhooks are automatically recovered within the reconciliation window.
Successful payments trigger booking confirmation, invoice generation, email, and notifications through the same processing path as webhooks.
Failed payments are marked as FAILED and handled consistently.
Payments older than 24 hours are excluded from reconciliation and logged for manual investigation.

closes: #1332 