### PR TITLE
Admin audit log, settlement startup validation, index-audit tooling, versioned webhook contract

### DIFF
--- a/.github/workflows/index-audit.yaml
+++ b/.github/workflows/index-audit.yaml
@@ -1,0 +1,58 @@
+name: Index Audit (BE-140)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  index-audit:
+    name: Migrations from empty + EXPLAIN audit
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: managehub_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    defaults:
+      run:
+        working-directory: backend
+
+    env:
+      DATABASE_HOST: localhost
+      DATABASE_PORT: 5432
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: postgres
+      DATABASE_NAME: managehub_test
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Migrate a fresh, empty database
+        run: npm run migration:run
+
+      - name: Run EXPLAIN index audit on hot paths
+        run: npm run index-audit

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,7 @@
     "migration:generate": "npm run typeorm -- migration:generate -d src/database/data-source.ts",
     "migration:run": "npm run typeorm -- migration:run -d src/database/data-source.ts",
     "migration:revert": "npm run typeorm -- migration:revert -d src/database/data-source.ts",
+    "index-audit": "node scripts/index-audit.js",
     "demo:seed": "node scripts/demo-data.js seed",
     "demo:clear": "node scripts/demo-data.js clear",
     "demo:info": "node scripts/demo-data.js info",

--- a/backend/scripts/index-audit.js
+++ b/backend/scripts/index-audit.js
@@ -1,0 +1,72 @@
+/**
+ * BE-140 index audit: fails CI if a hot-path listing query would
+ * sequential-scan instead of using an index, guarding the two endpoints
+ * most likely to grow large (GET /credits/statement and GET /payments).
+ *
+ * Run after `npm run migration:run` against a freshly-migrated database:
+ *   node scripts/index-audit.js
+ */
+const { Client } = require('pg');
+
+const DUMMY_UUID = '00000000-0000-0000-0000-000000000000';
+
+const QUERIES = [
+  {
+    name: 'GET /credits/statement (ledger_entries by account, newest first)',
+    sql: `EXPLAIN SELECT * FROM "ledger_entries"
+          WHERE "account_id" = $1
+          ORDER BY "created_at" DESC LIMIT 100`,
+  },
+  {
+    name: 'GET /payments member list (by user)',
+    sql: `EXPLAIN SELECT * FROM "payments"
+          WHERE "user_id" = $1
+          ORDER BY "created_at" DESC`,
+  },
+  {
+    name: 'admin manual-review queue (by status, oldest first)',
+    sql: `EXPLAIN SELECT * FROM "payments"
+          WHERE "status" = 'MANUAL_REVIEW'
+          ORDER BY "updated_at" ASC`,
+  },
+];
+
+async function main() {
+  const client = new Client({
+    host: process.env.DATABASE_HOST,
+    port: Number(process.env.DATABASE_PORT || 5432),
+    user: process.env.DATABASE_USERNAME,
+    password: process.env.DATABASE_PASSWORD,
+    database: process.env.DATABASE_NAME,
+  });
+  await client.connect();
+
+  let failed = false;
+  for (const query of QUERIES) {
+    const result = await client.query(query.sql, [DUMMY_UUID]);
+    const plan = result.rows.map((row) => Object.values(row).join(' ')).join('\n');
+    const seqScan = /Seq Scan/i.test(plan);
+
+    console.log(`\n[${query.name}]`);
+    console.log(plan);
+    if (seqScan) {
+      failed = true;
+      console.log('  -> FAIL: sequential scan detected (missing or weak index)');
+    } else {
+      console.log('  -> OK');
+    }
+  }
+
+  await client.end();
+
+  if (failed) {
+    console.error('\nIndex audit FAILED: a hot-path query is sequential-scanning.');
+    process.exit(1);
+  }
+  console.log('\nIndex audit passed: no sequential scans on the audited hot paths.');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/backend/src/admin-audit/admin-action-log.entity.ts
+++ b/backend/src/admin-audit/admin-action-log.entity.ts
@@ -1,0 +1,41 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+/**
+ * Append-only audit trail for structured administrator actions that are not
+ * otherwise covered by a domain audit log (e.g. settlement batch recovery,
+ * revenue-split activation, manual payment resolution).
+ */
+@Entity('admin_action_logs')
+export class AdminActionLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** The admin user who performed the action. */
+  @Column({ type: 'uuid', name: 'actor_id' })
+  actorId: string;
+
+  /** Machine-readable action identifier, e.g. "settlement_batch_execute". */
+  @Column({ type: 'varchar', length: 64 })
+  action: string;
+
+  /** Which kind of entity the action targeted, e.g. "SettlementBatch". */
+  @Column({ type: 'varchar', length: 64, name: 'target_type' })
+  targetType: string;
+
+  @Index('idx_admin_action_logs_target')
+  @Column({ type: 'uuid', name: 'target_id', nullable: true })
+  targetId: string | null;
+
+  /** Free-form context (a human reason where one was required). */
+  @Column({ type: 'text', nullable: true })
+  detail: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/backend/src/admin-audit/admin-action-log.service.spec.ts
+++ b/backend/src/admin-audit/admin-action-log.service.spec.ts
@@ -1,0 +1,80 @@
+import { AdminActionLogService } from './admin-action-log.service';
+import { AdminActionType } from './admin-action-type.enum';
+
+function makeLogRepository(seed: any[] = []) {
+  const rows = [...seed];
+  return {
+    create: jest.fn((entity) => ({ id: 'generated', ...entity })),
+    save: jest.fn(async (entity) => {
+      const row = { ...entity, createdAt: new Date('2025-01-01T00:00:00Z') };
+      rows.push(row);
+      return row;
+    }),
+    find: jest.fn(async (options?: any) => {
+      let result = rows.map((r) => ({ ...r }));
+      if (options?.where?.action) {
+        result = result.filter((r) => r.action === options.where.action);
+      }
+      return result;
+    }),
+    count: jest.fn(async () => rows.length),
+    _rows: rows,
+  };
+}
+
+describe('AdminActionLogService', () => {
+  it('records each admin action with actor, target and detail', async () => {
+    const repo = makeLogRepository();
+    const service = new AdminActionLogService(repo as any);
+
+    const log = await service.record({
+      actorId: 'actor-1',
+      action: AdminActionType.SETTLEMENT_BATCH_EXECUTE,
+      targetType: 'SettlementBatch',
+      targetId: 'batch-1',
+      detail: 'DISTRIBUTION',
+    });
+
+    expect(repo.save).toHaveBeenCalledTimes(1);
+    expect(repo._rows).toHaveLength(1);
+    expect(log.actorId).toBe('actor-1');
+    expect(log.action).toBe('settlement_batch_execute');
+    expect(log.targetId).toBe('batch-1');
+    expect(log.detail).toBe('DISTRIBUTION');
+  });
+
+  it('lists logs newest first', async () => {
+    const repo = makeLogRepository([
+      { id: 'a', action: 'payment_void', createdAt: new Date('2025-01-01T00:00:00Z') },
+      { id: 'b', action: 'payment_resolve_manually', createdAt: new Date('2025-01-01T00:00:00Z') },
+    ]);
+    const service = new AdminActionLogService(repo as any);
+
+    const list = await service.list();
+    expect(list).toHaveLength(2);
+    expect(repo.find).toHaveBeenCalledWith({
+      where: {},
+      order: { createdAt: 'DESC' },
+    });
+  });
+
+  it('filters by action type', async () => {
+    const repo = makeLogRepository([
+      { id: 'a', action: 'payment_void' },
+      { id: 'b', action: 'split_config_activate' },
+    ]);
+    const service = new AdminActionLogService(repo as any);
+
+    await service.list(AdminActionType.PAYMENT_VOID);
+    expect(repo.find).toHaveBeenCalledWith({
+      where: { action: 'payment_void' },
+      order: { createdAt: 'DESC' },
+    });
+  });
+
+  it('counts recorded actions', async () => {
+    const repo = makeLogRepository([{ id: 'a', action: 'payment_void' }]);
+    const service = new AdminActionLogService(repo as any);
+    await expect(service.count()).resolves.toBe(1);
+  });
+});

--- a/backend/src/admin-audit/admin-action-log.service.ts
+++ b/backend/src/admin-audit/admin-action-log.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AdminActionLog } from './admin-action-log.entity';
+import { AdminActionType } from './admin-action-type.enum';
+
+export interface RecordAdminActionInput {
+  actorId: string;
+  action: AdminActionType;
+  targetType: string;
+  targetId?: string | null;
+  detail?: string | null;
+}
+
+@Injectable()
+export class AdminActionLogService {
+  constructor(
+    @InjectRepository(AdminActionLog)
+    private readonly logRepository: Repository<AdminActionLog>,
+  ) {}
+
+  async record(input: RecordAdminActionInput): Promise<AdminActionLog> {
+    const entry = this.logRepository.create({
+      actorId: input.actorId,
+      action: input.action,
+      targetType: input.targetType,
+      targetId: input.targetId ?? null,
+      detail: input.detail ?? null,
+    });
+    return this.logRepository.save(entry);
+  }
+
+  list(action?: AdminActionType): Promise<AdminActionLog[]> {
+    return this.logRepository.find({
+      where: action ? { action } : {},
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async count(): Promise<number> {
+    return this.logRepository.count();
+  }
+}

--- a/backend/src/admin-audit/admin-action-type.enum.ts
+++ b/backend/src/admin-audit/admin-action-type.enum.ts
@@ -1,0 +1,13 @@
+/**
+ * Structured admin actions captured by the AdminActionLog. Kept here so the
+ * audit trail has a stable, queryable vocabulary rather than ad hoc strings.
+ */
+export enum AdminActionType {
+  SETTLEMENT_BATCH_EXECUTE = 'settlement_batch_execute',
+  SETTLEMENT_BATCH_RETRY = 'settlement_batch_retry',
+  SETTLEMENT_BATCH_ABANDON = 'settlement_batch_abandon',
+  SPLIT_CONFIG_ACTIVATE = 'split_config_activate',
+  SPLIT_CONFIG_DEACTIVATE = 'split_config_deactivate',
+  PAYMENT_RESOLVE_MANUALLY = 'payment_resolve_manually',
+  PAYMENT_VOID = 'payment_void',
+}

--- a/backend/src/admin-audit/admin-audit.controller.ts
+++ b/backend/src/admin-audit/admin-audit.controller.ts
@@ -1,0 +1,38 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { UserRole } from '../auth/enums/user-role.enum';
+import { AdminActionLogService } from './admin-action-log.service';
+import { AdminActionLogResponseDto } from './dto/admin-action-log.response.dto';
+import { AdminActionType } from './admin-action-type.enum';
+
+/**
+ * Read-only surface for the structured admin action audit trail. Every
+ * recorded action (settlement batch execute/retry/abandon, split activation,
+ * manual payment resolution/void) is reviewable here.
+ */
+@ApiTags('admin-audit')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
+@Controller('admin/audit')
+export class AdminAuditController {
+  constructor(private readonly audit: AdminActionLogService) {}
+
+  @Get('actions')
+  @ApiOperation({
+    summary: 'List recorded admin actions, newest first',
+    description:
+      'Optionally filter to a single action type. Every row captures the ' +
+      'acting admin, the targeted entity, and a human detail where one was ' +
+      'required.',
+  })
+  async list(
+    @Query('action') action?: AdminActionType,
+  ): Promise<AdminActionLogResponseDto[]> {
+    const logs = await this.audit.list(action);
+    return logs.map((log) => AdminActionLogResponseDto.fromEntity(log));
+  }
+}

--- a/backend/src/admin-audit/admin-audit.module.ts
+++ b/backend/src/admin-audit/admin-audit.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AdminActionLog } from './admin-action-log.entity';
+import { AdminActionLogService } from './admin-action-log.service';
+import { AdminAuditController } from './admin-audit.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AdminActionLog])],
+  controllers: [AdminAuditController],
+  providers: [AdminActionLogService],
+  exports: [AdminActionLogService],
+})
+export class AdminAuditModule {}

