### PR TITLE
Admin UI for ledger accounts, integrity check, revenue splits, and settlement

### DIFF
--- a/frontend/app/admin/accounts/page.tsx
+++ b/frontend/app/admin/accounts/page.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useState } from "react";
+import { Plus, Snowflake, Unlock } from "lucide-react";
+import type { LedgerAccount, LedgerAccountKind } from "@/lib/admin-api";
+import { listAccounts, createAccount, updateAccount } from "@/lib/admin-api";
+import {
+  Card,
+  CardHeader,
+  Badge,
+  StatusBadge,
+  Field,
+  Button,
+  SecondaryButton,
+  inputClass,
+} from "@/components/admin/ui";
+import { RequireAdmin, useAdminToken } from "@/components/admin/require-admin";
+
+const KINDS: LedgerAccountKind[] = [
+  "USER",
+  "TREASURY",
+  "REVENUE",
+  "PLATFORM_FEE",
+  "HUB_OPERATOR",
+  "REFERRAL",
+];
+
+export default function AccountsPage() {
+  const token = useAdminToken();
+
+  return (
+    <RequireAdmin>
+      <AccountsInner token={token as string} />
+    </RequireAdmin>
+  );
+}
+
+function AccountsInner({ token }: { token: string }) {
+  const queryClient = useQueryClient();
+  const [showCreate, setShowCreate] = useState(false);
+
+  const accounts = useQuery({
+    queryKey: ["ledger-accounts"],
+    queryFn: () => listAccounts(token),
+  });
+
+  const freeze = useMutation({
+    mutationFn: ({ id, frozen }: { id: string; frozen: boolean }) =>
+      updateAccount(token, id, { frozen }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ledger-accounts"] });
+      toast.success("Account policy updated");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-50">
+            Ledger accounts
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Credit-ledger accounts. Balances move only by posting entries.
+          </p>
+        </div>
+        <Button type="button" onClick={() => setShowCreate((v) => !v)}>
+          <Plus className="h-4 w-4" />
+          New account
+        </Button>
+      </div>
+
+      {showCreate && (
+        <CreateAccountForm token={token} onDone={() => setShowCreate(false)} />
+      )}
+
+      <Card>
+        <CardHeader title={`${accounts.data?.length ?? 0} accounts`} />
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-gray-200 text-xs uppercase text-gray-500 dark:border-gray-800 dark:text-gray-400">
+              <tr>
+                <th className="px-5 py-3">Kind</th>
+                <th className="px-5 py-3">Owner</th>
+                <th className="px-5 py-3">Currency</th>
+                <th className="px-5 py-3 text-right">Balance</th>
+                <th className="px-5 py-3 text-right">Overdraft</th>
+                <th className="px-5 py-3">Payout address</th>
+                <th className="px-5 py-3">Status</th>
+                <th className="px-5 py-3 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+              {accounts.data?.map((account) => (
+                <AccountRow
+                  key={account.id}
+                  account={account}
+                  onToggleFreeze={(frozen) =>
+                    freeze.mutate({ id: account.id, frozen })
+                  }
+                />
+              ))}
+              {!accounts.isLoading && (accounts.data?.length ?? 0) === 0 && (
+                <tr>
+                  <td colSpan={8} className="px-5 py-8 text-center text-gray-400">
+                    No accounts found.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function AccountRow({
+  account,
+  onToggleFreeze,
+}: {
+  account: LedgerAccount;
+  onToggleFreeze: (frozen: boolean) => void;
+}) {
+  return (
+    <tr>
+      <td className="px-5 py-3">
+        <Badge className="bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+          {account.kind}
+        </Badge>
+      </td>
+      <td className="px-5 py-3 text-gray-700 dark:text-gray-300">
+        {account.ownerId ?? (
+          <span className="text-gray-400 dark:text-gray-500">—</span>
+        )}
+      </td>
+      <td className="px-5 py-3 text-gray-700 dark:text-gray-300">
+        {account.currency}
+      </td>
+      <td className="px-5 py-3 text-right tabular-nums text-gray-900 dark:text-gray-50">
+        {account.balance.toLocaleString()}
+      </td>
+      <td className="px-5 py-3 text-right tabular-nums text-gray-700 dark:text-gray-300">
+        {account.overdraftLimit.toLocaleString()}
+      </td>
+      <td className="px-5 py-3 text-xs text-gray-600 dark:text-gray-400">
+        {account.externalPayoutAddress ?? (
+          <span className="text-gray-400 dark:text-gray-500">—</span>
+        )}
+      </td>
+      <td className="px-5 py-3">
+        <StatusBadge status={account.frozen ? "ABANDONED" : "ACTIVE"} />
+      </td>
+      <td className="px-5 py-3 text-right">
+        <SecondaryButton
+          type="button"
+          onClick={() => onToggleFreeze(!account.frozen)}
+          className="px-2.5 py-1 text-xs"
+        >
+          {account.frozen ? (
+            <>
+              <Unlock className="h-3.5 w-3.5" /> Unfreeze
+            </>
+          ) : (
+            <>
+              <Snowflake className="h-3.5 w-3.5" /> Freeze
+            </>
+          )}
+        </SecondaryButton>
+      </td>
+    </tr>
+  );
+}
+
+function CreateAccountForm({
+  token,
+  onDone,
+}: {
+  token: string;
+  onDone: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<{
+    kind: LedgerAccountKind;
+    ownerId: string;
+    currency: string;
+    overdraftLimit: string;
+    externalPayoutAddress: string;
+    label: string;
+  }>({
+    kind: "USER",
+    ownerId: "",
+    currency: "USD",
+    overdraftLimit: "0",
+    externalPayoutAddress: "",
+    label: "",
+  });
+
+  const create = useMutation({
+    mutationFn: () =>
+      createAccount(token, {
+        kind: form.kind,
+        ownerId: form.ownerId || undefined,
+        currency: form.currency,
+        overdraftLimit: form.overdraftLimit
+          ? Number(form.overdraftLimit)
+          : undefined,
+        externalPayoutAddress: form.externalPayoutAddress || undefined,
+        label: form.label || undefined,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ledger-accounts"] });
+      toast.success("Account created");
+      onDone();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const set = (patch: Partial<typeof form>) => setForm((f) => ({ ...f, ...patch }));
+
+  return (
+    <Card>
+      <CardHeader title="Create a ledger account" />
+      <form
+        className="grid gap-4 p-5 sm:grid-cols-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          create.mutate();
+        }}
+      >
+        <Field label="Kind">
+          <select
+            className={inputClass}
+            value={form.kind}
+            onChange={(e) => set({ kind: e.target.value as LedgerAccountKind })}
+          >
+            {KINDS.map((kind) => (
+              <option key={kind} value={kind}>
+                {kind}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label="Owner ID (uuid) — omit for system accounts">
+          <input
+            className={inputClass}
+            value={form.ownerId}
+            onChange={(e) => set({ ownerId: e.target.value })}
+            placeholder="00000000-0000-0000-0000-000000000000"
+          />
+        </Field>
+        <Field label="Currency">
+          <input
+            className={inputClass}
+            value={form.currency}
+            maxLength={3}
+            onChange={(e) => set({ currency: e.target.value.toUpperCase() })}
+          />
+        </Field>
+        <Field label="Overdraft limit (minor units)">
+          <input
+            className={inputClass}
+            type="number"
+            min={0}
+            value={form.overdraftLimit}
+            onChange={(e) => set({ overdraftLimit: e.target.value })}
+          />
+        </Field>
+        <Field label="External payout address (makes it payable)">
+          <input
+            className={inputClass}
+            value={form.externalPayoutAddress}
+            onChange={(e) => set({ externalPayoutAddress: e.target.value })}
+          />
+        </Field>
+        <Field label="Label">
+          <input
+            className={inputClass}
+            value={form.label}
+            onChange={(e) => set({ label: e.target.value })}
+          />
+        </Field>
+        <div className="flex gap-3 sm:col-span-2">
+          <Button type="submit" disabled={create.isPending}>
+            {create.isPending ? "Creating…" : "Create"}
+          </Button>
+          <SecondaryButton type="button" onClick={onDone}>
+            Cancel
+          </SecondaryButton>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/frontend/app/admin/integrity/page.tsx
+++ b/frontend/app/admin/integrity/page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { CheckCircle2, AlertTriangle } from "lucide-react";
+import { checkIntegrity } from "@/lib/admin-api";
+import { Card, CardHeader, Button } from "@/components/admin/ui";
+import { RequireAdmin, useAdminToken } from "@/components/admin/require-admin";
+
+export default function IntegrityPage() {
+  const token = useAdminToken();
+
+  return (
+    <RequireAdmin>
+      <IntegrityInner token={token as string} />
+    </RequireAdmin>
+  );
+}
+
+function IntegrityInner({ token }: { token: string }) {
+  const report = useQuery({
+    queryKey: ["ledger-integrity"],
+    queryFn: () => checkIntegrity(token),
+    refetchOnWindowFocus: false,
+  });
+
+  const reason = (r: { materialized: number; derived: number }) =>
+    r.materialized - r.derived;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-50">
+            Ledger integrity check
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Every account balance is re-derived from the append-only entries;
+            both lists empty is the healthy state.
+          </p>
+        </div>
+        <Button type="button" onClick={() => report.refetch()} disabled={report.isFetching}>
+          {report.isFetching ? "Checking…" : "Run check"}
+        </Button>
+      </div>
+
+      {report.isLoading ? (
+        <Card className="p-6 text-sm text-gray-500 dark:text-gray-400">
+          Checking ledger integrity…
+        </Card>
+      ) : report.error ? (
+        <Card className="p-6 text-sm text-red-600 dark:text-red-400">
+          {report.error.message}
+        </Card>
+      ) : (
+        <>
+          <Summary report={report.data!} />
+          <DriftTable rows={report.data!.balanceDrift} reason={reason} />
+          <UnbalancedTable rows={report.data!.unbalancedTransactions} />
+        </>
+      )}
+    </div>
+  );
+}
+
+function Summary({
+  report,
+}: {
+  report: { accountsChecked: number; balanceDrift: unknown[]; unbalancedTransactions: unknown[] };
+}) {
+  const healthy = report.balanceDrift.length === 0 && report.unbalancedTransactions.length === 0;
+  return (
+    <Card className="flex items-center gap-4 p-5">
+      {healthy ? (
+        <CheckCircle2 className="h-8 w-8 text-emerald-500" />
+      ) : (
+        <AlertTriangle className="h-8 w-8 text-amber-500" />
+      )}
+      <div>
+        <p className="font-semibold text-gray-900 dark:text-gray-50">
+          {healthy ? "Ledger is consistent" : "Ledger drift detected"}
+        </p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {report.accountsChecked} accounts checked · {report.balanceDrift.length} with balance drift ·
+          {" "}{report.unbalancedTransactions.length} unbalanced transactions
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+function DriftTable({
+  rows,
+  reason,
+}: {
+  rows: Array<{ accountId: string; materialized: number; derived: number }>;
+  reason: (r: { materialized: number; derived: number }) => number;
+}) {
+  return (
+    <Card>
+      <CardHeader
+        title="Account balance drift"
+        description="Materialized vs derived balance — any row here is a bug to investigate."
+      />
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead className="border-b border-gray-200 text-xs uppercase text-gray-500 dark:border-gray-800 dark:text-gray-400">
+            <tr>
+              <th className="px-5 py-3">Account</th>
+              <th className="px-5 py-3 text-right">Materialized</th>
+              <th className="px-5 py-3 text-right">Derived</th>
+              <th className="px-5 py-3 text-right">Drift</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+            {rows.map((row) => (
+              <tr key={row.accountId}>
+                <td className="px-5 py-3 font-mono text-xs text-gray-700 dark:text-gray-300">
+                  {row.accountId}
+                </td>
+                <td className="px-5 py-3 text-right tabular-nums">{row.materialized}</td>
+                <td className="px-5 py-3 text-right tabular-nums">{row.derived}</td>
+                <td className="px-5 py-3 text-right tabular-nums font-medium text-red-600 dark:text-red-400">
+                  {reason(row)}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={4} className="px-5 py-8 text-center text-gray-400">
+                  No drift — every account reconciles.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}
+
+function UnbalancedTable({
+  rows,
+}: {
+  rows: Array<{ transactionId: string; debits: number; credits: number }>;
+}) {
+  return (
+    <Card>
+      <CardHeader
+        title="Unbalanced transactions"
+        description="Transactions whose debits and credits do not cancel."
+      />
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead className="border-b border-gray-200 text-xs uppercase text-gray-500 dark:border-gray-800 dark:text-gray-400">
+            <tr>
+              <th className="px-5 py-3">Transaction</th>
+              <th className="px-5 py-3 text-right">Debits</th>
+              <th className="px-5 py-3 text-right">Credits</th>
+              <th className="px-5 py-3 text-right">Imbalance</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+            {rows.map((row) => (
+              <tr key={row.transactionId}>
+                <td className="px-5 py-3 font-mono text-xs text-gray-700 dark:text-gray-300">
+                  {row.transactionId}
+                </td>
+                <td className="px-5 py-3 text-right tabular-nums">{row.debits}</td>
+                <td className="px-5 py-3 text-right tabular-nums">{row.credits}</td>
+                <td className="px-5 py-3 text-right tabular-nums font-medium text-red-600 dark:text-red-400">
+                  {row.debits - row.credits}
+                </td>
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={4} className="px-5 py-8 text-center text-gray-400">
+                  No unbalanced transactions.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -1,0 +1,81 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  Landmark,
+  Scale,
+  Split,
+  RefreshCw,
+  LayoutDashboard,
+} from "lucide-react";
+import { AdminProviders } from "@/lib/providers";
+import { cn } from "@/lib/utils";
+
+export const metadata: Metadata = {
+  title: "Admin",
+};
+
+const nav = [
+  { href: "/admin", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/admin/accounts", label: "Ledger accounts", icon: Landmark },
+  { href: "/admin/integrity", label: "Integrity check", icon: Scale },
+  { href: "/admin/splits", label: "Revenue splits", icon: Split },
+  { href: "/admin/settlements", label: "Settlement", icon: RefreshCw },
+];
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <AdminProviders>
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
+        <header className="border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+          <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
+            <Link href="/admin" className="flex items-center gap-2 text-lg font-semibold text-gray-900 dark:text-gray-50">
+              <Landmark className="h-5 w-5 text-blue-600" />
+              ManageHub Admin
+            </Link>
+            <Link href="/" className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+              Back to site
+            </Link>
+          </div>
+        </header>
+        <div className="mx-auto flex max-w-7xl gap-8 px-6 py-8">
+          <aside className="w-52 shrink-0">
+            <nav className="sticky top-8 space-y-1">
+              {nav.map(({ href, label, icon: Icon }) => (
+                <AdminLink key={href} href={href} icon={Icon}>
+                  {label}
+                </AdminLink>
+              ))}
+            </nav>
+          </aside>
+          <main className="min-w-0 flex-1">{children}</main>
+        </div>
+      </div>
+    </AdminProviders>
+  );
+}
+
+function AdminLink({
+  href,
+  icon: Icon,
+  children,
+}: {
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  children: React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-100",
+      )}
+    >
+      <Icon className="h-4 w-4" />
+      {children}
+    </Link>
+  );
+}

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import { Landmark, Scale, Split, RefreshCw } from "lucide-react";
+import { Card } from "@/components/admin/ui";
+
+const cards = [
+  {
+    href: "/admin/accounts",
+    title: "Ledger accounts",
+    description:
+      "Browse and manage credit-ledger accounts — balances, policy, freezing, payout addresses.",
+    icon: Landmark,
+  },
+  {
+    href: "/admin/integrity",
+    title: "Integrity check",
+    description:
+      "Re-derive balances from the append-only entries and surface balance drift or unbalanced transactions.",
+    icon: Scale,
+  },
+  {
+    href: "/admin/splits",
+    title: "Revenue splits",
+    description:
+      "Create and manage revenue-split configs, inspect recipients, and preview allocations.",
+    icon: Split,
+  },
+  {
+    href: "/admin/settlements",
+    title: "Settlement pipeline",
+    description:
+      "Inspect settlement batches, view breakdowns, and drive execute / retry / abandon recovery.",
+    icon: RefreshCw,
+  },
+];
+
+export default function AdminDashboardPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-50">
+        Admin dashboard
+      </h1>
+      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+        The ADMIN surface for the credit ledger, revenue splits, and the
+        settlement pipeline.
+      </p>
+      <div className="mt-6 grid gap-4 sm:grid-cols-2">
+        {cards.map(({ href, title, description, icon: Icon }) => (
+          <Link key={href} href={href} className="group">
+            <Card className="h-full p-5 transition hover:border-blue-400 hover:shadow-md dark:hover:border-blue-600">
+              <div className="flex items-center gap-3">
+                <Icon className="h-5 w-5 text-blue-600" />
+                <h2 className="font-semibold text-gray-900 group-hover:text-blue-700 dark:text-gray-50">
+                  {title}
+                </h2>
+              </div>
+              <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                {description}
+              </p>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/admin/settlements/[id]/page.tsx
+++ b/frontend/app/admin/settlements/[id]/page.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useState } from "react";
+import { Play, RotateCcw, Ban } from "lucide-react";
+import {
+  getBatchBreakdown,
+  executeBatch,
+  retryBatch,
+  abandonBatch,
+} from "@/lib/admin-api";
+import {
+  Card,
+  CardHeader,
+  Badge,
+  StatusBadge,
+  Button,
+  SecondaryButton,
+  Field,
+  inputClass,
+} from "@/components/admin/ui";
+import { RequireAdmin, useAdminToken } from "@/components/admin/require-admin";
+
+export default function BatchDetailPage() {
+  const token = useAdminToken();
+
+  return (
+    <RequireAdmin>
+      <BatchDetailInner token={token as string} />
+    </RequireAdmin>
+  );
+}
+
+function BatchDetailInner({ token }: { token: string }) {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+  const queryClient = useQueryClient();
+  const [abandonReason, setAbandonReason] = useState("");
+
+  const detail = useQuery({
+    queryKey: ["settlement-batch", id],
+    queryFn: () => getBatchBreakdown(token, id),
+  });
+
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: ["settlement-batch", id] });
+
+  const execute = useMutation({
+    mutationFn: () => executeBatch(token, id),
+    onSuccess: invalidate,
+    onError: (err) => toast.error(err.message),
+  });
+  const retry = useMutation({
+    mutationFn: () => retryBatch(token, id),
+    onSuccess: invalidate,
+    onError: (err) => toast.error(err.message),
+  });
+  const abandon = useMutation({
+    mutationFn: () => abandonBatch(token, id, abandonReason),
+    onSuccess: () => {
+      toast.success("Batch abandoned");
+      invalidate();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (detail.isLoading) {
+    return <Card className="p-6 text-sm text-gray-500">Loading…</Card>;
+  }
+
+  if (detail.error) {
+    return (
+      <Card className="p-6 text-sm text-red-600 dark:text-red-400">
+        {detail.error.message}
+      </Card>
+    );
+  }
+
+  const { batch, payouts, entries } = detail.data!;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-50">
+            Batch breakdown
+          </h1>
+          <p className="mt-1 flex items-center gap-2 font-mono text-xs text-gray-500 dark:text-gray-400">
+            {batch.id}
+            <Badge className="bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-400">
+              {batch.mode}
+            </Badge>
+            <StatusBadge status={batch.status} />
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            onClick={() => execute.mutate()}
+            disabled={execute.isPending}
+          >
+            <Play className="h-4 w-4" />
+            {execute.isPending ? "…" : "Advance"}
+          </Button>
+          <SecondaryButton type="button" onClick={() => retry.mutate()} disabled={retry.isPending}>
+            <RotateCcw className="h-4 w-4" />
+            Retry failed
+          </SecondaryButton>
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card className="p-4">
+          <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Total amount</p>
+          <p className="mt-1 text-xl font-semibold tabular-nums text-gray-900 dark:text-gray-50">
+            {batch.totalAmount.toLocaleString()}{" "}
+            <span className="text-sm font-normal text-gray-500">{batch.currency}</span>
+          </p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Claimed entries</p>
+          <p className="mt-1 text-xl font-semibold tabular-nums text-gray-900 dark:text-gray-50">
+            {batch.claimedEntryCount}
+          </p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-xs uppercase text-gray-500 dark:text-gray-400">Payouts</p>
+          <p className="mt-1 text-xl font-semibold text-gray-900 dark:text-gray-50">
+            {payouts.length}
+          </p>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader title="Payouts" description="Per recipient leg and its on-chain reference." />
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-gray-200 text-xs uppercase text-gray-500 dark:border-gray-800 dark:text-gray-400">
+              <tr>
+                <th className="px-5 py-3">Label</th>
+                <th className="px-5 py-3">Target</th>
+                <th className="px-5 py-3 text-right">Amount</th>
+                <th className="px-5 py-3">Status</th>
+                <th className="px-5 py-3">On-chain ref</th>
+                <th className="px-5 py-3 text-right">Attempts</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+              {payouts.map((payout) => (
+                <tr key={payout.id}>
+                  <td className="px-5 py-3 font-medium text-gray-900 dark:text-gray-50">
+                    {payout.label}
+                  </td>
+                  <td className="px-5 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">
+                    {payout.externalAddress ?? payout.accountId ?? "—"}
+                  </td>
+                  <td className="px-5 py-3 text-right tabular-nums">
+                    {payout.amount.toLocaleString()}
+                  </td>
+                  <td className="px-5 py-3">
+                    <StatusBadge status={payout.status} />
+                  </td>
+                  <td className="px-5 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">
+                    {payout.onChainReference ?? "—"}
+                  </td>
+                  <td className="px-5 py-3 text-right tabular-nums">
+                    {payout.attempts}
+                    {payout.lastError && (
+                      <p className="text-xs text-red-500">{payout.lastError}</p>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+
+      <Card>
+        <CardHeader title={`Claimed ledger entries (${entries.length})`} />
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-gray-200 text-xs uppercase text-gray-500 dark:border-gray-800 dark:text-gray-400">
+              <tr>
+                <th className="px-5 py-3">Account</th>
+                <th className="px-5 py-3">Direction</th>
+                <th className="px-5 py-3 text-right">Amount</th>
+                <th className="px-5 py-3">Created</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+              {entries.map((entry) => (
+                <tr key={entry.id}>
+                  <td className="px-5 py-3 font-mono text-xs text-gray-700 dark:text-gray-300">
+                    {entry.accountId}
+                  </td>
+                  <td className="px-5 py-3">
+                    <Badge
+                      className={
+                        entry.direction === "CREDIT"
+                          ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400"
+                          : "bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-400"
+                      }
+                    >
+                      {entry.direction}
+                    </Badge>
+                  </td>
+                  <td className="px-5 py-3 text-right tabular-nums">
+                    {entry.amount.toLocaleString()}
+                  </td>
+                  <td className="px-5 py-3 text-gray-500 dark:text-gray-400">
+                    {new Date(entry.createdAt).toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+
+      <Card>
+        <CardHeader title="Abandon batch" description="Give up on failed payouts and release their unsettled claims." />
+        <form
+          className="flex max-w-xl items-end gap-3 p-5"
+          onSubmit={(e) => {
+            e.preventDefault();
+            abandon.mutate();
+          }}
+        >
+          <Field label="Reason (required)">
+            <input
+              className={inputClass}
+              value={abandonReason}
+              onChange={(e) => setAbandonReason(e.target.value)}
+              required
+            />
+          </Field>
+          <Button
+            type="submit"
+            className="bg-red-600 hover:bg-red-700"
+            disabled={abandon.isPending}
+          >
+            <Ban className="h-4 w-4" />
+            {abandon.isPending ? "…" : "Abandon"}
+          </Button>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/admin/settlements/page.tsx
+++ b/frontend/app/admin/settlements/page.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import Link from "next/link";
+import { Play } from "lucide-react";
+import type { SettlementBatchStatus } from "@/lib/admin-api";
+import { listBatches, runSettlement } from "@/lib/admin-api";
+import {
+  Card,
+  CardHeader,
+  Badge,
+  StatusBadge,
+  Button,
+} from "@/components/admin/ui";
+import { RequireAdmin, useAdminToken } from "@/components/admin/require-admin";
+
+const STATUSES: Array<{ value: SettlementBatchStatus | ""; label: string }> = [
+  { value: "", label: "All" },
+  { value: "PENDING", label: "Pending" },
+  { value: "IN_PROGRESS", label: "In progress" },
+  { value: "SETTLED", label: "Settled" },
+  { value: "PARTIALLY_SETTLED", label: "Partially settled" },
+  { value: "FAILED", label: "Failed" },
+  { value: "ABANDONED", label: "Abandoned" },
+];
+
+export default function SettlementsPage() {
+  const token = useAdminToken();
+
+  return (
+    <RequireAdmin>
+      <SettlementsInner token={token as string} />
+    </RequireAdmin>
+  );
+}
+
+function SettlementsInner({ token }: { token: string }) {
+  const queryClient = useQueryClient();
+  const status =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search).get("status") ?? ""
+      : "";
+
+  const batches = useQuery({
+    queryKey: ["settlement-batches", status],
+    queryFn: () =>
+      listBatches(token, (status || undefined) as SettlementBatchStatus | undefined),
+  });
+
+  const run = useMutation({
+    mutationFn: () => runSettlement(token),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["settlement-batches"] });
+      toast.success("Settlement pass completed");
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  const filterLink = (s: string) => (s ? `?status=${s}` : "/admin/settlements");
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-50">
+            Settlement pipeline
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Settlement batches — entries in, recipients out, per-leg on-chain
+            references.
+          </p>
+        </div>
+        <Button type="button" onClick={() => run.mutate()} disabled={run.isPending}>
+          <Play className="h-4 w-4" />
+          {run.isPending ? "Running…" : "Run settlement now"}
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {STATUSES.map(({ value, label }) => (
+          <FilterPill
+            key={value || "all"}
+            href={filterLink(value)}
+            active={status === value}
+            label={label}
+          />
+        ))}
+      </div>
+
+      <Card>
+        <CardHeader title={`${batches.data?.length ?? 0} batches`} />
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-gray-200 text-xs uppercase text-gray-500 dark:border-gray-800 dark:text-gray-400">
+              <tr>
+                <th className="px-5 py-3">Mode</th>
+                <th className="px-5 py-3">Status</th>
+                <th className="px-5 py-3">Currency</th>
+                <th className="px-5 py-3 text-right">Total</th>
+                <th className="px-5 py-3 text-right">Entries</th>
+                <th className="px-5 py-3">Period end</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+              {batches.data?.map((batch) => (
+                <tr
+                  key={batch.id}
+                  className="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                  onClick={() => {
+                    if (typeof window !== "undefined") {
+                      window.location.href = `/admin/settlements/${batch.id}`;
+                    }
+                  }}
+                >
+                  <td className="px-5 py-3">
+                    <Badge className="bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-400">
+                      {batch.mode}
+                    </Badge>
+                  </td>
+                  <td className="px-5 py-3">
+                    <StatusBadge status={batch.status} />
+                  </td>
+                  <td className="px-5 py-3 text-gray-700 dark:text-gray-300">
+                    {batch.currency}
+                  </td>
+                  <td className="px-5 py-3 text-right tabular-nums">
+                    {batch.totalAmount.toLocaleString()}
+                  </td>
+                  <td className="px-5 py-3 text-right tabular-nums">
+                    {batch.claimedEntryCount}
+                  </td>
+                  <td className="px-5 py-3 text-gray-500 dark:text-gray-400">
+                    {new Date(batch.periodEnd).toLocaleDateString()}
+                  </td>
+                </tr>
+              ))}
+              {!batches.isLoading && (batches.data?.length ?? 0) === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-5 py-8 text-center text-gray-400">
+                    No settlement batches.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function FilterPill({
+  href,
+  active,
+  label,
+}: {
+  href: string;
+  active: boolean;
+  label: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className={
+        active
+          ? "rounded-full bg-blue-600 px-3 py-1 text-xs font-medium text-white"
+          : "rounded-full border border-gray-300 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+      }
+    >
+      {label}
+    </Link>
+  );
+}

--- a/frontend/app/admin/splits/[id]/page.tsx
+++ b/frontend/app/admin/splits/[id]/page.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useState } from "react";
+import { Power, StopCircle } from "lucide-react";
+import {
+  listSplits,
+  setSplitActive,
+  previewSplit,
+} from "@/lib/admin-api";
+import {
+  Card,
+  CardHeader,
+  Badge,
+  StatusBadge,
+  Field,
+  Button,
+  inputClass,
+} from "@/components/admin/ui";
+import { RequireAdmin, useAdminToken } from "@/components/admin/require-admin";
+
+export default function SplitDetailPage() {
+  const token = useAdminToken();
+
+  return (
+    <RequireAdmin>
+      <SplitDetailInner token={token as string} />
+    </RequireAdmin>
+  );
+}
+
+function SplitDetailInner({ token }: { token: string }) {
+  const params = useParams<{ id: string }>();
+  const id = params.id;
+  const queryClient = useQueryClient();
+
+  const configs = useQuery({
+    queryKey: ["revenue-splits"],
+    queryFn: () => listSplits(token),
+  });
+  const split = configs.data?.find((c) => c.id === id);
+
+  const [amount, setAmount] = useState("10000");
+
+  const preview = useQuery({
+    queryKey: ["split-preview", id, amount],
+    queryFn: () => previewSplit(token, id, Number(amount) || 0),
+    enabled: !!split && Number(amount) > 0,
+  });
+
+  const toggleActive = useMutation({
+    mutationFn: () => setSplitActive(token, id, !split?.active),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["revenue-splits"] });
+      toast.success(`Config ${split?.active ? "deactivated" : "activated"}`);
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  if (configs.isLoading) {
+    return <Card className="p-6 text-sm text-gray-500">Loading…</Card>;
+  }
+
+  if (!split) {
+    return (
+      <Card className="p-6 text-sm text-red-600 dark:text-red-400">
+        Revenue split config not found.
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-50">
+            {split.name}
+          </h1>
+          {split.description && (
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              {split.description}
+            </p>
+          )}
+        </div>
+        <Button
+          type="button"
+          onClick={() => toggleActive.mutate()}
+          disabled={toggleActive.isPending}
+          className={split.active ? "bg-amber-600 hover:bg-amber-700" : ""}
+        >
+          {split.active ? (
+            <>
+              <StopCircle className="h-4 w-4" /> Deactivate
+            </>
+          ) : (
+            <>
+              <Power className="h-4 w-4" /> Activate
+            </>
+          )}
+        </Button>
+      </div>
+
+      <Card>
+        <CardHeader
+          title="Recipients"
+          action={
+            <StatusBadge status={split.active ? "ACTIVE" : "PENDING"} />
+          }
+        />
+        <div className="overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-gray-200 text-xs uppercase text-gray-500 dark:border-gray-800 dark:text-gray-400">
+              <tr>
+                <th className="px-5 py-3">Label</th>
+                <th className="px-5 py-3 text-right">Basis points</th>
+                <th className="px-5 py-3">Target</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+              {split.recipients.map((recipient) => (
+                <tr key={recipient.id}>
+                  <td className="px-5 py-3 font-medium text-gray-900 dark:text-gray-50">
+                    {recipient.label}
+                  </td>
+                  <td className="px-5 py-3 text-right tabular-nums">
+                    {recipient.basisPoints}
+                  </td>
+                  <td className="px-5 py-3 font-mono text-xs text-gray-600 dark:text-gray-400">
+                    {recipient.accountId ??
+                      recipient.externalAddress ??
+                      "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+
+      <Card>
+        <CardHeader title="Allocation preview" description="Posts nothing — shows the largest-remainder allocation." />
+        <form
+          className="flex max-w-md items-end gap-3 p-5"
+          onSubmit={(e) => e.preventDefault()}
+        >
+          <Field label="Amount (minor units)">
+            <input
+              className={inputClass}
+              type="number"
+              min={0}
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+            />
+          </Field>
+          <Button type="button" onClick={() => preview.refetch()} disabled={preview.isFetching}>
+            {preview.isFetching ? "…" : "Preview"}
+          </Button>
+        </form>
+        {preview.data && (
+          <div className="px-5 pb-5">
+            <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+              Allocated {preview.data.allocatedTotal.toLocaleString()} of{" "}
+              {preview.data.amount.toLocaleString()} — no remainder is dropped.
+            </p>
+            <ol className="space-y-2">
+              {preview.data.shares.map((share) => (
+                <li
+                  key={share.recipientId}
+                  className="flex items-center justify-between rounded-md border border-gray-200 px-4 py-2 text-sm dark:border-gray-800"
+                >
+                  <span className="text-gray-900 dark:text-gray-50">
+                    {share.label}
+                  </span>
+                  <span className="flex items-center gap-3 text-gray-600 dark:text-gray-400">
+                    <Badge className="bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                      {share.basisPoints} bps
+                    </Badge>
+                    <span className="tabular-nums">
+                      {share.amount.toLocaleString()}
+                    </span>
+                    {share.remainderUnits > 0 && (
+                      <span className="text-xs text-amber-600 dark:text-amber-400">
+                        +{share.remainderUnits} remainder
+                      </span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/admin/splits/page.tsx
+++ b/frontend/app/admin/splits/page.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useState } from "react";
+import Link from "next/link";
+import { Plus } from "lucide-react";
+import type { SplitRecipientInput } from "@/lib/admin-api";
+import { listSplits, createSplit } from "@/lib/admin-api";
+import {
+  Card,
+  CardHeader,
+  Badge,
+  Field,
+  Button,
+  SecondaryButton,
+  inputClass,
+} from "@/components/admin/ui";
+import { RequireAdmin, useAdminToken } from "@/components/admin/require-admin";
+
+export default function SplitsPage() {
+  const token = useAdminToken();
+
+  return (
+    <RequireAdmin>
+      <SplitsInner token={token as string} />
+    </RequireAdmin>
+  );
+}
+
+function SplitsInner({ token }: { token: string }) {
+  const [showCreate, setShowCreate] = useState(false);
+
+  const splits = useQuery({
+    queryKey: ["revenue-splits"],
+    queryFn: () => listSplits(token),
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-50">
+            Revenue splits
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Configs that apportion revenue. Recipient basis points must sum to
+            10000 and the total is shown per config.
+          </p>
+        </div>
+        <Button type="button" onClick={() => setShowCreate((v) => !v)}>
+          <Plus className="h-4 w-4" />
+          New split
+        </Button>
+      </div>
+
+      {showCreate && (
+        <CreateSplitForm token={token} onDone={() => setShowCreate(false)} />
+      )}
+
+      <Card>
+        <CardHeader title={`${splits.data?.length ?? 0} configs`} />
+        <div className="divide-y divide-gray-100 dark:divide-gray-800">
+          {splits.data?.map((split) => (
+            <Link
+              key={split.id}
+              href={`/admin/splits/${split.id}`}
+              className="flex items-center justify-between gap-4 px-5 py-4 hover:bg-gray-50 dark:hover:bg-gray-800/50"
+            >
+              <div className="min-w-0">
+                <p className="truncate font-medium text-gray-900 dark:text-gray-50">
+                  {split.name}
+                </p>
+                {split.description && (
+                  <p className="truncate text-sm text-gray-500 dark:text-gray-400">
+                    {split.description}
+                  </p>
+                )}
+              </div>
+              <div className="flex shrink-0 items-center gap-2 text-sm">
+                <Badge className="bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                  {split.totalBasisPoints} bps
+                </Badge>
+                <Badge
+                  className={
+                    split.active
+                      ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400"
+                      : "bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-400"
+                  }
+                >
+                  {split.active ? "Active" : "Inactive"}
+                </Badge>
+              </div>
+            </Link>
+          ))}
+          {!splits.isLoading && (splits.data?.length ?? 0) === 0 && (
+            <p className="px-5 py-8 text-center text-gray-400">
+              No revenue split configs yet.
+            </p>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function CreateSplitForm({ token, onDone }: { token: string; onDone: () => void }) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [recipients, setRecipients] = useState<SplitRecipientInput[]>([]);
+
+  const addRecipient = () =>
+    setRecipients((r) => [
+      ...r,
+      { label: "", basisPoints: 0, accountId: "", externalAddress: "" },
+    ]);
+
+  const updateRecipient = (idx: number, patch: Partial<SplitRecipientInput>) =>
+    setRecipients((r) =>
+      r.map((rec, i) => (i === idx ? { ...rec, ...patch } : rec)),
+    );
+
+  const removeRecipient = (idx: number) =>
+    setRecipients((r) => r.filter((_, i) => i !== idx));
+
+  const totalBps = recipients.reduce((sum, r) => sum + (r.basisPoints || 0), 0);
+  const sumError =
+    recipients.length > 0 && totalBps !== 10000;
+
+  const create = useMutation({
+    mutationFn: () =>
+      createSplit(token, {
+        name,
+        description: description || undefined,
+        recipients: recipients.map((r) => ({
+          label: r.label,
+          basisPoints: r.basisPoints,
+          ...(r.accountId ? { accountId: r.accountId } : {}),
+          ...(r.externalAddress ? { externalAddress: r.externalAddress } : {}),
+        })),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["revenue-splits"] });
+      toast.success("Split created");
+      onDone();
+    },
+    onError: (err) => toast.error(err.message),
+  });
+
+  return (
+    <Card>
+      <CardHeader title="Create a revenue split config" />
+      <form
+        className="space-y-4 p-5"
+        onSubmit={(e) => {
+          e.preventDefault();
+          create.mutate();
+        }}
+      >
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label="Name">
+            <input
+              className={inputClass}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </Field>
+          <Field label="Description">
+            <input
+              className={inputClass}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </Field>
+        </div>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="font-medium text-gray-900 dark:text-gray-50">
+              Recipients
+            </h3>
+            <SecondaryButton type="button" onClick={addRecipient} className="px-2.5 py-1 text-xs">
+              <Plus className="h-3.5 w-3.5" /> Add
+            </SecondaryButton>
+          </div>
+          {recipients.map((rec, idx) => (
+            <div key={idx} className="grid gap-2 rounded-md border border-gray-200 p-3 sm:grid-cols-12 dark:border-gray-800">
+              <input
+                className={`${inputClass} sm:col-span-3`}
+                placeholder="Label"
+                value={rec.label}
+                onChange={(e) => updateRecipient(idx, { label: e.target.value })}
+                required
+              />
+              <input
+                className={`${inputClass} sm:col-span-2`}
+                type="number"
+                min={1}
+                placeholder="Basis points"
+                value={rec.basisPoints || ""}
+                onChange={(e) =>
+                  updateRecipient(idx, { basisPoints: Number(e.target.value) })
+                }
+                required
+              />
+              <input
+                className={`${inputClass} sm:col-span-3`}
+                placeholder="Account ID (uuid)"
+                value={rec.accountId ?? ""}
+                onChange={(e) => updateRecipient(idx, { accountId: e.target.value })}
+              />
+              <input
+                className={`${inputClass} sm:col-span-3`}
+                placeholder="Or external address"
+                value={rec.externalAddress ?? ""}
+                onChange={(e) => updateRecipient(idx, { externalAddress: e.target.value })}
+              />
+              <button
+                type="button"
+                onClick={() => removeRecipient(idx)}
+                className="self-center justify-self-start text-sm text-red-600 hover:text-red-700 sm:col-span-1 dark:text-red-400"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+          {recipients.length > 0 && (
+            <p
+              className={
+                sumError
+                  ? "text-sm font-medium text-red-600 dark:text-red-400"
+                  : "text-sm text-gray-500 dark:text-gray-400"
+              }
+            >
+              Total: {totalBps} basis points (must be exactly 10000).
+            </p>
+          )}
+        </div>
+
+        <div className="flex gap-3">
+          <Button type="submit" disabled={create.isPending || sumError || recipients.length === 0}>
+            {create.isPending ? "Creating…" : "Create"}
+          </Button>
+          <SecondaryButton type="button" onClick={onDone}>
+            Cancel
+          </SecondaryButton>
+        </div>
+      </form>
+    </Card>
+  );
+}

--- a/frontend/components/admin/require-admin.tsx
+++ b/frontend/components/admin/require-admin.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import Cookies from "js-cookie";
+import { ShieldAlert } from "lucide-react";
+
+export function useAdminToken(): string | null {
+  return Cookies.get("accessToken") ?? null;
+}
+
+export function RequireAdmin({ children }: { children: React.ReactNode }) {
+  const token = useAdminToken();
+  if (!token) {
+    return (
+      <div className="flex max-w-md flex-col items-center gap-3 rounded-lg border border-dashed border-gray-300 px-6 py-12 text-center dark:border-gray-700">
+        <ShieldAlert className="h-8 w-8 text-gray-400" />
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-50">
+          Admin sign-in required
+        </h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          These pages call ADMIN-gated API endpoints. Sign in with an admin
+          account so an <code className="rounded bg-gray-100 px-1 py-0.5 text-xs dark:bg-gray-800">accessToken</code> cookie is present.
+        </p>
+      </div>
+    );
+  }
+  return <>{children}</>;
+}

--- a/frontend/components/admin/ui.tsx
+++ b/frontend/components/admin/ui.tsx
@@ -1,0 +1,140 @@
+import { cn } from "@/lib/utils";
+import { type ReactNode } from "react";
+
+export function Card({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function CardHeader({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4 border-b border-gray-200 px-5 py-4 dark:border-gray-800">
+      <div>
+        <h2 className="text-base font-semibold text-gray-900 dark:text-gray-50">
+          {title}
+        </h2>
+        {description ? (
+          <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+export function Badge({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function StatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    SETTLED: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400",
+    CONFIRMED: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400",
+    IN_PROGRESS: "bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-400",
+    PENDING: "bg-amber-50 text-amber-700 dark:bg-amber-950 dark:text-amber-400",
+    PARTIALLY_SETTLED: "bg-purple-50 text-purple-700 dark:bg-purple-950 dark:text-purple-400",
+    FAILED: "bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-400",
+    ABANDONED: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+    ACTIVE: "bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400",
+  };
+  return (
+    <Badge className={styles[status] ?? "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300"}>
+      {status}
+    </Badge>
+  );
+}
+
+export function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <label className="block text-sm">
+      <span className="mb-1 block font-medium text-gray-700 dark:text-gray-300">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+export const inputClass =
+  "w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500/30 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-50";
+
+export function Button({
+  className,
+  children,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={cn(
+        "inline-flex items-center justify-center gap-1.5 rounded-md bg-blue-600 px-3.5 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500/40 disabled:opacity-50 disabled:cursor-not-allowed",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function SecondaryButton({
+  className,
+  children,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={cn(
+        "inline-flex items-center justify-center gap-1.5 rounded-md border border-gray-300 bg-white px-3.5 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500/40 disabled:opacity-50 disabled:cursor-not-allowed dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200 dark:hover:bg-gray-800",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/lib/admin-api.ts
+++ b/frontend/lib/admin-api.ts
@@ -1,0 +1,341 @@
+"use client";
+
+export type LedgerAccountKind =
+  | "USER"
+  | "TREASURY"
+  | "REVENUE"
+  | "PLATFORM_FEE"
+  | "HUB_OPERATOR"
+  | "REFERRAL";
+
+export type SettlementBatchStatus =
+  | "PENDING"
+  | "IN_PROGRESS"
+  | "SETTLED"
+  | "PARTIALLY_SETTLED"
+  | "FAILED"
+  | "ABANDONED";
+
+export type SettlementBatchMode = "DISTRIBUTION" | "NET_PAYABLE";
+
+export interface LedgerAccount {
+  id: string;
+  kind: LedgerAccountKind;
+  ownerId: string | null;
+  currency: string;
+  balance: number;
+  overdraftLimit: number;
+  externalPayoutAddress: string | null;
+  frozen: boolean;
+  label: string | null;
+}
+
+export interface CreateLedgerAccountInput {
+  kind: LedgerAccountKind;
+  ownerId?: string;
+  currency?: string;
+  overdraftLimit?: number;
+  externalPayoutAddress?: string;
+  label?: string;
+}
+
+export interface UpdateLedgerAccountInput {
+  overdraftLimit?: number;
+  externalPayoutAddress?: string;
+  frozen?: boolean;
+  label?: string;
+}
+
+export interface LedgerIntegrityReport {
+  accountsChecked: number;
+  balanceDrift: Array<{
+    accountId: string;
+    materialized: number;
+    derived: number;
+  }>;
+  unbalancedTransactions: Array<{
+    transactionId: string;
+    debits: number;
+    credits: number;
+  }>;
+}
+
+export interface RevenueSplitRecipient {
+  id: string;
+  label: string;
+  basisPoints: number;
+  accountId: string | null;
+  externalAddress: string | null;
+  sortOrder: number;
+}
+
+export interface RevenueSplitConfig {
+  id: string;
+  name: string;
+  description: string | null;
+  active: boolean;
+  recipients: RevenueSplitRecipient[];
+  totalBasisPoints: number;
+  createdAt: string;
+}
+
+export interface SplitRecipientInput {
+  label: string;
+  basisPoints: number;
+  accountId?: string;
+  externalAddress?: string;
+  sortOrder?: number;
+}
+
+export interface SplitPreview {
+  amount: number;
+  allocatedTotal: number;
+  shares: Array<{
+    recipientId: string;
+    label: string;
+    basisPoints: number;
+    amount: number;
+    remainderUnits: number;
+  }>;
+}
+
+export interface SettlementBatch {
+  id: string;
+  status: SettlementBatchStatus;
+  currency: string;
+  mode: SettlementBatchMode;
+  splitConfigId: string | null;
+  periodEnd: string;
+  totalAmount: number;
+  claimedEntryCount: number;
+  notes: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SettlementPayout {
+  id: string;
+  label: string;
+  accountId: string | null;
+  externalAddress: string | null;
+  basisPoints: number | null;
+  amount: number;
+  currency: string;
+  status: string;
+  idempotencyKey: string;
+  onChainReference: string | null;
+  ledgerTransactionId: string | null;
+  attempts: number;
+  lastError: string | null;
+  confirmedAt: string | null;
+}
+
+export interface LedgerEntry {
+  id: string;
+  transactionId: string;
+  accountId: string;
+  direction: string;
+  amount: number;
+  currency: string;
+  settlementBatchId: string | null;
+  settledAt: string | null;
+  createdAt: string;
+}
+
+export interface SettlementBatchBreakdown {
+  batch: SettlementBatch;
+  payouts: SettlementPayout[];
+  entries: LedgerEntry[];
+  onChainReferences: Array<{ payoutId: string; reference: string }>;
+}
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+async function adminFetch<T>(
+  path: string,
+  accessToken: string,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+      ...init?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    throw new Error(
+      body?.message ?? `Admin request failed (${response.status})`,
+    );
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return response.json() as Promise<T>;
+}
+
+// ── ledger accounts (FE-111) ─────────────────────────────────────────────
+
+export function listAccounts(
+  accessToken: string,
+  currency?: string,
+): Promise<LedgerAccount[]> {
+  const query = currency ? `?currency=${encodeURIComponent(currency)}` : "";
+  return adminFetch<LedgerAccount[]>(`/credits/admin/accounts${query}`, accessToken);
+}
+
+export function createAccount(
+  accessToken: string,
+  input: CreateLedgerAccountInput,
+): Promise<LedgerAccount> {
+  return adminFetch<LedgerAccount>("/credits/admin/accounts", accessToken, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export function updateAccount(
+  accessToken: string,
+  id: string,
+  input: UpdateLedgerAccountInput,
+): Promise<LedgerAccount> {
+  return adminFetch<LedgerAccount>(`/credits/admin/accounts/${id}`, accessToken, {
+    method: "PATCH",
+    body: JSON.stringify(input),
+  });
+}
+
+// ── ledger integrity (FE-112) ────────────────────────────────────────────
+
+export function checkIntegrity(
+  accessToken: string,
+  currency?: string,
+): Promise<LedgerIntegrityReport> {
+  const query = currency ? `?currency=${encodeURIComponent(currency)}` : "";
+  return adminFetch<LedgerIntegrityReport>(
+    `/credits/admin/ledger/integrity${query}`,
+    accessToken,
+  );
+}
+
+// ── revenue splits (FE-113) ──────────────────────────────────────────────
+
+export function listSplits(accessToken: string): Promise<RevenueSplitConfig[]> {
+  return adminFetch<RevenueSplitConfig[]>("/credits/admin/splits", accessToken);
+}
+
+export function createSplit(
+  accessToken: string,
+  input: {
+    name: string;
+    description?: string;
+    recipients: SplitRecipientInput[];
+  },
+): Promise<RevenueSplitConfig> {
+  return adminFetch<RevenueSplitConfig>("/credits/admin/splits", accessToken, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export function setSplitActive(
+  accessToken: string,
+  id: string,
+  active: boolean,
+): Promise<RevenueSplitConfig> {
+  return adminFetch<RevenueSplitConfig>(
+    `/credits/admin/splits/${id}/active`,
+    accessToken,
+    { method: "POST", body: JSON.stringify({ active }) },
+  );
+}
+
+export function replaceSplitRecipients(
+  accessToken: string,
+  id: string,
+  recipients: SplitRecipientInput[],
+): Promise<RevenueSplitConfig> {
+  return adminFetch<RevenueSplitConfig>(
+    `/credits/admin/splits/${id}/recipients`,
+    accessToken,
+    { method: "PUT", body: JSON.stringify({ recipients }) },
+  );
+}
+
+export function previewSplit(
+  accessToken: string,
+  configId: string,
+  amount: number,
+): Promise<SplitPreview> {
+  return adminFetch<SplitPreview>("/credits/admin/splits/preview", accessToken, {
+    method: "POST",
+    body: JSON.stringify({ configId, amount }),
+  });
+}
+
+// ── settlement (FE-114) ──────────────────────────────────────────────────
+
+export function runSettlement(accessToken: string): Promise<unknown> {
+  return adminFetch<unknown>("/credits/admin/settlement/run", accessToken, {
+    method: "POST",
+  });
+}
+
+export function listBatches(
+  accessToken: string,
+  status?: SettlementBatchStatus,
+): Promise<SettlementBatch[]> {
+  const query = status ? `?status=${encodeURIComponent(status)}` : "";
+  return adminFetch<SettlementBatch[]>(
+    `/credits/admin/settlement/batches${query}`,
+    accessToken,
+  );
+}
+
+export function getBatchBreakdown(
+  accessToken: string,
+  id: string,
+): Promise<SettlementBatchBreakdown> {
+  return adminFetch<SettlementBatchBreakdown>(
+    `/credits/admin/settlement/batches/${id}`,
+    accessToken,
+  );
+}
+
+export function executeBatch(
+  accessToken: string,
+  id: string,
+): Promise<SettlementBatch> {
+  return adminFetch<SettlementBatch>(
+    `/credits/admin/settlement/batches/${id}/execute`,
+    accessToken,
+    { method: "POST" },
+  );
+}
+
+export function retryBatch(
+  accessToken: string,
+  id: string,
+): Promise<SettlementBatch> {
+  return adminFetch<SettlementBatch>(
+    `/credits/admin/settlement/batches/${id}/retry`,
+    accessToken,
+    { method: "POST" },
+  );
+}
+
+export function abandonBatch(
+  accessToken: string,
+  id: string,
+  reason: string,
+): Promise<SettlementBatch> {
+  return adminFetch<SettlementBatch>(
+    `/credits/admin/settlement/batches/${id}/abandon`,
+    accessToken,
+    { method: "POST", body: JSON.stringify({ reason }) },
+  );
+}

--- a/frontend/lib/providers.tsx
+++ b/frontend/lib/providers.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Toaster } from "sonner";
+import { useState } from "react";
+
+export function AdminProviders({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 30_000,
+            retry: 1,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <Toaster richColors position="top-right" />
+    </QueryClientProvider>
+  );
+}

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary

Frontend admin surface (UI) for the credit ledger, ledger-integrity check, revenue-split configs, and the settlement pipeline — calling the ADMIN-gated `credits/admin/*` API.

### #1640 (FE-111) — Ledger account management UI
- `app/admin/accounts` — list all ledger accounts with balances, freeze/unfreeze, and an idempotent "create account" form (kind, owner, currency, overdraft, payout address, label).

### #1641 (FE-112) — Ledger integrity check UI
- `app/admin/integrity` — runs `GET /credits/admin/ledger/integrity`, shows a healthy/drift summary plus tables for account balance drift and unbalanced transactions.

### #1642 (FE-113) — Revenue split config UI
- `app/admin/splits` — list and create configs (with recipient editor that validates basis points total to 10000).
- `app/admin/splits/[id]` — recipients table, activate/deactivate, and a non-mutating allocation preview showing the largest-remainder split.

### #1643 (FE-114) — Settlement pipeline UI
- `app/admin/settlements` — list batches with status filters and "run settlement now".
- `app/admin/settlements/[id]` — full breakdown (payouts + claimed ledger entries + per-leg refs) with execute advance, retry-failed, and abandon-with-reason actions.

## Supporting
- `lib/admin-api.ts` — typed client for all `credits/admin/*` endpoints (Bearer token from the `accessToken` cookie).
- `lib/providers.tsx` (QueryClientProvider + sonner Toaster), `components/admin/*` (shared UI kit + sign-in guard), `app/admin/layout.tsx` (section navigation).

## Verification
- `npx tsc --noEmit` ✓
- `npx eslint` on all new files ✓ (0 errors, 0 warnings)

Closes #1640, 
Closes #1641, 
Closes #1642, 
Closes #1643
