### PR TITLE
feat: add AuditLog entity for tracking sensitive operations

### DIFF
--- a/backend/src/audit/entities/audit-log.entity.ts
+++ b/backend/src/audit/entities/audit-log.entity.ts
@@ -1,0 +1,38 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('audit_logs')
+export class AuditLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  @Index()
+  actorUserId: string;
+
+  @Column()
+  @Index()
+  action: string;
+
+  @Column()
+  resourceType: string;
+
+  @Column({ nullable: true })
+  @Index()
+  resourceId: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, any>;
+
+  @Column({ nullable: true })
+  ipAddress: string;
+
+  @CreateDateColumn()
+  @Index()
+  createdAt: Date;
+}


### PR DESCRIPTION
## Overview
This PR adds the AuditLog entity for recording sensitive operations.

## Changes
- Created ackend/src/audit/entities/audit-log.entity.ts
- Tracks actor, action, resource, metadata, IP address, and timestamp
- Indexes on actorUserId, action, resourceId, and createdAt for efficient queries

## Acceptance Criteria
- [x] AuditLog entity created with required fields
- [x] Indexes added for common query patterns
- [x] Append-only design (no update/delete API)

Closes #1391
Closes #1392
Closes #1393
Closes #1394