--- a/backend/src/admin-audit/dto/admin-action-log.response.dto.ts
+++ b/backend/src/admin-audit/dto/admin-action-log.response.dto.ts
@@ -1,0 +1,38 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { AdminActionLog } from '../admin-action-log.entity';
+import { AdminActionType } from '../admin-action-type.enum';
+
+export class AdminActionLogResponseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  actorId: string;
+
+  @ApiProperty({ enum: AdminActionType })
+  action: AdminActionType;
+
+  @ApiProperty()
+  targetType: string;
+
+  @ApiProperty({ nullable: true })
+  targetId: string | null;
+
+  @ApiProperty({ nullable: true })
+  detail: string | null;
+
+  @ApiProperty()
+  createdAt: Date;
+
+  static fromEntity(log: AdminActionLog): AdminActionLogResponseDto {
+    const dto = new AdminActionLogResponseDto();
+    dto.id = log.id;
+    dto.actorId = log.actorId;
+    dto.action = log.action as AdminActionType;
+    dto.targetType = log.targetType;
+    dto.targetId = log.targetId;
+    dto.detail = log.detail;
+    dto.createdAt = log.createdAt;
+    return dto;
+  }
+}

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { AuthModule } from './auth/auth.module';
 import { PaymentsModule } from './payments/payments.module';
 import { WalletsModule } from './wallets/wallets.module';
 import { CreditsModule } from './credits/credits.module';
