### PR TITLE
Contracts: require_auth CI audit, Makefile, security docs (CT-68, CT-69, CT-70, CT-72)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+## Contracts checklist
+
+If this PR touches anything under `contracts/`, confirm it against the
+[pre-deployment security checklist](../contracts/SECURITY.md) before
+requesting review:
+
+- [ ] `make audit` (CT-72 require_auth() coverage) passes.
+- [ ] Every amount-handling path uses checked arithmetic (CT-73) — no raw
+      `+`/`-` on amounts.
+- [ ] Not applicable — this PR does not touch `contracts/`.
+
+## Test plan
+
+<!-- How did you verify this change? -->

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -154,3 +154,17 @@ jobs:
             frontend/playwright-report/
             frontend/test-results/
           retention-days: 7
+
+  # ─────────────────────────────────────────────
+  # CONTRACTS — require_auth coverage audit (CT-72)
+  # ─────────────────────────────────────────────
+  contracts-auth-audit:
+    name: Contracts — require_auth coverage (CT-72)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Audit state-changing entrypoints for require_auth()
+        run: bash scripts/audit_require_auth.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# ManageHub — Soroban contracts workspace
+#
+# Unified build/test/deploy/clean targets spanning every crate in
+# contracts/ (CT-70). Run `make help` for the full target list.
+
+CONTRACTS_DIR := contracts
+NETWORK ?= testnet
+
+.PHONY: help build test deploy clean audit
+
+help:
+	@echo "Targets:"
+	@echo "  make build   - cargo build --release (wasm32-unknown-unknown) for the contracts workspace"
+	@echo "  make test    - cargo test for the contracts workspace"
+	@echo "  make deploy  - build then 'soroban contract deploy' every crate in the workspace"
+	@echo "                 (override the target network with NETWORK=<name>, default: testnet)"
+	@echo "  make clean   - cargo clean for the contracts workspace"
+	@echo "  make audit   - run the CT-72 require_auth() coverage audit"
+
+build:
+	cd $(CONTRACTS_DIR) && cargo build --release --target wasm32-unknown-unknown
+
+test:
+	cd $(CONTRACTS_DIR) && cargo test
+
+deploy: build
+	@for crate in $(CONTRACTS_DIR)/*/; do \
+		name=$$(basename $$crate); \
+		wasm=$(CONTRACTS_DIR)/target/wasm32-unknown-unknown/release/$$name.wasm; \
+		if [ -f "$$wasm" ]; then \
+			echo "Deploying $$name to $(NETWORK)..."; \
+			soroban contract deploy --wasm "$$wasm" --network $(NETWORK); \
+		fi; \
+	done
+
+clean:
+	cd $(CONTRACTS_DIR) && cargo clean
+
+audit:
+	bash scripts/audit_require_auth.sh

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -72,3 +72,15 @@ this pattern. See [`payment_escrow/src/lib.rs`](payment_escrow/src/lib.rs).
 
 Additional crates (e.g. `resource_credits`, `staking_rewards`) should be added
 as workspace members in [`Cargo.toml`](Cargo.toml) as they are developed.
+
+## Tooling
+
+- `make build` / `make test` / `make deploy` / `make clean` — see the root
+  [`Makefile`](../Makefile) (CT-70).
+- `make audit` — CI-enforced authorization audit; see
+  [`scripts/audit_require_auth.sh`](../scripts/audit_require_auth.sh) (CT-72).
+
+## Security
+
+- [`SECURITY.md`](SECURITY.md) — trust model and pre-deployment checklist (CT-68).
+- [`UPGRADE.md`](UPGRADE.md) — contract upgrade/migration path (CT-69).

--- a/contracts/SECURITY.md
+++ b/contracts/SECURITY.md
@@ -1,0 +1,81 @@
+# Contracts Workspace — Threat Model & Pre-Deployment Checklist (CT-68)
+
+This document covers the Soroban contracts under `contracts/`. It must be
+reviewed and kept current before any contract in this workspace is deployed
+to Stellar mainnet.
+
+## Trust model
+
+The backend integration (see [`README.md`](README.md)) holds a single
+treasury/operator secret key, `STELLAR_SECRET_KEY` (bound via
+`soroban-config.ts`), used to submit `release` and `refund` transactions.
+
+- **Who is trusted:** whoever holds `STELLAR_SECRET_KEY`. That key is a
+  single point of trust for triggering escrow resolution transactions from
+  the backend's side.
+- **What each role can do today:**
+  - **Payer** — creates an escrow (`create`, requires the payer's own
+    `require_auth()`) and authorizes releasing its funds to the beneficiary
+    (`release`, requires the payer's `require_auth()`).
+  - **Beneficiary** — authorizes giving up their claim and refunding the
+    payer (`refund`, requires the beneficiary's `require_auth()`).
+  - **Backend/treasury key** — submits the transaction envelope for
+    `release`/`refund` calls, but does **not** currently hold any special
+    on-chain authorization of its own; the contract has no admin/operator
+    Address concept yet. The backend must collect a valid `require_auth()`
+    signature from the payer or beneficiary out-of-band before it can
+    successfully submit these calls.
+- **Blast radius of a compromised `STELLAR_SECRET_KEY`:** since the
+  contract does not (yet) grant this key any special authority, a
+  compromise of this key alone cannot move escrowed funds — the attacker
+  would still need a valid payer/beneficiary authorization. However, it
+  could be used to censor (withhold submission of) legitimate
+  release/refund transactions, or to submit malformed transactions that
+  the contract itself is responsible for rejecting.
+- **Open question:** whether a future version should introduce an
+  admin/arbiter role (e.g. for disputed refunds) is intentionally left
+  undecided here — see [CT-69's upgrade doc](UPGRADE.md) for how such a
+  change would be rolled out safely.
+
+## Assets at risk per contract
+
+| Contract         | Asset at risk                          | Attack surface                                                                 |
+| ----------------- | --------------------------------------- | -------------------------------------------------------------------------------- |
+| `payment_escrow`  | Escrowed `amount` per `Escrow` record  | `create`, `release`, `refund` — every state-changing entrypoint (see CT-72)     |
+
+### Entrypoint-by-entrypoint attack surface (`payment_escrow`)
+
+- **`create`** — requires `payer.require_auth()`. Rejects non-positive
+  amounts and duplicate `escrow_id`s. Risk: a colliding/predictable
+  `escrow_id` could let an attacker front-run `create` for an ID the
+  backend intended to use next — mitigated by the backend deriving IDs as
+  a SHA-256 hash of an internal UUID (see `README.md`), which is
+  infeasible to predict or collide.
+- **`release`** — requires `escrow.payer.require_auth()`. Rejects if the
+  escrow is not `Locked`. Risk: none beyond payer key compromise.
+- **`refund`** — requires `escrow.beneficiary.require_auth()`. Rejects if
+  the escrow is not `Locked`. Risk: none beyond beneficiary key
+  compromise.
+- **`get_status`** — read-only, no authorization required by design
+  (informational only, cannot mutate state).
+
+## Pre-deployment checklist
+
+Before deploying any contract in this workspace to mainnet:
+
+- [ ] **Authorization audit (CT-72)** — `make audit` (or
+      `bash scripts/audit_require_auth.sh`) passes with no findings, and
+      CI's `contracts-auth-audit` job is green on the deploy commit.
+- [ ] **Arithmetic overflow audit (CT-73)** — every amount-handling path
+      uses `checked_add`/`checked_sub` (see `payment_escrow/src/lib.rs`'s
+      `checked_amount_add`/`checked_amount_sub` helpers); no raw `+`/`-`
+      on amounts anywhere in the workspace.
+- [ ] This trust model has been reviewed by at least one other
+      contributor and any open questions above have been resolved or
+      explicitly accepted as known risk.
+- [ ] The upgrade path (see [`UPGRADE.md`](UPGRADE.md)) is in place if
+      the deployment is expected to require future fixes.
+
+This checklist is also linked from the PR template
+(`.github/PULL_REQUEST_TEMPLATE.md`) so contract changes are reviewed
+against it before merge.

--- a/contracts/UPGRADE.md
+++ b/contracts/UPGRADE.md
@@ -1,0 +1,53 @@
+# Contract Upgrade / Migration Path (CT-69)
+
+## Chosen mechanism
+
+Soroban's native contract-upgrade support (`env.deployer().update_current_contract_wasm(new_wasm_hash)`)
+is the chosen upgrade mechanism, rather than a separate proxy contract:
+
+- It keeps the contract's storage and Address (and therefore every
+  existing `Escrow` record and every StrKey the backend already has
+  configured as `STELLAR_ESCROW_CONTRACT_ID`) unchanged across an
+  upgrade — a proxy pattern would either require redeploying storage at a
+  new address or adding an extra indirection hop the backend integration
+  doesn't need.
+- It is the officially supported upgrade path for Soroban contracts and
+  needs no additional infrastructure.
+
+## Required scaffolding (not yet implemented)
+
+The current `payment_escrow` scaffold has no admin/operator concept and
+therefore **cannot yet perform an upgrade safely** — there is no
+authorization gate on who may call `update_current_contract_wasm`. Before
+this contract is deployed anywhere upgrades might be needed, it must gain:
+
+1. An `admin: Address` stored at `initialize()` time (a new one-time entrypoint).
+2. An `upgrade(new_wasm_hash: BytesN<32>)` entrypoint that:
+   - calls `admin.require_auth()` (subject to the same CT-72 audit as every
+     other state-changing entrypoint),
+   - then calls `env.deployer().update_current_contract_wasm(new_wasm_hash)`.
+
+This keeps the upgrade path itself in scope for the CT-72 authorization
+audit and the CT-68 threat model — an unauthenticated upgrade entrypoint
+would be a critical vulnerability.
+
+## Verifying state survives an upgrade
+
+Once the `admin`/`upgrade` scaffolding above lands, the upgrade path must
+be proven safe with a test that:
+
+1. Deploys the current contract version and creates one or more `Escrow`
+   records via `create`.
+2. Invokes `upgrade` with a build of the *next* contract version's WASM.
+3. Re-reads the same `escrow_id`s via `get_status` (and/or a direct
+   storage read) on the upgraded contract and asserts every record is
+   byte-for-byte unchanged — in particular that `EscrowState`,
+   `payer`, `beneficiary`, and `amount` all survive.
+4. Exercises `release`/`refund` post-upgrade to confirm the upgraded code
+   can still resolve escrows created under the old version.
+
+This test is tracked as a follow-up (not included in this PR, which
+scopes to documenting the mechanism per CT-69's acceptance criteria) and
+must exist and pass before any contract in this workspace that uses the
+upgrade entrypoint is deployed to mainnet — see the checklist in
+[`SECURITY.md`](SECURITY.md).

--- a/contracts/payment_escrow/src/lib.rs
+++ b/contracts/payment_escrow/src/lib.rs
@@ -77,13 +77,16 @@ impl PaymentEscrowContract {
         Ok(())
     }
 
-    /// Release escrowed funds to the beneficiary.
+    /// Release escrowed funds to the beneficiary. Only the payer — the
+    /// party whose funds are locked — may authorize a release (CT-72).
     pub fn release(env: Env, escrow_id: BytesN<32>) -> Result<(), Error> {
         let mut escrow: Escrow = env
             .storage()
             .persistent()
             .get(&DataKey::Escrow(escrow_id.clone()))
             .ok_or(Error::NotFound)?;
+
+        escrow.payer.require_auth();
 
         if escrow.state != EscrowState::Locked {
             return Err(Error::AlreadyResolved);
@@ -94,13 +97,16 @@ impl PaymentEscrowContract {
         Ok(())
     }
 
-    /// Refund escrowed funds back to the payer.
+    /// Refund escrowed funds back to the payer. Only the beneficiary — the
+    /// party giving up their claim — may authorize a refund (CT-72).
     pub fn refund(env: Env, escrow_id: BytesN<32>) -> Result<(), Error> {
         let mut escrow: Escrow = env
             .storage()
             .persistent()
             .get(&DataKey::Escrow(escrow_id.clone()))
             .ok_or(Error::NotFound)?;
+
+        escrow.beneficiary.require_auth();
 
         if escrow.state != EscrowState::Locked {
             return Err(Error::AlreadyResolved);

--- a/scripts/audit_require_auth.sh
+++ b/scripts/audit_require_auth.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# CT-72 — authorization audit.
+#
+# Fails if any `pub fn` in a contracts/*/src/*.rs file writes to contract
+# storage (persistent/instance/temporary .set/.remove/.extend_ttl) without
+# also calling require_auth() somewhere in its body.
+#
+# A function that intentionally skips the check (e.g. a permissionless
+# public entrypoint) can opt out with a `// AUTH-EXEMPT: <reason>` comment
+# on the line directly above its `pub fn`.
+#
+# Usage: scripts/audit_require_auth.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+while IFS= read -r -d '' file; do
+  if ! awk -v file="$file" '
+    /\/\/[ \t]*AUTH-EXEMPT:/ { exempt = 1; next }
+    /^[ \t]*pub fn / {
+      fn_line = $0
+      in_fn = 1
+      depth = 0
+      started = 0
+      has_write = 0
+      has_auth = 0
+    }
+    in_fn {
+      if ($0 ~ /\.(persistent|instance|temporary)\(\)\.(set|remove|extend_ttl)\(/) has_write = 1
+      if ($0 ~ /require_auth\(/) has_auth = 1
+
+      n_open = gsub(/\{/, "{")
+      depth += n_open
+      n_close = gsub(/\}/, "}")
+      depth -= n_close
+      if (depth > 0) started = 1
+
+      if (started && depth <= 0) {
+        in_fn = 0
+        if (has_write && !has_auth && !exempt) {
+          print file ": " fn_line
+          bad = 1
+        }
+        exempt = 0
+      }
+    }
+    END { exit bad ? 1 : 0 }
+  ' "$file"; then
+    fail=1
+  fi
+done < <(find contracts -name "*.rs" -not -path "*/target/*" -print0)
+
+if [ "$fail" -ne 0 ]; then
+  echo ""
+  echo "::error::One or more state-changing entrypoints are missing a require_auth() call (see above)."
+  echo "Add the missing check, or mark a deliberately permissionless entrypoint with a"
+  echo "'// AUTH-EXEMPT: <reason>' comment on the line above its pub fn."
+  exit 1
+fi
+
+echo "✓ All state-changing contract entrypoints have require_auth() coverage."


### PR DESCRIPTION
## Summary

Closes four issues assigned to me.

### Closes #1686 (CT-72 — Authorization audit)
`scripts/audit_require_auth.sh` statically scans every `pub fn` under `contracts/*/src` and flags any that write to contract storage without a `require_auth()` call anywhere in the body (a `// AUTH-EXEMPT: <reason>` comment above a `pub fn` opts it out deliberately). Wired into CI as a new `contracts-auth-audit` job.

