### PR TITLE
feat(auth): landing page, sign-in flow and route protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ManageHub uses a modern full-stack technology stack:
 | Frontend               | **Next.js**, React, Tailwind CSS               |     |
 | Backend                | **NestJS**, Node.js                            |     |
 | Database               | **PostgreSQL**                                 |     |
-| Blockchain / Contracts | Rust, Stellar                                  |     |
+| Blockchain / Contracts | Rust, Stellar _(planned — see [CT-42](https://github.com/DistinctCodes/ManageHub/labels/contracts) tracking)_ |     |
 | Deployment             | Vercel 🚀 (Frontend & possibly Serverless API) |     |
 
 > Side note: Using NestJS for API and backend services alongside Next.js for the frontend is a powerful combination for maintainable, scalable projects, especially when complex business logic or multi-client access is needed — something Next.js alone doesn’t fully optimize for in large systems.
@@ -71,7 +71,7 @@ Make sure you have the following installed:
 - Node.js ≥ 18.x
 - npm or yarn
 - PostgreSQL database
-- Rust toolchain (if building or interacting with _contracts_)
+- Rust toolchain (only if/when you work on the _contracts_ workspace, which is planned but **not yet part of the repository**)
 
 ---
 
@@ -140,14 +140,14 @@ Open `http://localhost:3000` in your browser.
 ManageHub/
 ├── backend/            # NestJS backend API
 ├── frontend/           # Next.js client application
-├── contracts/          # Rust & Stellar contract modules (wasm, etc.)
+├── contracts/          # Rust & Stellar contract modules — **planned**, not yet in the repo (see CT-42 tracking)
 ├── .github/            # CI/CD workflows
 ├── README.md           # Project readme (this file)
 ```
 
 - **backend/** — Contains controllers, services, modules, database logic.
 - **frontend/** — UI components, pages, API integrations.
-- **contracts/** — Smart contract or blockchain/logic modules (Rust).
+- **contracts/** — *(planned)* Smart contract or blockchain/logic modules (Rust). This workspace does not exist in the repository yet; it is tracked under the [CT-42 series of issues](https://github.com/DistinctCodes/ManageHub/labels/contracts) and will be added with the contracts scaffold.
 
 ---
 

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from "react";
+import { AuthForm } from "@/components/auth/auth-form";
+
+export const metadata = {
+  title: "Sign in",
+};
+
+export default function LoginPage() {
+  return (
+    <Suspense
+      fallback={<div className="mx-auto max-w-md px-6 py-16">Loading...</div>}
+    >
+      <AuthForm mode="login" />
+    </Suspense>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export const metadata = {
   title: "ManageHub - Smart Hub & Workspace Management",
   description:
@@ -5,5 +7,82 @@ export const metadata = {
 };
 
 export default function Home() {
-  return <main></main>;
+  return (
+    <main>
+      <header className="mx-auto flex max-w-6xl items-center justify-between px-6 py-6">
+        <Link href="/" className="text-lg font-semibold tracking-tight">
+          ManageHub
+        </Link>
+        <nav className="flex items-center gap-4 text-sm">
+          <Link
+            href="/wallet"
+            className="rounded-md border border-gray-300 dark:border-gray-700 px-4 py-2 font-medium"
+          >
+            Wallet
+          </Link>
+          <Link
+            href="/login"
+            className="rounded-md bg-gray-900 text-white dark:bg-white dark:text-gray-900 px-4 py-2 font-medium"
+          >
+            Sign in
+          </Link>
+        </nav>
+      </header>
+
+      <section className="mx-auto max-w-6xl px-6 pt-20 pb-32 text-center">
+        <h1 className="mx-auto max-w-3xl text-4xl font-semibold tracking-tight sm:text-5xl">
+          Simplify how you manage workspaces, teams, and resources.
+        </h1>
+        <p className="mx-auto mt-6 max-w-2xl text-lg text-gray-600 dark:text-gray-400">
+          ManageHub brings everything together in one place — streamline
+          operations, manage resources, and boost productivity with our
+          comprehensive management platform.
+        </p>
+        <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+          <Link
+            href="/register"
+            className="rounded-md bg-gray-900 text-white dark:bg-white dark:text-gray-900 px-6 py-3 font-medium"
+          >
+            Get started
+          </Link>
+          <Link
+            href="/login"
+            className="rounded-md border border-gray-300 dark:border-gray-700 px-6 py-3 font-medium"
+          >
+            Sign in
+          </Link>
+        </div>
+      </section>
+
+      <section className="mx-auto grid max-w-6xl gap-6 px-6 pb-24 sm:grid-cols-3">
+        {[
+          {
+            title: "Workspace management",
+            description:
+              "Organize teams, spaces, and daily operations from a single dashboard.",
+          },
+          {
+            title: "Resources & productivity",
+            description:
+              "Track and allocate resources so your team can focus on what matters.",
+          },
+          {
+            title: "Smart hub operations",
+            description:
+              "Comprehensive oversight for modern hubs and workspaces.",
+          },
+        ].map((feature) => (
+          <div
+            key={feature.title}
+            className="rounded-lg border border-gray-200 dark:border-gray-800 p-6"
+          >
+            <h2 className="text-lg font-semibold">{feature.title}</h2>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+              {feature.description}
+            </p>
+          </div>
+        ))}
+      </section>
+    </main>
+  );
 }

--- a/frontend/app/register/page.tsx
+++ b/frontend/app/register/page.tsx
@@ -1,0 +1,16 @@
+import { Suspense } from "react";
+import { AuthForm } from "@/components/auth/auth-form";
+
+export const metadata = {
+  title: "Create account",
+};
+
+export default function RegisterPage() {
+  return (
+    <Suspense
+      fallback={<div className="mx-auto max-w-md px-6 py-16">Loading...</div>}
+    >
+      <AuthForm mode="register" />
+    </Suspense>
+  );
+}

--- a/frontend/components/auth/auth-form.tsx
+++ b/frontend/components/auth/auth-form.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { login, register } from "@/lib/auth-api";
+import { useSessionStore } from "@/lib/stores/session-store";
+
+type Mode = "login" | "register";
+
+export function AuthForm({ mode }: { mode: Mode }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const setAccessToken = useSessionStore((state) => state.setAccessToken);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const isLogin = mode === "login";
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = isLogin
+        ? await login(email.trim(), password)
+        : await register(email.trim(), password);
+      setAccessToken(result.accessToken);
+      const next = searchParams.get("next");
+      router.push(next && next.startsWith("/") ? next : "/wallet");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-md px-6 py-16">
+      <h1 className="text-2xl font-semibold mb-6">
+        {isLogin ? "Sign in" : "Create your account"}
+      </h1>
+
+      <form onSubmit={handleSubmit} className="space-y-4">
+        {error && (
+          <p className="text-sm text-red-600 dark:text-red-400">{error}</p>
+        )}
+
+        <div>
+          <label
+            htmlFor="email"
+            className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300"
+          >
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-transparent px-3 py-2 text-sm"
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="password"
+            className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300"
+          >
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            required
+            minLength={isLogin ? 1 : 8}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-md border border-gray-300 dark:border-gray-700 bg-transparent px-3 py-2 text-sm"
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full rounded-md bg-gray-900 text-white dark:bg-white dark:text-gray-900 px-4 py-2 text-sm font-medium disabled:opacity-50"
+        >
+          {submitting ? (isLogin ? "Signing in..." : "Creating account...") : isLogin ? "Sign in" : "Create account"}
+        </button>
+      </form>
+
+      <p className="mt-6 text-sm text-gray-600 dark:text-gray-400">
+        {isLogin ? (
+          <>
+            Don&apos;t have an account?{" "}
+            <Link href="/register" className="underline">
+              Create one
+            </Link>
+          </>
+        ) : (
+          <>
+            Already have an account?{" "}
+            <Link href="/login" className="underline">
+              Sign in
+            </Link>
+          </>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/frontend/lib/auth-api.ts
+++ b/frontend/lib/auth-api.ts
@@ -1,0 +1,45 @@
+export type UserRole = "MEMBER" | "ADMIN" | "SUPER_ADMIN";
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  role: UserRole;
+}
+
+export interface AuthResponse {
+  accessToken: string;
+  user: AuthUser;
+}
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+async function authRequest<T>(
+  path: string,
+  body: { email: string; password: string },
+): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => null);
+    throw new Error(
+      errorBody?.message ?? `Authentication failed (${response.status})`,
+    );
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export function login(email: string, password: string): Promise<AuthResponse> {
+  return authRequest<AuthResponse>("/auth/login", { email, password });
+}
+
+export function register(
+  email: string,
+  password: string,
+): Promise<AuthResponse> {
+  return authRequest<AuthResponse>("/auth/register", { email, password });
+}

--- a/frontend/lib/stores/session-store.ts
+++ b/frontend/lib/stores/session-store.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { create } from "zustand";
+import Cookies from "js-cookie";
+
+const ACCESS_TOKEN_COOKIE = "accessToken";
+
+function readStoredToken(): string | null {
+  if (typeof window === "undefined") return null;
+  return Cookies.get(ACCESS_TOKEN_COOKIE) ?? null;
+}
+
+interface SessionState {
+  accessToken: string | null;
+  setAccessToken: (token: string | null) => void;
+}
+
+export const useSessionStore = create<SessionState>((set) => ({
+  accessToken: readStoredToken(),
+  setAccessToken: (token) => {
+    if (token) {
+      Cookies.set(ACCESS_TOKEN_COOKIE, token, {
+        sameSite: "lax",
+        secure: window.location.protocol === "https:",
+      });
+    } else {
+      Cookies.remove(ACCESS_TOKEN_COOKIE);
+    }
+    set({ accessToken: token });
+  },
+}));

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,51 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { jwtVerify } from "jose";
+
+const protectedRoutes = ["/wallet"];
+const authRoutes = ["/login", "/register"];
+
+function getAccessToken(request: NextRequest): string | null {
+  return request.cookies.get("accessToken")?.value ?? null;
+}
+
+async function isAuthenticated(request: NextRequest): Promise<boolean> {
+  const token = getAccessToken(request);
+  if (!token) return false;
+
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    return true;
+  }
+
+  try {
+    const key = new TextEncoder().encode(secret);
+    await jwtVerify(token, key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const authenticated = await isAuthenticated(request);
+
+  if (protectedRoutes.includes(pathname) && !authenticated) {
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = "/login";
+    loginUrl.searchParams.set("next", pathname);
+    return NextResponse.redirect(loginUrl);
+  }
+
+  if (authRoutes.includes(pathname) && authenticated) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/wallet";
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/wallet/:path*", "/login/:path*", "/register/:path*"],
+};


### PR DESCRIPTION
## Summary

Makes the app actually usable end-to-end: a real landing page, a working sign-in/sign-up flow backed by the existing `POST /auth/login` and `POST /auth/register` endpoints, route-level protection, and a README that accurately reflects the repo.

### Landing page (FE-93)
- Replaced the empty `<main></main>` on the root route with a real landing page: hero section, feature highlights, and navigation into the wallet and auth flows — matching the page/layout metadata.

### Sign-in & sign-up (FE-91)
- Added `/login` and `/register` pages backed by the backend's `POST /auth/login` / `POST /auth/register` endpoints.
- On success, stores the JWT via the shared session store (sets the `accessToken` cookie) and redirects to the wallet (or the `?next=` target).
- Register enforces the backend's 8-character minimum password.

### Route protection (FE-92)
- Implemented `middleware.ts`:
  - Verifies the `accessToken` JWT with `jose` against `JWT_SECRET` when configured (falls back to cookie presence otherwise).
  - Redirects unauthenticated users away from protected routes (`/wallet`) to `/login`.
  - Redirects authenticated users away from `/login` and `/register`.

### README accuracy (BE-149)
- Marked the `contracts/` workspace and Rust/Stellar stack as **planned** (tracked under CT-42) instead of implying it currently exists in the repository.

## Verification
- `npx tsc --noEmit` passes.
- `npx eslint` passes.

Closes #1619
Closes #1620
Closes #1621
Closes #1622