+import { AdminAuditModule } from './admin-audit/admin-audit.module';
 import { MetricsService } from './common/metrics.service';
 import { RequestContextMiddleware } from './common/request-context.middleware';
 
@@ -68,6 +69,9 @@ import { RequestContextMiddleware } from './common/request-context.middleware';
     // Micropayment credit ledger, revenue splits and batch settlement
     // (issue #1575). Its own @Cron jobs ride the ScheduleModule above.
     CreditsModule,
+    // Structured audit trail for admin actions (issue #1612). Consumed by
+    // the payments and credits admin controllers; read via /admin/audit.
+    AdminAuditModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/credits/credits-admin.controller.ts
+++ b/backend/src/credits/credits-admin.controller.ts
@@ -28,6 +28,8 @@ import { LedgerService } from './ledger.service';
 import { PaymentCreditsService } from './payment-credits.service';
 import { RevenueSplitService } from './revenue-split.service';
 import { SettlementService } from './settlement.service';
+import { AdminActionLogService } from '../admin-audit/admin-action-log.service';
+import { AdminActionType } from '../admin-audit/admin-action-type.enum';
 import { SettlementBatchStatus } from './enums/settlement-batch-status.enum';
 import { Workbook } from 'exceljs';
 import { Response } from 'express';
@@ -80,6 +82,7 @@ export class CreditsAdminController {
     private readonly splits: RevenueSplitService,
     private readonly settlement: SettlementService,
     private readonly paymentCredits: PaymentCreditsService,
+    private readonly audit: AdminActionLogService,
   ) {}
 
   // ── accounts ───────────────────────────────────────────────────────────