Running it against the current workspace found a real gap: **`release()` and `refund()` on `payment_escrow` mutated escrow state with no authorization check at all** — anyone could call either on any `escrow_id`. Fixed:
- `release()` now requires `escrow.payer.require_auth()` — the payer approves releasing their own locked funds to the beneficiary.
- `refund()` now requires `escrow.beneficiary.require_auth()` — the beneficiary approves giving up their claim.

This is symmetric with the `payer.require_auth()` that `create()` already had.

### Closes #1685 (CT-70 — Makefile)
Root `Makefile` with `build`/`test`/`deploy`/`clean` targets spanning the contracts workspace, plus an `audit` target for CT-72's script. `deploy` iterates every workspace member's built `.wasm` and deploys each via `soroban contract deploy` (network overridable via `NETWORK=`).

### Closes #1684 (CT-69 — Upgrade/migration path)
`contracts/UPGRADE.md` documents the chosen mechanism (Soroban's native `update_current_contract_wasm`, over a proxy pattern, since it preserves the contract's existing Address and storage) and the admin/upgrade scaffolding it requires — which `payment_escrow` doesn't have yet (no admin/operator concept at all today). Also specifies exactly what a state-preservation test must cover once that scaffolding lands. No upgrade entrypoint exists yet, so there's nothing to test in this PR; tracked as a documented follow-up.

### Closes #1683 (CT-68 — Threat model & pre-deployment checklist)
`contracts/SECURITY.md` documents the trust model (who holds `STELLAR_SECRET_KEY`, what each role can/can't do, blast radius of a compromised treasury key), the attack surface of every `payment_escrow` entrypoint, and a pre-deployment checklist referencing CT-72 and CT-73. Linked from a new `.github/PULL_REQUEST_TEMPLATE.md` so future contract changes get reviewed against it.

## Notes

- Per instruction, this PR is scoped to minimal code with no new tests — the existing `#[cfg(test)]` suite in `payment_escrow` is untouched, and CT-69's state-preservation test is explicitly deferred (documented in `UPGRADE.md`) since it depends on scaffolding (an admin/upgrade entrypoint) that doesn't exist yet.
- The `audit_require_auth.sh` script uses POSIX character classes (`[ \t]*` / `[[:space:]]`-equivalent), not `\s`, since `\s` isn't portable across `awk` implementations (notably not supported by the BWK/mawk-family `awk` that both macOS and Ubuntu CI runners default to) — verified by round-tripping the script against the pre-fix `lib.rs` (correctly fails) and the fixed version (correctly passes).