### PR TITLE
feat(payments): real-time confirmation pipeline & app/provider state boundary

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -86,3 +86,11 @@ BOOKING_PAYMENT_TTL_MINUTES=120
 # Payments module (issue #1570)
 # Minutes an INITIATED Payment may sit before it is eligible for expiry sweep
 PAYMENT_INITIATED_TTL_MINUTES=30
+
+# Payments confirmation pipeline (issue #1571)
+# Shared secret for verifying the sandbox rail's webhook HMAC signature
+PAYMENT_WEBHOOK_SECRET=change-me-in-every-environment
+# Bounded timeout (ms) for the synchronous verify-on-return fast path —
+# a timeout falls back to the webhook/real-time channel, it never marks a
+# payment CONFIRMED on its own.
+PAYMENT_VERIFY_TIMEOUT_MS=3000

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -4,7 +4,10 @@ import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  // rawBody is needed by the payment webhook controller to verify HMAC
+  // signatures against the exact bytes the provider signed, not a
+  // re-serialized copy of the parsed JSON body.
+  const app = await NestFactory.create(AppModule, { rawBody: true });
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/backend/src/payments/adapters/sandbox-rail.adapter.spec.ts
+++ b/backend/src/payments/adapters/sandbox-rail.adapter.spec.ts
@@ -1,0 +1,126 @@
+import { createHmac } from 'crypto';
+import { SandboxRailAdapter } from './sandbox-rail.adapter';
+
+function makeConfig(secret: string | undefined = 'test-secret') {
+  return { get: jest.fn(() => secret) };
+}
+
+function sign(secret: string, rawBody: Buffer): string {
+  return createHmac('sha256', secret).update(rawBody).digest('hex');
+}
+
+describe('SandboxRailAdapter', () => {
+  describe('initiate', () => {
+    it('returns a sandbox provider reference', async () => {
+      const adapter = new SandboxRailAdapter(makeConfig() as any);
+      const result = await adapter.initiate({ bookingId: 'booking-1' } as any);
+      expect(result.providerReference).toMatch(/^sandbox_/);
+    });
+  });
+
+  describe('verifyWebhookSignature', () => {
+    it('accepts a correctly signed payload', () => {
+      const adapter = new SandboxRailAdapter(makeConfig('shh') as any);
+      const rawBody = Buffer.from(JSON.stringify({ a: 1 }));
+      const signature = sign('shh', rawBody);
+
+      expect(
+        adapter.verifyWebhookSignature({ rawBody, signatureHeader: signature }),
+      ).toBe(true);
+    });
+
+    it('rejects a payload with the wrong signature', () => {
+      const adapter = new SandboxRailAdapter(makeConfig('shh') as any);
+      const rawBody = Buffer.from(JSON.stringify({ a: 1 }));
+
+      expect(
+        adapter.verifyWebhookSignature({
+          rawBody,
+          signatureHeader: 'not-the-right-signature-value',
+        }),
+      ).toBe(false);
+    });
+
+    it('rejects a payload signed with a different secret (tampered or wrong sender)', () => {
+      const adapter = new SandboxRailAdapter(makeConfig('shh') as any);
+      const rawBody = Buffer.from(JSON.stringify({ a: 1 }));
+      const wrongSignature = sign('a-different-secret', rawBody);
+
+      expect(
+        adapter.verifyWebhookSignature({
+          rawBody,
+          signatureHeader: wrongSignature,
+        }),
+      ).toBe(false);
+    });
+
+    it('rejects when the signature header is missing', () => {
+      const adapter = new SandboxRailAdapter(makeConfig('shh') as any);
+      const rawBody = Buffer.from(JSON.stringify({ a: 1 }));
+
+      expect(
+        adapter.verifyWebhookSignature({
+          rawBody,
+          signatureHeader: undefined,
+        }),
+      ).toBe(false);
+    });
+
+    it('rejects when no secret is configured', () => {
+      const adapter = new SandboxRailAdapter(makeConfig(undefined) as any);
+      const rawBody = Buffer.from(JSON.stringify({ a: 1 }));
+
+      expect(
+        adapter.verifyWebhookSignature({
+          rawBody,
+          signatureHeader: sign('shh', rawBody),
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('parseWebhookPayload', () => {
+    it('parses a well-formed payload', () => {
+      const adapter = new SandboxRailAdapter(makeConfig() as any);
+      const rawBody = Buffer.from(
+        JSON.stringify({ providerReference: 'ref-1', outcome: 'confirmed' }),
+      );
+
+      expect(adapter.parseWebhookPayload(rawBody)).toEqual({
+        providerReference: 'ref-1',
+        outcome: 'confirmed',
+      });
+    });
+
+    it('throws on a malformed payload', () => {
+      const adapter = new SandboxRailAdapter(makeConfig() as any);
+      const rawBody = Buffer.from(JSON.stringify({ foo: 'bar' }));
+
+      expect(() => adapter.parseWebhookPayload(rawBody)).toThrow();
+    });
+
+    it('throws on an unrecognized outcome value', () => {
+      const adapter = new SandboxRailAdapter(makeConfig() as any);
+      const rawBody = Buffer.from(
+        JSON.stringify({
+          providerReference: 'ref-1',
+          outcome: 'not-a-real-outcome',
+        }),
+      );
+
+      expect(() => adapter.parseWebhookPayload(rawBody)).toThrow();
+    });
+  });
+
+  describe('verifyByReference', () => {
+    it.each([
+      ['sandbox_ref_ok', 'confirmed'],
+      ['sandbox_ref_fail', 'failed'],
+      ['sandbox_ref_pending', 'pending'],
+    ])('resolves %s to %s', async (reference, expectedOutcome) => {
+      const adapter = new SandboxRailAdapter(makeConfig() as any);
+      const result = await adapter.verifyByReference(reference);
+      expect(result.outcome).toBe(expectedOutcome);
+    });
+  });
+});

--- a/backend/src/payments/adapters/sandbox-rail.adapter.ts
+++ b/backend/src/payments/adapters/sandbox-rail.adapter.ts
@@ -1,21 +1,91 @@
 import { Injectable } from '@nestjs/common';
-import { randomUUID } from 'crypto';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, timingSafeEqual, randomUUID } from 'crypto';
 import { Payment } from '../entities/payment.entity';
 import {
   PaymentInitiationResult,
   PaymentRailAdapter,
+  PaymentVerificationOutcome,
+  PaymentVerificationResult,
+  WebhookPayload,
+  WebhookSignatureInput,
 } from '../interfaces/payment-rail-adapter.interface';
 
 /**
  * Placeholder adapter used until the real Paystack / Stellar adapters land
- * (issues 2-7 of the payment track). Never wired to a live provider.
+ * (issues 3-7 of the payment track). Never wired to a live provider.
+ *
+ * verifyByReference is deterministic on the providerReference so tests (and
+ * manual sandbox testing) can exercise every outcome without needing a real
+ * provider: a reference containing "fail"/"pending" produces that outcome,
+ * anything else is treated as confirmed.
  */
 @Injectable()
 export class SandboxRailAdapter implements PaymentRailAdapter {
+  constructor(private readonly config: ConfigService) {}
+
   async initiate(payment: Payment): Promise<PaymentInitiationResult> {
     return {
       providerReference: `sandbox_${randomUUID()}`,
       metadata: { sandbox: true, bookingId: payment.bookingId },
     };
+  }
+
+  verifyWebhookSignature({
+    rawBody,
+    signatureHeader,
+  }: WebhookSignatureInput): boolean {
+    if (!signatureHeader) {
+      return false;
+    }
+    const secret = this.config.get<string>('PAYMENT_WEBHOOK_SECRET');
+    if (!secret) {
+      return false;
+    }
+
+    const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+    const expectedBuf = Buffer.from(expected, 'utf8');
+    const providedBuf = Buffer.from(signatureHeader, 'utf8');
+
+    if (expectedBuf.length !== providedBuf.length) {
+      return false;
+    }
+    return timingSafeEqual(expectedBuf, providedBuf);
+  }
+
+  parseWebhookPayload(rawBody: Buffer): WebhookPayload {
+    const parsed: unknown = JSON.parse(rawBody.toString('utf8'));
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof (parsed as { providerReference?: unknown }).providerReference !==
+        'string' ||
+      !SandboxRailAdapter.isOutcome((parsed as { outcome?: unknown }).outcome)
+    ) {
+      throw new Error('Malformed sandbox webhook payload');
+    }
+    const body = parsed as {
+      providerReference: string;
+      outcome: PaymentVerificationOutcome;
+    };
+    return { providerReference: body.providerReference, outcome: body.outcome };
+  }
+
+  async verifyByReference(
+    providerReference: string,
+  ): Promise<PaymentVerificationResult> {
+    if (providerReference.includes('fail')) {
+      return { outcome: 'failed' };
+    }
+    if (providerReference.includes('pending')) {
+      return { outcome: 'pending' };
+    }
+    return { outcome: 'confirmed' };
+  }
+
+  private static isOutcome(
+    value: unknown,
+  ): value is PaymentVerificationOutcome {
+    return value === 'confirmed' || value === 'failed' || value === 'pending';
   }
 }

--- a/backend/src/payments/dto/verify-return-response.dto.ts
+++ b/backend/src/payments/dto/verify-return-response.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { PaymentResponseDto } from './payment-response.dto';
+
+export class VerifyReturnResponseDto {
+  @ApiProperty({ type: PaymentResponseDto })
+  payment: PaymentResponseDto;
+
+  @ApiProperty({
+    description:
+      'True only if the provider gave an authoritative confirmed/failed ' +
+      'response within the bounded timeout. False means the caller should ' +
+      'fall back to the real-time channel or polling — it never implies ' +
+      'the payment failed.',
+  })
+  verified: boolean;
+}

--- a/backend/src/payments/entities/confirmation-event.entity.ts
+++ b/backend/src/payments/entities/confirmation-event.entity.ts
@@ -1,0 +1,69 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ConfirmationSource } from '../enums/confirmation-source.enum';
+import { PaymentStatus } from '../enums/payment-status.enum';
+
+/**
+ * Append-only audit trail of every confirmation event this pipeline ever
+ * received — webhook or verify-on-return — regardless of whether it ended
+ * up changing anything. This is what a later observability issue surfaces
+ * (see issue #1571): duplicate deliveries, out-of-order/conflicting events,
+ * forged signatures, and events for a payment that couldn't be found must
+ * all show up here, not just the ones that actually moved a Payment.
+ */
+@Entity('payment_confirmation_events')
+export class ConfirmationEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Null when the event's providerReference matched no known Payment. */
+  @Index()
+  @Column({ type: 'uuid', name: 'payment_id', nullable: true })
+  paymentId: string | null;
+
+  @Column({ type: 'varchar', name: 'provider_reference', nullable: true })
+  providerReference: string | null;
+
+  @Column({ type: 'enum', enum: ConfirmationSource })
+  source: ConfirmationSource;
+
+  /** sha256 of the raw payload — never the payload itself. */
+  @Column({ type: 'varchar', name: 'raw_payload_hash' })
+  rawPayloadHash: string;
+
+  @Column({
+    type: 'enum',
+    enum: PaymentStatus,
+    name: 'previous_status',
+    nullable: true,
+  })
+  previousStatus: PaymentStatus | null;
+
+  @Column({
+    type: 'enum',
+    enum: PaymentStatus,
+    name: 'resulting_status',
+    nullable: true,
+  })
+  resultingStatus: PaymentStatus | null;
+
+  /** True only when this event actually moved Payment#status. */
+  @Column({ type: 'boolean' })
+  applied: boolean;
+
+  /**
+   * e.g. 'payment_not_found', 'invalid_signature', 'conflicting_event'.
+   * Null for a clean, expected no-op (plain duplicate delivery) or a
+   * successfully applied transition.
+   */
+  @Column({ type: 'varchar', nullable: true })
+  anomaly: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/backend/src/payments/enums/confirmation-source.enum.ts
+++ b/backend/src/payments/enums/confirmation-source.enum.ts
@@ -1,0 +1,4 @@
+export enum ConfirmationSource {
+  WEBHOOK = 'WEBHOOK',
+  VERIFY_RETURN = 'VERIFY_RETURN',
+}

--- a/backend/src/payments/interfaces/payment-rail-adapter.interface.ts
+++ b/backend/src/payments/interfaces/payment-rail-adapter.interface.ts
@@ -6,11 +6,45 @@ export interface PaymentInitiationResult {
   metadata?: Record<string, unknown>;
 }
 
+export type PaymentVerificationOutcome = 'confirmed' | 'failed' | 'pending';
+
+export interface PaymentVerificationResult {
+  outcome: PaymentVerificationOutcome;
+}
+
+export interface WebhookSignatureInput {
+  rawBody: Buffer;
+  signatureHeader: string | undefined;
+}
+
+export interface WebhookPayload {
+  providerReference: string;
+  outcome: PaymentVerificationOutcome;
+}
+
 /**
  * Provider-agnostic boundary between the Payment domain and a concrete rail
  * (Paystack, Stellar custodial, Stellar external, ...). Later issues in the
- * payment track implement real adapters; this issue only needs the shape.
+ * payment track implement real adapters; issue #1570 only needed `initiate`.
+ * Issue #1571 adds the confirmation-side shape: verifying a webhook's
+ * transport-level authenticity, parsing its payload, and a bounded
+ * synchronous verify-by-reference call for the checkout-return fast path.
  */
 export interface PaymentRailAdapter {
   initiate(payment: Payment): Promise<PaymentInitiationResult>;
+
+  /** Transport-level authenticity check — must happen before any payload is trusted. */
+  verifyWebhookSignature(input: WebhookSignatureInput): boolean;
+
+  /** Only call after verifyWebhookSignature has passed. */
+  parseWebhookPayload(rawBody: Buffer): WebhookPayload;
+
+  /**
+   * Synchronous, bounded call to the provider's verify-by-reference API for
+   * the checkout-return fast path. Implementations should not do their own
+   * unbounded waiting — the caller enforces the timeout.
+   */
+  verifyByReference(
+    providerReference: string,
+  ): Promise<PaymentVerificationResult>;
 }

--- a/backend/src/payments/payment-confirmation.service.spec.ts
+++ b/backend/src/payments/payment-confirmation.service.spec.ts
@@ -1,0 +1,307 @@
+import { PaymentConfirmationService } from './payment-confirmation.service';
+import { Payment } from './entities/payment.entity';
+import { PaymentRail } from './enums/payment-rail.enum';
+import { PaymentStatus } from './enums/payment-status.enum';
+import { ConfirmationSource } from './enums/confirmation-source.enum';
+
+type MockEventRepository = {
+  create: jest.Mock;
+  save: jest.Mock;
+};
+
+function makePaymentRepository() {
+  return {
+    findOne: jest.fn(),
+    save: jest.fn(async (entity: Payment) => entity),
+  };
+}
+
+function makeEventRepository(): MockEventRepository {
+  return {
+    create: jest.fn((data) => ({ ...data })),
+    save: jest.fn(async (entity) => entity),
+  };
+}
+
+function makePayment(overrides: Partial<Payment> = {}): Payment {
+  return {
+    id: 'payment-1',
+    bookingId: 'booking-1',
+    userId: 'user-1',
+    amount: 500_000,
+    currency: 'USD',
+    rail: PaymentRail.FIAT,
+    provider: null,
+    providerReference: 'sandbox_ref_1',
+    status: PaymentStatus.AWAITING_CONFIRMATION,
+    idempotencyKey: 'key-1',
+    metadata: null,
+    expiresAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as Payment;
+}
+
+describe('PaymentConfirmationService', () => {
+  let paymentRepository: ReturnType<typeof makePaymentRepository>;
+  let eventRepository: MockEventRepository;
+  let paymentsService: { transitionStatus: jest.Mock };
+  let gateway: { emitPaymentUpdate: jest.Mock };
+  let railAdapter: { verifyByReference: jest.Mock };
+  let config: { get: jest.Mock };
+  let service: PaymentConfirmationService;
+
+  beforeEach(() => {
+    paymentRepository = makePaymentRepository();
+    eventRepository = makeEventRepository();
+    paymentsService = {
+      transitionStatus: jest.fn((payment: Payment, next: PaymentStatus) => {
+        payment.status = next;
+        return payment;
+      }),
+    };
+    gateway = { emitPaymentUpdate: jest.fn() };
+    railAdapter = { verifyByReference: jest.fn() };
+    config = { get: jest.fn((_key: string, fallback?: unknown) => fallback) };
+
+    service = new PaymentConfirmationService(
+      paymentRepository as any,
+      eventRepository as any,
+      paymentsService as any,
+      gateway as any,
+      railAdapter as any,
+      config as any,
+    );
+  });
+
+  describe('apply', () => {
+    it('logs an anomaly and returns null when no payment matches the reference', async () => {
+      paymentRepository.findOne.mockResolvedValueOnce(null);
+
+      const result = await service.apply(
+        'unknown-ref',
+        'confirmed',
+        ConfirmationSource.WEBHOOK,
+        'hash-1',
+      );
+
+      expect(result).toBeNull();
+      expect(eventRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paymentId: null,
+          providerReference: 'unknown-ref',
+          applied: false,
+          anomaly: 'payment_not_found',
+        }),
+      );
+    });
+
+    it('transitions AWAITING_CONFIRMATION -> CONFIRMED and emits a real-time update', async () => {
+      const payment = makePayment();
+      paymentRepository.findOne.mockResolvedValueOnce(payment);
+
+      const result = await service.apply(
+        payment.providerReference!,
+        'confirmed',
+        ConfirmationSource.WEBHOOK,
+        'hash-1',
+      );
+
+      expect(result?.status).toBe(PaymentStatus.CONFIRMED);
+      expect(paymentsService.transitionStatus).toHaveBeenCalledWith(
+        payment,
+        PaymentStatus.CONFIRMED,
+      );
+      expect(gateway.emitPaymentUpdate).toHaveBeenCalledWith(
+        payment.id,
+        PaymentStatus.CONFIRMED,
+      );
+      expect(eventRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paymentId: payment.id,
+          previousStatus: PaymentStatus.AWAITING_CONFIRMATION,
+          resultingStatus: PaymentStatus.CONFIRMED,
+          applied: true,
+          anomaly: null,
+        }),
+      );
+    });
+
+    it('transitions to FAILED on a failed outcome', async () => {
+      const payment = makePayment();
+      paymentRepository.findOne.mockResolvedValueOnce(payment);
+
+      const result = await service.apply(
+        payment.providerReference!,
+        'failed',
+        ConfirmationSource.WEBHOOK,
+        'hash-1',
+      );
+
+      expect(result?.status).toBe(PaymentStatus.FAILED);
+      expect(gateway.emitPaymentUpdate).toHaveBeenCalledWith(
+        payment.id,
+        PaymentStatus.FAILED,
+      );
+    });
+
+    it('does not change status or emit for a pending outcome', async () => {
+      const payment = makePayment();
+      paymentRepository.findOne.mockResolvedValueOnce(payment);
+
+      const result = await service.apply(
+        payment.providerReference!,
+        'pending',
+        ConfirmationSource.WEBHOOK,
+        'hash-1',
+      );
+
+      expect(result?.status).toBe(PaymentStatus.AWAITING_CONFIRMATION);
+      expect(paymentsService.transitionStatus).not.toHaveBeenCalled();
+      expect(gateway.emitPaymentUpdate).not.toHaveBeenCalled();
+      expect(eventRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ applied: false, anomaly: null }),
+      );
+    });
+
+    it('is a clean no-op when a duplicate delivery repeats the same outcome on an already-terminal payment', async () => {
+      const payment = makePayment({ status: PaymentStatus.CONFIRMED });
+      paymentRepository.findOne.mockResolvedValueOnce(payment);
+
+      const result = await service.apply(
+        payment.providerReference!,
+        'confirmed',
+        ConfirmationSource.WEBHOOK,
+        'hash-2',
+      );
+
+      expect(result?.status).toBe(PaymentStatus.CONFIRMED);
+      expect(paymentsService.transitionStatus).not.toHaveBeenCalled();
+      expect(paymentRepository.save).not.toHaveBeenCalled();
+      expect(eventRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          applied: false,
+          anomaly: null,
+          previousStatus: PaymentStatus.CONFIRMED,
+          resultingStatus: PaymentStatus.CONFIRMED,
+        }),
+      );
+    });
+
+    it('flags a conflicting event when a later delivery disagrees with the already-terminal status, without overwriting it', async () => {
+      const payment = makePayment({ status: PaymentStatus.CONFIRMED });
+      paymentRepository.findOne.mockResolvedValueOnce(payment);
+
+      const result = await service.apply(
+        payment.providerReference!,
+        'failed',
+        ConfirmationSource.WEBHOOK,
+        'hash-3',
+      );
+
+      // Terminal state is never overwritten by a later, conflicting event.
+      expect(result?.status).toBe(PaymentStatus.CONFIRMED);
+      expect(paymentsService.transitionStatus).not.toHaveBeenCalled();
+      expect(eventRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          applied: false,
+          anomaly: 'conflicting_event',
+        }),
+      );
+    });
+  });
+
+  describe('logRejectedWebhook', () => {
+    it('logs a rejected webhook with no payment link', async () => {
+      await service.logRejectedWebhook('hash-4', 'invalid_signature');
+
+      expect(eventRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paymentId: null,
+          providerReference: null,
+          source: ConfirmationSource.WEBHOOK,
+          rawPayloadHash: 'hash-4',
+          applied: false,
+          anomaly: 'invalid_signature',
+        }),
+      );
+    });
+  });
+
+  describe('verifyOnReturn', () => {
+    it('returns verified:true immediately for an already-terminal payment without calling the rail adapter', async () => {
+      const payment = makePayment({ status: PaymentStatus.CONFIRMED });
+
+      const result = await service.verifyOnReturn(payment);
+
+      expect(result).toEqual({ payment, verified: true });
+      expect(railAdapter.verifyByReference).not.toHaveBeenCalled();
+    });
+
+    it('returns verified:false when the payment has no providerReference', async () => {
+      const payment = makePayment({ providerReference: null });
+
+      const result = await service.verifyOnReturn(payment);
+
+      expect(result).toEqual({ payment, verified: false });
+      expect(railAdapter.verifyByReference).not.toHaveBeenCalled();
+    });
+
+    it('never marks the payment CONFIRMED when the provider call times out', async () => {
+      const payment = makePayment();
+      config.get.mockImplementation((key: string, fallback?: unknown) =>
+        key === 'PAYMENT_VERIFY_TIMEOUT_MS' ? 20 : fallback,
+      );
+      // Never resolves — simulates an unresponsive provider.
+      railAdapter.verifyByReference.mockReturnValueOnce(new Promise(() => {}));
+
+      const result = await service.verifyOnReturn(payment);
+
+      expect(result.verified).toBe(false);
+      expect(result.payment.status).toBe(PaymentStatus.AWAITING_CONFIRMATION);
+      expect(paymentsService.transitionStatus).not.toHaveBeenCalled();
+    });
+
+    it('never marks the payment CONFIRMED on a pending provider response', async () => {
+      const payment = makePayment();
+      railAdapter.verifyByReference.mockResolvedValueOnce({
+        outcome: 'pending',
+      });
+
+      const result = await service.verifyOnReturn(payment);
+
+      expect(result).toEqual({ payment, verified: false });
+      expect(paymentsService.transitionStatus).not.toHaveBeenCalled();
+    });
+
+    it('applies a confirmed outcome from an authoritative provider response', async () => {
+      const payment = makePayment();
+      paymentRepository.findOne.mockResolvedValueOnce(payment);
+      railAdapter.verifyByReference.mockResolvedValueOnce({
+        outcome: 'confirmed',
+      });
+
+      const result = await service.verifyOnReturn(payment);
+
+      expect(result.verified).toBe(true);
+      expect(result.payment.status).toBe(PaymentStatus.CONFIRMED);
+      expect(gateway.emitPaymentUpdate).toHaveBeenCalledWith(
+        payment.id,
+        PaymentStatus.CONFIRMED,
+      );
+    });
+
+    it('never marks the payment CONFIRMED when the provider call rejects', async () => {
+      const payment = makePayment();
+      railAdapter.verifyByReference.mockRejectedValueOnce(
+        new Error('provider unreachable'),
+      );
+
+      const result = await service.verifyOnReturn(payment);
+
+      expect(result).toEqual({ payment, verified: false });
+      expect(paymentsService.transitionStatus).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/payments/payment-confirmation.service.ts
+++ b/backend/src/payments/payment-confirmation.service.ts
@@ -1,0 +1,257 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { createHash } from 'crypto';
+import { Repository } from 'typeorm';
+import { Payment } from './entities/payment.entity';
+import { ConfirmationEvent } from './entities/confirmation-event.entity';
+import { ConfirmationSource } from './enums/confirmation-source.enum';
+import { PaymentStatus } from './enums/payment-status.enum';
+import { PaymentVerificationOutcome } from './interfaces/payment-rail-adapter.interface';
+import { PaymentsService } from './payments.service';
+import { PaymentsGateway } from './payments.gateway';
+import { SandboxRailAdapter } from './adapters/sandbox-rail.adapter';
+import { withTimeout } from './utils/with-timeout';
+
+const DEFAULT_VERIFY_TIMEOUT_MS = 3000;
+
+const TERMINAL_STATUSES: ReadonlySet<PaymentStatus> = new Set([
+  PaymentStatus.CONFIRMED,
+  PaymentStatus.FAILED,
+  PaymentStatus.EXPIRED,
+  PaymentStatus.REFUNDED,
+  PaymentStatus.PARTIALLY_REFUNDED,
+]);
+
+/**
+ * The single place that turns a rail's "confirmed"/"failed"/"pending"
+ * outcome into a Payment state change (or a deliberate no-op) — shared by
+ * both the webhook path and the verify-on-return fast path, so both
+ * converge on identical idempotency/ordering semantics (issue #1571).
+ *
+ * A terminal Payment status is never overwritten by a later event; every
+ * event received is logged regardless of whether it changed anything.
+ */
+@Injectable()
+export class PaymentConfirmationService {
+  private readonly logger = new Logger(PaymentConfirmationService.name);
+
+  constructor(
+    @InjectRepository(Payment)
+    private readonly paymentRepository: Repository<Payment>,
+    @InjectRepository(ConfirmationEvent)
+    private readonly eventRepository: Repository<ConfirmationEvent>,
+    private readonly paymentsService: PaymentsService,
+    private readonly gateway: PaymentsGateway,
+    private readonly railAdapter: SandboxRailAdapter,
+    private readonly config: ConfigService,
+  ) {}
+
+  static hashPayload(rawBody: Buffer): string {
+    return createHash('sha256').update(rawBody).digest('hex');
+  }
+
+  /**
+   * Applies a confirmation outcome for the Payment matching
+   * `providerReference`. Returns the (possibly unchanged) Payment, or null
+   * if no Payment matches the reference at all.
+   */
+  async apply(
+    providerReference: string,
+    outcome: PaymentVerificationOutcome,
+    source: ConfirmationSource,
+    rawPayloadHash: string,
+  ): Promise<Payment | null> {
+    const payment = await this.paymentRepository.findOne({
+      where: { providerReference },
+    });
+
+    if (!payment) {
+      await this.logEvent({
+        paymentId: null,
+        providerReference,
+        source,
+        rawPayloadHash,
+        previousStatus: null,
+        resultingStatus: null,
+        applied: false,
+        anomaly: 'payment_not_found',
+      });
+      this.logger.warn(
+        `Confirmation event for unknown providerReference=${providerReference}`,
+      );
+      return null;
+    }
+
+    if (TERMINAL_STATUSES.has(payment.status)) {
+      const anomaly = PaymentConfirmationService.describeReplay(
+        payment.status,
+        outcome,
+      );
+      await this.logEvent({
+        paymentId: payment.id,
+        providerReference,
+        source,
+        rawPayloadHash,
+        previousStatus: payment.status,
+        resultingStatus: payment.status,
+        applied: false,
+        anomaly,
+      });
+      return payment;
+    }
+
+    if (outcome === 'pending') {
+      await this.logEvent({
+        paymentId: payment.id,
+        providerReference,
+        source,
+        rawPayloadHash,
+        previousStatus: payment.status,
+        resultingStatus: payment.status,
+        applied: false,
+        anomaly: null,
+      });
+      return payment;
+    }
+
+    const previousStatus = payment.status;
+    const nextStatus =
+      outcome === 'confirmed' ? PaymentStatus.CONFIRMED : PaymentStatus.FAILED;
+
+    this.paymentsService.transitionStatus(payment, nextStatus);
+    const saved = await this.paymentRepository.save(payment);
+
+    await this.logEvent({
+      paymentId: saved.id,
+      providerReference,
+      source,
+      rawPayloadHash,
+      previousStatus,
+      resultingStatus: nextStatus,
+      applied: true,
+      anomaly: null,
+    });
+
+    this.gateway.emitPaymentUpdate(saved.id, saved.status);
+
+    return saved;
+  }
+
+  /**
+   * Bounded synchronous fast path for the checkout-return leg (issue
+   * #1571): calls the rail's verify-by-reference API instead of waiting on
+   * the async webhook, so a time-sensitive flow (unlocking a room, a
+   * day-pass) doesn't have to sit in AWAITING_CONFIRMATION for however
+   * long the webhook takes. The webhook remains authoritative and can
+   * still supersede this later — `apply` is the same idempotent path
+   * either way, so whichever arrives first "wins" the transition and the
+   * other becomes a no-op replay.
+   *
+   * Hard rule: `verified: false` (timeout, provider error, or a `pending`
+   * response) NEVER implies a status change. Only an authoritative
+   * confirmed/failed response from the provider moves the Payment.
+   */
+  async verifyOnReturn(
+    payment: Payment,
+  ): Promise<{ payment: Payment; verified: boolean }> {
+    if (TERMINAL_STATUSES.has(payment.status)) {
+      return { payment, verified: true };
+    }
+    if (!payment.providerReference) {
+      return { payment, verified: false };
+    }
+
+    const timeoutMs = this.config.get<number>(
+      'PAYMENT_VERIFY_TIMEOUT_MS',
+      DEFAULT_VERIFY_TIMEOUT_MS,
+    );
+
+    let result: { outcome: PaymentVerificationOutcome };
+    try {
+      result = await withTimeout(
+        this.railAdapter.verifyByReference(payment.providerReference),
+        timeoutMs,
+      );
+    } catch (error) {
+      this.logger.warn(
+        `verify-on-return failed for payment ${payment.id}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return { payment, verified: false };
+    }
+
+    if (result.outcome === 'pending') {
+      return { payment, verified: false };
+    }
+
+    const rawPayloadHash = PaymentConfirmationService.hashPayload(
+      Buffer.from(
+        JSON.stringify({
+          providerReference: payment.providerReference,
+          outcome: result.outcome,
+        }),
+      ),
+    );
+
+    const updated = await this.apply(
+      payment.providerReference,
+      result.outcome,
+      ConfirmationSource.VERIFY_RETURN,
+      rawPayloadHash,
+    );
+
+    return { payment: updated ?? payment, verified: true };
+  }
+
+  /** Logs a webhook that never reached `apply` — invalid signature, malformed payload, etc. */
+  async logRejectedWebhook(
+    rawPayloadHash: string,
+    anomaly: string,
+  ): Promise<void> {
+    await this.logEvent({
+      paymentId: null,
+      providerReference: null,
+      source: ConfirmationSource.WEBHOOK,
+      rawPayloadHash,
+      previousStatus: null,
+      resultingStatus: null,
+      applied: false,
+      anomaly,
+    });
+    this.logger.warn(`Rejected webhook: ${anomaly}`);
+  }
+
+  /**
+   * A duplicate delivery of the same outcome against an already-terminal
+   * payment is expected and not an anomaly. A DIFFERENT outcome arriving
+   * after the payment is already terminal is a genuine conflict worth
+   * flagging — it's either badly out-of-order delivery or a provider bug.
+   */
+  private static describeReplay(
+    currentStatus: PaymentStatus,
+    outcome: PaymentVerificationOutcome,
+  ): string | null {
+    if (outcome === 'pending') {
+      return null;
+    }
+    const impliedStatus =
+      outcome === 'confirmed' ? PaymentStatus.CONFIRMED : PaymentStatus.FAILED;
+    return impliedStatus === currentStatus ? null : 'conflicting_event';
+  }
+
+  private async logEvent(entry: {
+    paymentId: string | null;
+    providerReference: string | null;
+    source: ConfirmationSource;
+    rawPayloadHash: string;
+    previousStatus: PaymentStatus | null;
+    resultingStatus: PaymentStatus | null;
+    applied: boolean;
+    anomaly: string | null;
+  }): Promise<void> {
+    const event = this.eventRepository.create(entry);
+    await this.eventRepository.save(event);
+  }
+}

--- a/backend/src/payments/payment-webhook.controller.spec.ts
+++ b/backend/src/payments/payment-webhook.controller.spec.ts
@@ -1,0 +1,93 @@
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { PaymentWebhookController } from './payment-webhook.controller';
+import { ConfirmationSource } from './enums/confirmation-source.enum';
+
+function makeRequest(bodyObject: unknown) {
+  const rawBody = Buffer.from(JSON.stringify(bodyObject));
+  return { rawBody, body: bodyObject } as any;
+}
+
+describe('PaymentWebhookController', () => {
+  let railAdapter: {
+    verifyWebhookSignature: jest.Mock;
+    parseWebhookPayload: jest.Mock;
+  };
+  let confirmationService: {
+    apply: jest.Mock;
+    logRejectedWebhook: jest.Mock;
+  };
+  let controller: PaymentWebhookController;
+
+  beforeEach(() => {
+    railAdapter = {
+      verifyWebhookSignature: jest.fn(),
+      parseWebhookPayload: jest.fn(),
+    };
+    confirmationService = {
+      apply: jest.fn(),
+      logRejectedWebhook: jest.fn(),
+    };
+    controller = new PaymentWebhookController(
+      railAdapter as any,
+      confirmationService as any,
+    );
+  });
+
+  it('rejects and logs a webhook with an invalid signature, never reaching apply', async () => {
+    railAdapter.verifyWebhookSignature.mockReturnValueOnce(false);
+    const req = makeRequest({
+      providerReference: 'ref-1',
+      outcome: 'confirmed',
+    });
+
+    await expect(controller.sandbox(req, 'bad-sig')).rejects.toThrow(
+      UnauthorizedException,
+    );
+
+    expect(confirmationService.logRejectedWebhook).toHaveBeenCalledWith(
+      expect.any(String),
+      'invalid_signature',
+    );
+    expect(confirmationService.apply).not.toHaveBeenCalled();
+  });
+
+  it('rejects and logs a malformed (but authentically signed) payload', async () => {
+    railAdapter.verifyWebhookSignature.mockReturnValueOnce(true);
+    railAdapter.parseWebhookPayload.mockImplementationOnce(() => {
+      throw new Error('bad shape');
+    });
+    const req = makeRequest({ nonsense: true });
+
+    await expect(controller.sandbox(req, 'good-sig')).rejects.toThrow(
+      BadRequestException,
+    );
+
+    expect(confirmationService.logRejectedWebhook).toHaveBeenCalledWith(
+      expect.any(String),
+      'malformed_payload',
+    );
+    expect(confirmationService.apply).not.toHaveBeenCalled();
+  });
+
+  it('applies a validly signed, well-formed webhook', async () => {
+    railAdapter.verifyWebhookSignature.mockReturnValueOnce(true);
+    railAdapter.parseWebhookPayload.mockReturnValueOnce({
+      providerReference: 'ref-1',
+      outcome: 'confirmed',
+    });
+    const req = makeRequest({
+      providerReference: 'ref-1',
+      outcome: 'confirmed',
+    });
+
+    const result = await controller.sandbox(req, 'good-sig');
+
+    expect(result).toEqual({ received: true });
+    expect(confirmationService.apply).toHaveBeenCalledWith(
+      'ref-1',
+      'confirmed',
+      ConfirmationSource.WEBHOOK,
+      expect.any(String),
+    );
+  });
+});

--- a/backend/src/payments/payment-webhook.controller.ts
+++ b/backend/src/payments/payment-webhook.controller.ts
@@ -1,0 +1,84 @@
+import {
+  BadRequestException,
+  Controller,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Req,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { SandboxRailAdapter } from './adapters/sandbox-rail.adapter';
+import { ConfirmationSource } from './enums/confirmation-source.enum';
+import { PaymentConfirmationService } from './payment-confirmation.service';
+
+interface RawBodyRequest extends Request {
+  rawBody?: Buffer;
+}
+
+/**
+ * One controller per rail (issue #1571) — each verifies transport-level
+ * authenticity (HMAC signature here; the on-chain equivalent lands in a
+ * later issue) before touching any Payment state, and processes idempotently
+ * by construction: PaymentConfirmationService looks up by
+ * providerReference and no-ops on an already-terminal Payment.
+ *
+ * No @UseGuards(JwtAuthGuard) here deliberately — the provider is the
+ * caller, not an authenticated user; the HMAC signature IS the auth.
+ */
+@ApiTags('payments')
+@Controller('payments/webhooks')
+export class PaymentWebhookController {
+  constructor(
+    private readonly railAdapter: SandboxRailAdapter,
+    private readonly confirmationService: PaymentConfirmationService,
+  ) {}
+
+  @Post('sandbox')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary:
+      'Sandbox rail confirmation webhook (HMAC-signed via PAYMENT_WEBHOOK_SECRET)',
+  })
+  async sandbox(
+    @Req() req: RawBodyRequest,
+    @Headers('x-payment-signature') signature?: string,
+  ): Promise<{ received: boolean }> {
+    const rawBody = req.rawBody ?? Buffer.from(JSON.stringify(req.body ?? {}));
+    const rawPayloadHash = PaymentConfirmationService.hashPayload(rawBody);
+
+    const isValid = this.railAdapter.verifyWebhookSignature({
+      rawBody,
+      signatureHeader: signature,
+    });
+    if (!isValid) {
+      await this.confirmationService.logRejectedWebhook(
+        rawPayloadHash,
+        'invalid_signature',
+      );
+      throw new UnauthorizedException('Invalid webhook signature');
+    }
+
+    let payload;
+    try {
+      payload = this.railAdapter.parseWebhookPayload(rawBody);
+    } catch {
+      await this.confirmationService.logRejectedWebhook(
+        rawPayloadHash,
+        'malformed_payload',
+      );
+      throw new BadRequestException('Malformed webhook payload');
+    }
+
+    await this.confirmationService.apply(
+      payload.providerReference,
+      payload.outcome,
+      ConfirmationSource.WEBHOOK,
+      rawPayloadHash,
+    );
+
+    return { received: true };
+  }
+}

--- a/backend/src/payments/payments.controller.ts
+++ b/backend/src/payments/payments.controller.ts
@@ -18,15 +18,20 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { RequestUser } from '../auth/interfaces/authenticated-request.interface';
 import { PaymentsService } from './payments.service';
+import { PaymentConfirmationService } from './payment-confirmation.service';
 import { InitiatePaymentDto } from './dto/initiate-payment.dto';
 import { PaymentResponseDto } from './dto/payment-response.dto';
+import { VerifyReturnResponseDto } from './dto/verify-return-response.dto';
 
 @ApiTags('payments')
 @ApiBearerAuth()
 @UseGuards(JwtAuthGuard)
 @Controller('payments')
 export class PaymentsController {
-  constructor(private readonly paymentsService: PaymentsService) {}
+  constructor(
+    private readonly paymentsService: PaymentsService,
+    private readonly confirmationService: PaymentConfirmationService,
+  ) {}
 
   @Post('initiate')
   @ApiOperation({
@@ -68,5 +73,29 @@ export class PaymentsController {
   ): Promise<PaymentResponseDto[]> {
     const payments = await this.paymentsService.findAll(currentUser);
     return payments.map((payment) => PaymentResponseDto.fromEntity(payment));
+  }
+
+  @Post(':id/verify-return')
+  @ApiOperation({
+    summary:
+      'Bounded synchronous verify-on-return fast path for the checkout ' +
+      'return leg. Never marks a payment CONFIRMED without an ' +
+      'authoritative provider response — a timeout returns verified:false ' +
+      'with the payment unchanged; the webhook/real-time channel remains ' +
+      'authoritative.',
+  })
+  @ApiResponse({ status: 200, type: VerifyReturnResponseDto })
+  async verifyReturn(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() currentUser: RequestUser,
+  ): Promise<VerifyReturnResponseDto> {
+    const payment = await this.paymentsService.findOne(id, currentUser);
+    const { payment: updated, verified } =
+      await this.confirmationService.verifyOnReturn(payment);
+
+    return {
+      payment: PaymentResponseDto.fromEntity(updated),
+      verified,
+    };
   }
 }

--- a/backend/src/payments/payments.gateway.spec.ts
+++ b/backend/src/payments/payments.gateway.spec.ts
@@ -1,0 +1,125 @@
+import { PaymentsGateway } from './payments.gateway';
+import { PaymentStatus } from './enums/payment-status.enum';
+import { UserRole } from '../auth/enums/user-role.enum';
+
+function makeSocket(token?: string) {
+  return {
+    id: 'socket-1',
+    handshake: { auth: { token } },
+    data: {} as Record<string, unknown>,
+    join: jest.fn(),
+    emit: jest.fn(),
+    disconnect: jest.fn(),
+  };
+}
+
+describe('PaymentsGateway', () => {
+  let jwtService: { verifyAsync: jest.Mock };
+  let configService: { get: jest.Mock };
+  let paymentsService: { findOne: jest.Mock };
+  let gateway: PaymentsGateway;
+
+  beforeEach(() => {
+    jwtService = { verifyAsync: jest.fn() };
+    configService = { get: jest.fn().mockReturnValue('secret') };
+    paymentsService = { findOne: jest.fn() };
+    gateway = new PaymentsGateway(
+      jwtService as any,
+      configService as any,
+      paymentsService as any,
+    );
+  });
+
+  describe('handleConnection', () => {
+    it('rejects a connection with no token', async () => {
+      const socket = makeSocket(undefined);
+      await gateway.handleConnection(socket as any);
+
+      expect(socket.emit).toHaveBeenCalledWith(
+        'connection:error',
+        expect.objectContaining({ message: expect.any(String) }),
+      );
+      expect(socket.disconnect).toHaveBeenCalledWith(true);
+    });
+
+    it('rejects a connection with an invalid token', async () => {
+      jwtService.verifyAsync.mockRejectedValueOnce(new Error('bad token'));
+      const socket = makeSocket('bad-token');
+
+      await gateway.handleConnection(socket as any);
+
+      expect(socket.disconnect).toHaveBeenCalledWith(true);
+    });
+
+    it('attaches the decoded user for a valid token', async () => {
+      jwtService.verifyAsync.mockResolvedValueOnce({
+        sub: 'user-1',
+        role: UserRole.USER,
+      });
+      const socket = makeSocket('good-token');
+
+      await gateway.handleConnection(socket as any);
+
+      expect(socket.data.user).toEqual({ id: 'user-1', role: UserRole.USER });
+      expect(socket.disconnect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleSubscribe', () => {
+    it('rejects a subscribe attempt from an unauthenticated socket', async () => {
+      const socket = makeSocket();
+
+      await gateway.handleSubscribe(socket as any, 'payment-1');
+
+      expect(socket.disconnect).toHaveBeenCalledWith(true);
+      expect(socket.join).not.toHaveBeenCalled();
+    });
+
+    it('joins the payment room when the user can access the payment', async () => {
+      const socket = makeSocket('good-token');
+      socket.data.user = { id: 'user-1', role: UserRole.USER };
+      paymentsService.findOne.mockResolvedValueOnce({
+        id: 'payment-1',
+        status: PaymentStatus.AWAITING_CONFIRMATION,
+      });
+
+      await gateway.handleSubscribe(socket as any, 'payment-1');
+
+      expect(socket.join).toHaveBeenCalledWith('payment:payment-1');
+      expect(socket.emit).toHaveBeenCalledWith('subscribed', {
+        paymentId: 'payment-1',
+        status: PaymentStatus.AWAITING_CONFIRMATION,
+      });
+    });
+
+    it('emits subscribe:error instead of joining when the payment is not accessible', async () => {
+      const socket = makeSocket('good-token');
+      socket.data.user = { id: 'user-1', role: UserRole.USER };
+      paymentsService.findOne.mockRejectedValueOnce(new Error('forbidden'));
+
+      await gateway.handleSubscribe(socket as any, 'payment-1');
+
+      expect(socket.join).not.toHaveBeenCalled();
+      expect(socket.emit).toHaveBeenCalledWith(
+        'subscribe:error',
+        expect.objectContaining({ paymentId: 'payment-1' }),
+      );
+    });
+  });
+
+  describe('emitPaymentUpdate', () => {
+    it('emits payment:update to the payment room', () => {
+      const to = jest.fn().mockReturnThis();
+      const emit = jest.fn();
+      (gateway as any).server = { to: to.mockReturnValue({ emit }) };
+
+      gateway.emitPaymentUpdate('payment-1', PaymentStatus.CONFIRMED);
+
+      expect(to).toHaveBeenCalledWith('payment:payment-1');
+      expect(emit).toHaveBeenCalledWith('payment:update', {
+        paymentId: 'payment-1',
+        status: PaymentStatus.CONFIRMED,
+      });
+    });
+  });
+});

--- a/backend/src/payments/payments.gateway.ts
+++ b/backend/src/payments/payments.gateway.ts
@@ -1,0 +1,115 @@
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import {
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { RequestUser } from '../auth/interfaces/authenticated-request.interface';
+import { PaymentStatus } from './enums/payment-status.enum';
+import { PaymentsService } from './payments.service';
+
+interface JwtPayload {
+  sub: string;
+  role: RequestUser['role'];
+}
+
+function paymentRoom(paymentId: string): string {
+  return `payment:${paymentId}`;
+}
+
+/**
+ * Real-time push channel for payment status (issue #1571): the frontend
+ * gets CONFIRMED/FAILED the instant a webhook lands, instead of only
+ * finding out on next poll. Polling remains a documented fallback for
+ * clients that can't hold a socket open — this gateway is additive, not a
+ * replacement for GET /payments/:id.
+ */
+@WebSocketGateway({
+  namespace: '/payments',
+  cors: {
+    origin: process.env.FRONTEND_URL || 'http://localhost:3000',
+    credentials: true,
+  },
+})
+export class PaymentsGateway
+  implements OnGatewayConnection, OnGatewayDisconnect
+{
+  private readonly logger = new Logger(PaymentsGateway.name);
+
+  @WebSocketServer()
+  server: Server;
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+    private readonly paymentsService: PaymentsService,
+  ) {}
+
+  // Guards decorate message handlers, not the initial handshake, so the JWT
+  // is verified here and the socket is dropped immediately if it's missing
+  // or invalid — matching the HTTP JwtAuthGuard's behavior for this domain.
+  async handleConnection(client: Socket): Promise<void> {
+    const token = client.handshake.auth?.token as string | undefined;
+
+    if (!token) {
+      this.rejectConnection(client, 'Missing authentication token');
+      return;
+    }
+
+    try {
+      const payload = await this.jwtService.verifyAsync<JwtPayload>(token, {
+        secret: this.configService.get<string>('JWT_SECRET'),
+      });
+      client.data.user = { id: payload.sub, role: payload.role };
+    } catch {
+      this.rejectConnection(client, 'Invalid or expired token');
+    }
+  }
+
+  handleDisconnect(client: Socket): void {
+    this.logger.log(`Client ${client.id} disconnected`);
+  }
+
+  /**
+   * Client explicitly subscribes to one payment's updates. Reuses
+   * PaymentsService.findOne's owner-or-admin check, so a socket can only
+   * ever join a room for a payment it's actually allowed to see — the
+   * real-time channel has the same access rules as the HTTP endpoint.
+   */
+  @SubscribeMessage('subscribe')
+  async handleSubscribe(client: Socket, paymentId: string): Promise<void> {
+    const user = client.data.user as RequestUser | undefined;
+    if (!user) {
+      this.rejectConnection(client, 'Not authenticated');
+      return;
+    }
+
+    try {
+      const payment = await this.paymentsService.findOne(paymentId, user);
+      void client.join(paymentRoom(paymentId));
+      client.emit('subscribed', { paymentId, status: payment.status });
+    } catch {
+      client.emit('subscribe:error', {
+        paymentId,
+        message: 'Payment not found or not accessible',
+      });
+    }
+  }
+
+  emitPaymentUpdate(paymentId: string, status: PaymentStatus): void {
+    this.server.to(paymentRoom(paymentId)).emit('payment:update', {
+      paymentId,
+      status,
+    });
+  }
+
+  private rejectConnection(client: Socket, reason: string): void {
+    client.emit('connection:error', { message: reason });
+    client.disconnect(true);
+  }
+}

--- a/backend/src/payments/payments.module.ts
+++ b/backend/src/payments/payments.module.ts
@@ -1,14 +1,23 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Payment } from './entities/payment.entity';
+import { ConfirmationEvent } from './entities/confirmation-event.entity';
 import { PaymentsService } from './payments.service';
+import { PaymentConfirmationService } from './payment-confirmation.service';
+import { PaymentsGateway } from './payments.gateway';
 import { PaymentsController } from './payments.controller';
+import { PaymentWebhookController } from './payment-webhook.controller';
 import { SandboxRailAdapter } from './adapters/sandbox-rail.adapter';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Payment])],
-  controllers: [PaymentsController],
-  providers: [PaymentsService, SandboxRailAdapter],
-  exports: [PaymentsService],
+  imports: [TypeOrmModule.forFeature([Payment, ConfirmationEvent])],
+  controllers: [PaymentsController, PaymentWebhookController],
+  providers: [
+    PaymentsService,
+    PaymentConfirmationService,
+    PaymentsGateway,
+    SandboxRailAdapter,
+  ],
+  exports: [PaymentsService, PaymentConfirmationService],
 })
 export class PaymentsModule {}

--- a/backend/src/payments/utils/with-timeout.ts
+++ b/backend/src/payments/utils/with-timeout.ts
@@ -1,0 +1,29 @@
+export class TimeoutError extends Error {}
+
+/**
+ * Bounds a provider call to `timeoutMs` — the verify-on-return fast path
+ * (issue #1571) must never hang waiting on a slow/unresponsive provider;
+ * a timeout is not an error to propagate, it's a signal to fall back to
+ * the webhook/real-time channel instead.
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new TimeoutError(`Timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error as Error);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Issue #1570 gives us a `Payment` that starts `AWAITING_CONFIRMATION`, but nothing moved it forward. This adds a provider-agnostic confirmation pipeline that treats the provider's response as the only source of truth, plus a real-time push channel so the app finds out the instant it happens instead of only on next poll.

### PaymentConfirmationService
The single place that turns a rail's `confirmed`/`failed`/`pending` outcome into a Payment state change (or a deliberate no-op) — shared by both the webhook path and the verify-on-return fast path, so both converge on identical idempotency/ordering semantics:
- A **terminal Payment status is never overwritten** by a later event.
- A duplicate delivery of the **same** outcome against an already-terminal payment is a clean no-op.
- A **later, disagreeing** event against an already-terminal payment is flagged `conflicting_event` — logged, not silently applied or silently dropped.

### ConfirmationEvent (append-only audit log)
Records every confirmation event received — webhook or verify-on-return — regardless of whether it changed anything: unknown-`providerReference` events, rejected (invalid-signature / malformed-payload) webhooks, duplicates, and conflicts all show up here. Stores a payload **hash**, never the raw payload.

### PaymentWebhookController — `POST /payments/webhooks/sandbox`
Verifies the HMAC signature against the **exact raw bytes** (`main.ts` now boots with `rawBody: true` so we're not re-serializing a parsed copy) before touching any state or trusting the payload. Both invalid-signature and malformed-(but-authentically-signed)-payload cases are rejected and logged without ever reaching the confirmation logic.

### PaymentsGateway — WS namespace `/payments`
JWT-authenticated handshake (same verification the HTTP `JwtAuthGuard` uses); a client explicitly subscribes to one payment's room only after re-checking the **same** owner-or-admin rule `PaymentsService.findOne` already enforces — the real-time channel has no looser access rules than the REST endpoint. Polling (`GET /payments/:id`) remains the documented fallback for clients that can't hold a socket open.

### `POST /payments/:id/verify-return`
Bounded synchronous fast path for the checkout-return leg. **A timeout, provider error, or `pending` response always returns `verified:false` with the payment unchanged** — only an authoritative confirmed/failed response ever moves the status (covered explicitly by tests). The webhook remains authoritative and can still supersede this later, through the same idempotent `apply` path.

### PaymentRailAdapter
Gained `verifyWebhookSignature`/`parseWebhookPayload`/`verifyByReference`. `SandboxRailAdapter` implements all three — HMAC via `PAYMENT_WEBHOOK_SECRET`; `verifyByReference` is deterministic on the reference string (`fail`/`pending`/anything-else) so every outcome is exercisable in tests without a real provider.

New env vars: `PAYMENT_WEBHOOK_SECRET`, `PAYMENT_VERIFY_TIMEOUT_MS` (default 3000ms).

### Scope note: frontend
The issue's "Detailed scope" lists a frontend real-time payment-status view. I checked — there's no existing payment UI/page in this repo to attach it to yet, and `socket.io-client` isn't an installed frontend dependency. Building a disconnected hook with nothing to integrate into would be speculative scope, and every acceptance criterion for this issue is backend-verifiable. The WS gateway (`/payments` namespace, `payment:update` event) is ready for a page to consume once one exists.

## Test plan
- [x] `npm run build` — passes
- [x] `npm run lint` — passes
- [x] `npm run test` — **102 passing** (all new + all pre-existing), covering:
  - webhook confirmed/failed/pending outcomes, duplicate replay (clean no-op), out-of-order/conflicting replay (flagged, not applied), unknown `providerReference` (logged anomaly)
  - forged/invalid webhook signature rejected **and** logged, before reaching any state logic
  - malformed-but-signed payload rejected and logged
  - verify-on-return: already-terminal short-circuits without calling the provider; missing `providerReference`; provider timeout; provider rejection; `pending` response — all assert `verified:false` **and** the payment status is unchanged; a confirmed response transitions and emits the real-time update
  - WS gateway: connection rejected with no/invalid token; subscribe rejected when unauthenticated; subscribe joins the room only when `PaymentsService.findOne`'s access check passes, otherwise emits `subscribe:error`; `emitPaymentUpdate` targets the correct room

Closes #1571