@@ -292,8 +295,18 @@ export class CreditsAdminController {
   async setActive(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: SetSplitConfigActiveDto,
+    @CurrentUser() currentUser: RequestUser,
   ): Promise<RevenueSplitConfigResponseDto> {
     const config = await this.splits.setActive(id, dto.active);
+    await this.audit.record({
+      actorId: currentUser.id,
+      action: dto.active
+        ? AdminActionType.SPLIT_CONFIG_ACTIVATE
+        : AdminActionType.SPLIT_CONFIG_DEACTIVATE,
+      targetType: 'RevenueSplitConfig',
+      targetId: id,
+      detail: config.name,
+    });
     return RevenueSplitConfigResponseDto.fromEntity(config);
   }
 
@@ -430,8 +443,16 @@ export class CreditsAdminController {
   @ApiResponse({ status: 201, type: SettlementBatchResponseDto })
   async executeBatch(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() currentUser: RequestUser,
   ): Promise<SettlementBatchResponseDto> {
     const batch = await this.settlement.executeBatch(id);
+    await this.audit.record({
+      actorId: currentUser.id,
+      action: AdminActionType.SETTLEMENT_BATCH_EXECUTE,
+      targetType: 'SettlementBatch',
+      targetId: id,
+      detail: batch.mode,
+    });
     return SettlementBatchResponseDto.fromEntity(batch);
   }
 
@@ -445,8 +466,16 @@ export class CreditsAdminController {
   @ApiResponse({ status: 201, type: SettlementBatchResponseDto })
   async retryBatch(
     @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() currentUser: RequestUser,
   ): Promise<SettlementBatchResponseDto> {
     const batch = await this.settlement.retryBatch(id);
+    await this.audit.record({
+      actorId: currentUser.id,
+      action: AdminActionType.SETTLEMENT_BATCH_RETRY,
+      targetType: 'SettlementBatch',
+      targetId: id,
+      detail: batch.mode,
+    });
     return SettlementBatchResponseDto.fromEntity(batch);
   }
 
@@ -462,8 +491,16 @@ export class CreditsAdminController {
   async abandonBatch(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: AbandonSettlementBatchDto,
+    @CurrentUser() currentUser: RequestUser,
   ): Promise<SettlementBatchResponseDto> {
     const batch = await this.settlement.abandonBatch(id, dto.reason);
+    await this.audit.record({
+      actorId: currentUser.id,
+      action: AdminActionType.SETTLEMENT_BATCH_ABANDON,
+      targetType: 'SettlementBatch',
+      targetId: id,
+      detail: dto.reason,
+    });
     return SettlementBatchResponseDto.fromEntity(batch);
   }
 }

--- a/backend/src/credits/credits.module.ts
+++ b/backend/src/credits/credits.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Payment } from '../payments/entities/payment.entity';
 import { PaymentsModule } from '../payments/payments.module';
+import { AdminAuditModule } from '../admin-audit/admin-audit.module';
 import { LedgerAccount } from './entities/ledger-account.entity';
 import { LedgerEntry } from './entities/ledger-entry.entity';
 import { LedgerTransaction } from './entities/ledger-transaction.entity';
@@ -49,6 +50,7 @@ import { SettlementService } from './settlement.service';
       Payment,
     ]),
     PaymentsModule,
+    AdminAuditModule,
   ],
   controllers: [CreditsController, CreditsAdminController],
   providers: [

--- a/backend/src/credits/settlement-startup.spec.ts
+++ b/backend/src/credits/settlement-startup.spec.ts
@@ -1,0 +1,66 @@
+import { SettlementService } from './settlement.service';
+
+function makeConfig(values: Record<string, unknown>) {
+  return {
+    get: jest.fn((key: string, fallback?: unknown) =>
+      (values as any)[key] ?? fallback,
+    ),
+  };
+}
+
+function build(
+  config: Record<string, unknown>,
+  findConfigByName: jest.Mock,
+): SettlementService {
+  return new SettlementService(
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    {} as any,
+    { findConfigByName } as any,
+    makeConfig(config) as any,
+    undefined,
+    { recordReconciliationPass: jest.fn() } as any,
+  );
+}
+
+describe('SettlementService.onModuleInit (CREDITS_SETTLEMENT_SPLIT_CONFIG)', () => {
+  it('does nothing when the env var is not set', async () => {
+    const findConfigByName = jest.fn();
+    const service = build({}, findConfigByName);
+    await expect(service.onModuleInit()).resolves.toBeUndefined();
+    expect(findConfigByName).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when settlement is disabled', async () => {
+    const findConfigByName = jest.fn();
+    const service = build(
+      { CREDITS_SETTLEMENT_SPLIT_CONFIG: 'split-a', CREDITS_SETTLEMENT_ENABLED: 'false' },
+      findConfigByName,
+    );
+    await expect(service.onModuleInit()).resolves.toBeUndefined();
+    expect(findConfigByName).not.toHaveBeenCalled();
+  });
+
+  it('passes startup when the named config exists', async () => {
+    const findConfigByName = jest.fn().mockResolvedValue({ id: 'config-1' });
+    const service = build(
+      { CREDITS_SETTLEMENT_SPLIT_CONFIG: 'split-a' },
+      findConfigByName,
+    );
+    await expect(service.onModuleInit()).resolves.toBeUndefined();
+    expect(findConfigByName).toHaveBeenCalledWith('split-a');
+  });
+
+  it('fails fast when the named config does not exist', async () => {
+    const findConfigByName = jest.fn().mockResolvedValue(null);
+    const service = build(
+      { CREDITS_SETTLEMENT_SPLIT_CONFIG: 'typo-config' },
+      findConfigByName,
+    );
+    await expect(service.onModuleInit()).rejects.toThrow(
+      'CREDITS_SETTLEMENT_SPLIT_CONFIG="typo-config"',
+    );
+  });
+});

--- a/backend/src/credits/settlement.service.ts
+++ b/backend/src/credits/settlement.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   Logger,
   NotFoundException,
+  OnModuleInit,
   Optional,
   UnprocessableEntityException,
 } from '@nestjs/common';
@@ -101,8 +102,33 @@ export interface SettlementBatchBreakdown {
  * never as paid.
  */
 @Injectable()
-export class SettlementService {
+export class SettlementService implements OnModuleInit {
   private readonly logger = new Logger(SettlementService.name);
+
+  /**
+   * Fail-fast startup validation for CREDITS_SETTLEMENT_SPLIT_CONFIG
+   * (issue #1613). When settlement is enabled and a split config is
+   * referenced by name, we confirm that config actually exists (and is
+   * usable) at boot time - otherwise a typo or a deleted config would only
+   * surface hours later on the next cron tick, silently skipping
+   * distribution.
+   */
+  async onModuleInit(): Promise<void> {
+    const name = this.config.get<string>('CREDITS_SETTLEMENT_SPLIT_CONFIG');
+    if (!name) return;
+    if (
+      this.config.get<string>('CREDITS_SETTLEMENT_ENABLED', 'true') !== 'true'
+    ) {
+      return;
+    }
+    const config = await this.splits.findConfigByName(name);
+    if (!config) {
+      throw new Error(
+        `CREDITS_SETTLEMENT_SPLIT_CONFIG="${name}" does not match any ` +
+          'RevenueSplitConfig. Fix the environment variable before starting.',
+      );
+    }
+  }
 
   constructor(
     @InjectRepository(SettlementBatch)

--- a/backend/src/database/migrations/1790001000000-CreateAdminActionLogsTable.ts
+++ b/backend/src/database/migrations/1790001000000-CreateAdminActionLogsTable.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateAdminActionLogsTable1790001000000
+  implements MigrationInterface
+{
+  name = 'CreateAdminActionLogsTable1790001000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "admin_action_logs" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "actor_id" uuid NOT NULL,
+        "action" varchar(64) NOT NULL,
+        "target_type" varchar(64) NOT NULL,
+        "target_id" uuid,
+        "detail" text,
+        "created_at" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "pk_admin_action_logs" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "idx_admin_action_logs_target" ON "admin_action_logs" ("target_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_admin_action_logs_action" ON "admin_action_logs" ("action")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_admin_action_logs_created_at" ON "admin_action_logs" ("created_at")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_admin_action_logs_created_at"`);
+    await queryRunner.query(`DROP INDEX "idx_admin_action_logs_action"`);
+    await queryRunner.query(`DROP INDEX "idx_admin_action_logs_target"`);
+    await queryRunner.query(`DROP TABLE "admin_action_logs"`);
+  }
+}

--- a/backend/src/database/migrations/1790002000000-AddIndexAuditIndexes.ts
+++ b/backend/src/database/migrations/1790002000000-AddIndexAuditIndexes.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * BE-140 index audit: the two most likely-to-grow read endpoints were
+ * running against single-column indexes that did not cover their filter +
+ * sort columns, leaving ORDER BY / status sweeps to sort in memory or
+ * seq-scan as the tables grow.
+ *
+ *  - GET /credits/statement → ledger_entries filtered by account_id,
+ *    ordered by created_at DESC. The existing single-column account_id
+ *    index covers the filter but not the ordering.
+ *  - GET /payments (member list) → filtered by user_id (+ status in the
+ *    admin/manual-review paths). Existing separate user_id index, but no
+ *    coverage for status-swept reconciliation queries.
+ */
+export class AddIndexAuditIndexes1790002000000 implements MigrationInterface {
+  name = 'AddIndexAuditIndexes1790002000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "idx_ledger_entries_account_created" ` +
+        `ON "ledger_entries" ("account_id", "created_at" DESC)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_payments_user_status" ` +
+        `ON "payments" ("user_id", "status")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_payments_status_updated" ` +
+        `ON "payments" ("status", "updated_at" ASC)`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_payments_status_updated"`);
+    await queryRunner.query(`DROP INDEX "idx_payments_user_status"`);
+    await queryRunner.query(`DROP INDEX "idx_ledger_entries_account_created"`);
+  }
+}

--- a/backend/src/payments/README.md
+++ b/backend/src/payments/README.md
@@ -98,3 +98,61 @@ and whether it exceeds `PAYMENT_MANUAL_REVIEW_ALERT_THRESHOLD`; the
 scheduled job logs a `WARN`-level alert when it does. This is a
 log-based signal by design — this module doesn't assume any particular
 metrics/observability backend is wired up yet.
+
+## Webhook payload contract
+
+Every payment rail adapter maps its provider-specific confirmation event
+into one **normalized** payload before the confirmation service consumes it.
+The shape below is the contract (BE-137); `src/webhook-contract.ts` is the
+machine-checkable source of truth, and every parsed webhook is validated
+against it before any `Payment` state is touched — a wrong-shaped event is
+rejected with a clear `400 Bad Request`, never silently mishandled.
+
+### Contract version
+
+`v1.0` — returned on every successful webhook response as `contractVersion`
+and available as `PAYMENT_WEBHOOK_CONTRACT_VERSION` in
+`src/webhook-contract.ts`. Bump this when a future issue makes a
+**breaking** change to the normalized shape.
+
+### Normalized payload
+
+```json
+{
+  "providerReference": "provider_1234",
+  "outcome": "confirmed"
+}
+```
+
+| Field              | Type                                  | Required | Notes                                                       |
+| ------------------ | ------------------------------------- | -------- | ----------------------------------------------------------- |
+| `providerReference`| string                                | yes      | The provider's id for the payment we initiated. Non-blank.   |
+| `outcome`          | `"confirmed" \| "failed" \| "pending"`| yes      | Terminal/current verdict to apply to the payment.            |
+
+### Transport & processing rules
+
+1. **Transport authenticity** — each rail has a dedicated controller
+   (`/payments/webhooks/<rail>`) that authenticates the caller at the
+   transport level (the sandbox rail uses an HMAC-SHA256 signature over the
+   raw body, secret `PAYMENT_WEBHOOK_SECRET`). A bad signature is rejected
+   with `401` before any parsing.
+2. **Per-rail mapping** — the rail adapter's `parseWebhookPayload(rawBody)`
+   maps the provider's native event fields into the normalized shape, so
+   provider-specific field names/layouts never leak past the adapter.
+3. **Contract validation** — the controller then runs
+   `validateWebhookPayload` on the normalized payload. Malformed/missing
+   fields → `400` with a field-specific message (logged as
+   `malformed_payload`).
+4. **Idempotency** — `PaymentConfirmationService.apply` looks the payment
+   up by `providerReference` and no-ops on an already-terminal payment, so
+   duplicate or replay webhooks are harmless by construction.
+
+### Adding a new rail
+
+Implement `PaymentRailAdapter` and add a `@Post('webhooks/<rail>')` handler.
+The handler must (a) verify transport authenticity, (b) call the adapter's
+`parseWebhookPayload` to map native events into the normalized shape, and
+(c) hand the validated `{ providerReference, outcome }` to
+`PaymentConfirmationService.apply`. The contract above — not any single
+provider's field names — is the boundary every rail is held to.
+

--- a/backend/src/payments/payment-webhook.controller.spec.ts
+++ b/backend/src/payments/payment-webhook.controller.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, UnauthorizedException } from '@nestjs/common';
 import { PaymentWebhookController } from './payment-webhook.controller';
 import { ConfirmationSource } from './enums/confirmation-source.enum';
+import { PAYMENT_WEBHOOK_CONTRACT_VERSION } from './webhook-contract';
 
 function makeRequest(bodyObject: unknown) {
   const rawBody = Buffer.from(JSON.stringify(bodyObject));
@@ -82,7 +83,10 @@ describe('PaymentWebhookController', () => {
 
     const result = await controller.sandbox(req, 'good-sig');
 
-    expect(result).toEqual({ received: true });
+    expect(result).toEqual({
+      received: true,
+      contractVersion: PAYMENT_WEBHOOK_CONTRACT_VERSION,
+    });
     expect(confirmationService.apply).toHaveBeenCalledWith(
       'ref-1',
       'confirmed',

--- a/backend/src/payments/payment-webhook.controller.ts
+++ b/backend/src/payments/payment-webhook.controller.ts
@@ -8,10 +8,14 @@ import {
   Req,
   UnauthorizedException,
 } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Request } from 'express';
 import { SandboxRailAdapter } from './adapters/sandbox-rail.adapter';
 import { ConfirmationSource } from './enums/confirmation-source.enum';
+import {
+  PAYMENT_WEBHOOK_CONTRACT_VERSION,
+  validateWebhookPayload,
+} from './webhook-contract';
 import { PaymentConfirmationService } from './payment-confirmation.service';
 
 interface RawBodyRequest extends Request {
@@ -41,11 +45,34 @@ export class PaymentWebhookController {
   @ApiOperation({
     summary:
       'Sandbox rail confirmation webhook (HMAC-signed via PAYMENT_WEBHOOK_SECRET)',
+    description:
+      `Accepts a webhook whose parsed payload conforms to the normalized ` +
+      `webhook contract v${PAYMENT_WEBHOOK_CONTRACT_VERSION} documented in the ` +
+      `payments README (providerReference + outcome). The transport is ` +
+      `authenticated by the HMAC signature; the payload shape is validated ` +
+      `against the contract so a wrong-shaped event is rejected, not silently ` +
+      `mishandled.`,
+  })
+  @ApiBody({
+    description:
+      `Expected parsed shape: { "providerReference": string, ` +
+      `"outcome": "confirmed" | "failed" | "pending" }`,
+    schema: {
+      type: 'object',
+      required: ['providerReference', 'outcome'],
+      properties: {
+        providerReference: { type: 'string' },
+        outcome: {
+          type: 'string',
+          enum: ['confirmed', 'failed', 'pending'],
+        },
+      },
+    },
   })
   async sandbox(
     @Req() req: RawBodyRequest,
     @Headers('x-payment-signature') signature?: string,
-  ): Promise<{ received: boolean }> {
+  ): Promise<{ received: boolean; contractVersion: string }> {
     const rawBody = req.rawBody ?? Buffer.from(JSON.stringify(req.body ?? {}));
     const rawPayloadHash = PaymentConfirmationService.hashPayload(rawBody);
 
@@ -64,12 +91,15 @@ export class PaymentWebhookController {
     let payload;
     try {
       payload = this.railAdapter.parseWebhookPayload(rawBody);
-    } catch {
+      validateWebhookPayload(payload);
+    } catch (err) {
       await this.confirmationService.logRejectedWebhook(
         rawPayloadHash,
         'malformed_payload',
       );
-      throw new BadRequestException('Malformed webhook payload');
+      throw new BadRequestException(
+        err instanceof Error ? err.message : 'Malformed webhook payload',
+      );
     }
 
     await this.confirmationService.apply(
@@ -79,6 +109,9 @@ export class PaymentWebhookController {
       rawPayloadHash,
     );
 
-    return { received: true };
+    return {
+      received: true,
+      contractVersion: PAYMENT_WEBHOOK_CONTRACT_VERSION,
+    };
   }
 }

--- a/backend/src/payments/payments-admin.controller.ts
+++ b/backend/src/payments/payments-admin.controller.ts
@@ -21,6 +21,8 @@ import { RequestUser } from '../auth/interfaces/authenticated-request.interface'
 import { UserRole } from '../auth/enums/user-role.enum';
 import { ReconciliationService } from './reconciliation.service';
 import { RefundsService } from './refunds.service';
+import { AdminActionLogService } from '../admin-audit/admin-action-log.service';
+import { AdminActionType } from '../admin-audit/admin-action-type.enum';
 import { PaymentResponseDto } from './dto/payment-response.dto';
 import { ResolvePaymentManuallyDto } from './dto/resolve-payment-manually.dto';
 import { VoidPaymentDto } from './dto/void-payment.dto';
@@ -45,6 +47,7 @@ export class PaymentsAdminController {
   constructor(
     private readonly reconciliationService: ReconciliationService,
     private readonly refundsService: RefundsService,
+    private readonly audit: AdminActionLogService,
   ) {}
 
   @Get('manual-review')
@@ -88,12 +91,20 @@ export class PaymentsAdminController {
   async resolveManually(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: ResolvePaymentManuallyDto,
+    @CurrentUser() currentUser: RequestUser,
   ): Promise<PaymentResponseDto> {
     const payment = await this.reconciliationService.resolveManually(
       id,
       dto.resolution,
       dto.reason,
     );
+    await this.audit.record({
+      actorId: currentUser.id,
+      action: AdminActionType.PAYMENT_RESOLVE_MANUALLY,
+      targetType: 'Payment',
+      targetId: id,
+      detail: `Resolution: ${dto.resolution} - ${dto.reason}`,
+    });
     return PaymentResponseDto.fromEntity(payment);
   }
 
@@ -106,8 +117,16 @@ export class PaymentsAdminController {
   async void(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() dto: VoidPaymentDto,
+    @CurrentUser() currentUser: RequestUser,
   ): Promise<PaymentResponseDto> {
     const payment = await this.reconciliationService.void(id, dto.reason);
+    await this.audit.record({
+      actorId: currentUser.id,
+      action: AdminActionType.PAYMENT_VOID,
+      targetType: 'Payment',
+      targetId: id,
+      detail: dto.reason,
+    });
     return PaymentResponseDto.fromEntity(payment);
   }
 

--- a/backend/src/payments/payments.module.ts
+++ b/backend/src/payments/payments.module.ts
@@ -16,6 +16,7 @@ import { PaymentWebhookController } from './payment-webhook.controller';
 import { PaymentsAdminController } from './payments-admin.controller';
 import { SandboxRailAdapter } from './adapters/sandbox-rail.adapter';
 import { WalletsModule } from '../wallets/wallets.module';
+import { AdminAuditModule } from '../admin-audit/admin-audit.module';
 import { loadSorobanConfig } from './soroban/soroban-config';
 import { SorobanRailAdapter } from './soroban/soroban-rail.adapter';
 import { SorobanPayoutAdapter } from './soroban/soroban-payout.adapter';
@@ -37,6 +38,7 @@ import {
   imports: [
     TypeOrmModule.forFeature([Payment, ConfirmationEvent, Refund]),
     WalletsModule,
+    AdminAuditModule,
     BullModule.registerQueue({ name: SOROBAN_ESCROW_QUEUE }),
   ],
   controllers: [

--- a/backend/src/payments/webhook-contract.spec.ts
+++ b/backend/src/payments/webhook-contract.spec.ts
@@ -1,0 +1,54 @@
+import {
+  PAYMENT_WEBHOOK_CONTRACT_VERSION,
+  validateWebhookPayload,
+} from './webhook-contract';
+
+describe('webhook-contract', () => {
+  it('exposes a versioned contract', () => {
+    expect(PAYMENT_WEBHOOK_CONTRACT_VERSION).toBe('1.0');
+  });
+
+  it('accepts a well-formed normalized payload', () => {
+    expect(
+      validateWebhookPayload({ providerReference: 'p1', outcome: 'confirmed' }),
+    ).toEqual({
+      providerReference: 'p1',
+      outcome: 'confirmed',
+    });
+  });
+
+  it('accepts every legal outcome', () => {
+    for (const outcome of ['confirmed', 'failed', 'pending']) {
+      expect(
+        validateWebhookPayload({ providerReference: 'p1', outcome }),
+      ).toEqual({ providerReference: 'p1', outcome });
+    }
+  });
+
+  it('rejects a non-object payload', () => {
+    for (const bad of [null, 'string', 42, [], undefined]) {
+      expect(() => validateWebhookPayload(bad)).toThrow(/JSON object/);
+    }
+  });
+
+  it('rejects a missing or blank providerReference with a clear error', () => {
+    expect(() => validateWebhookPayload({ outcome: 'confirmed' })).toThrow(
+      /providerReference/,
+    );
+    expect(() =>
+      validateWebhookPayload({
+        providerReference: '   ',
+        outcome: 'confirmed',
+      }),
+    ).toThrow(/providerReference/);
+  });
+
+  it('rejects an unknown or missing outcome with a clear error', () => {
+    expect(() => validateWebhookPayload({ providerReference: 'p1' })).toThrow(
+      /outcome/,
+    );
+    expect(() =>
+      validateWebhookPayload({ providerReference: 'p1', outcome: 'bogus' }),
+    ).toThrow(/outcome/);
+  });
+});

--- a/backend/src/payments/webhook-contract.ts
+++ b/backend/src/payments/webhook-contract.ts
@@ -1,0 +1,57 @@
+import {
+  PaymentVerificationOutcome,
+  WebhookPayload,
+} from './interfaces/payment-rail-adapter.interface';
+
+/**
+ * Normalized, versioned webhook payload contract (BE-137). Every payment
+ * rail adapter maps its provider-specific payload into this shape before the
+ * confirmation service consumes it. The contract is documented in
+ * ../payments/README.md ("Webhook payload contract"); this module is the
+ * machine-checkable source of truth it points at.
+ */
+export const PAYMENT_WEBHOOK_CONTRACT_VERSION = '1.0';
+
+const VALID_OUTCOMES: ReadonlySet<string> = new Set([
+  'confirmed',
+  'failed',
+  'pending',
+]);
+
+/**
+ * Validates an already-parsed payload against the normalized contract,
+ * throwing a clear, actionable error on the first violation so a
+ * wrong-shaped or malformed webhook is rejected loudly instead of being
+ * silently mishandled downstream.
+ */
+export function validateWebhookPayload(value: unknown): WebhookPayload {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(
+      'Malformed webhook payload: expected a JSON object (contract v1.0)',
+    );
+  }
+
+  const body = value as Record<string, unknown>;
+
+  if (
+    typeof body.providerReference !== 'string' ||
+    body.providerReference.trim() === ''
+  ) {
+    throw new Error(
+      'Malformed webhook payload: missing required string field ' +
+        '"providerReference" (contract v1.0)',
+    );
+  }
+
+  if (typeof body.outcome !== 'string' || !VALID_OUTCOMES.has(body.outcome)) {
+    throw new Error(
+      'Malformed webhook payload: "outcome" must be one of ' +
+        '"confirmed", "failed", "pending" (contract v1.0)',
+    );
+  }
+
+  return {
+    providerReference: body.providerReference,
+    outcome: body.outcome as PaymentVerificationOutcome,
+  };
+}


### PR DESCRIPTION
## Summary

Four backend issues for #1611, #1612, #1613, #1614 implementing the settlement/payment admin hardening track.

### #1611 (BE-137) — Documented, versioned webhook payload contract
- New `src/payments/webhook-contract.ts`: exports `PAYMENT_WEBHOOK_CONTRACT_VERSION` (`1.0`) and `validateWebhookPayload`, the machine-checkable source of truth for the normalized contract (`providerReference` string + `outcome` of `confirmed|failed|pending`).
- `PaymentWebhookController.sandbox` now validates every parsed payload against the contract before touching payment state; a wrong-shaped event returns a clear `400 Bad Request` (field-specific message, logged as `malformed_payload`).
- Contract fully documented in `src/payments/README.md` ("Webhook payload contract") and reflected in Swagger (`@ApiBody` schema). Successful responses now echo `contractVersion`.
- Tests: `webhook-contract.spec.ts` (6 cases) and updated `payment-webhook.controller.spec.ts`.

### #1612 (BE-138) — Structured admin-action audit log
- New `src/admin-audit/` module: entity, `AdminActionType` enum, service, `GET /admin/audit/actions` controller, response DTO, module (exports the service), migration `1790001000000-CreateAdminActionLogsTable`, and service spec.
- Payments admin actions (`PAYMENT_RESOLVE_MANUALLY`, `PAYMENT_VOID`) and credits admin actions (`SPLIT_CONFIG_ACTIVATE/DEACTIVATE`, `SETTLEMENT_BATCH_EXECUTE/RETRY/ABANDON`) now record an actor-bearing audit row via `@CurrentUser`.

### #1613 (BE-139) — Validate split-config existence at startup
- `SettlementService` now implements `OnModuleInit` and fails startup loudly (instead of silently) when `CREDITS_SETTLEMENT_SPLIT_CONFIG` names a config that doesn't exist; covered by `settlement-startup.spec.ts` (4 cases).

### #1614 (BE-140) — Database index audit + workflow
- Migration `1790002000000-AddIndexAuditIndexes` adds the three most-needed indexes (`idx_ledger_entries_account_created`, `idx_payments_user_status`, `idx_payments_status_updated`).
- `scripts/index-audit.js` runs `EXPLAIN` against the key lookup queries and fails on any Seq Scan; wired up as an `npm run index-audit` script.
- GitHub workflow `.github/workflows/index-audit.yaml` (Postgres 16 service, fresh migrate, index audit) to catch missing-index regressions in CI.

## Verification
- `npx tsc --noEmit` ✓
- `npx jest` for the new specs + payments + credits suites ✓ (377 tests passing)
- `npx eslint` on new files ✓

Closes #1611, 
Closes #1612, 
Closes #1613, 
Closes #1614
