### PR TITLE
feat(contracts): scaffold revenue-distribution crate (CT-56)

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "payment_escrow",
+    "revenue_distribution",
 ]
 
 [workspace.dependencies]

--- a/contracts/revenue_distribution/Cargo.toml
+++ b/contracts/revenue_distribution/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "revenue_distribution"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/revenue_distribution/src/lib.rs
+++ b/contracts/revenue_distribution/src/lib.rs
@@ -1,0 +1,58 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, contracttype, contracterror, vec, Env, Address, Vec};
+
+/// Total basis points a valid configuration must sum to (100.00%).
+pub const TOTAL_BASIS_POINTS: u32 = 10_000;
+
+/// A single recipient and their share in basis points.
+/// Mirrors the off-chain `RevenueSplitRecipientDto`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Recipient {
+    pub address: Address,
+    pub basis_points: u32,
+}
+
+/// The stored distribution configuration.
+/// Mirrors the off-chain `RevenueSplitConfig`.
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RevenueConfig {
+    pub recipients: Vec<Recipient>,
+    pub admin: Address,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Config,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    /// basis_points do not sum to exactly 10 000.
+    InvalidBasisPoints = 1,
+    /// No configuration has been set.
+    NotConfigured = 2,
+    /// Caller is not the admin.
+    Unauthorized = 3,
+    /// Recipient list is empty.
+    EmptyRecipients = 4,
+    /// Arithmetic overflow.
+    ArithmeticOverflow = 5,
+}
+
+#[contract]
+pub struct RevenueDistributionContract;
+
+#[contractimpl]
+impl RevenueDistributionContract {
+    /// Return the current distribution configuration, if any.
+    pub fn get_config(env: Env) -> Result<RevenueConfig, Error> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .ok_or(Error::NotConfigured)
+    }
+}


### PR DESCRIPTION
## Summary

Scaffolds the `contracts/revenue_distribution` crate as the on-chain analog for the off-chain basis-points revenue-split model in `credits/revenue-split.service.ts`.

## Changes

- Add `contracts/revenue_distribution/Cargo.toml` depending on `soroban-sdk` via workspace
- Add `contracts/revenue_distribution/src/lib.rs` with storage schema:
  - `Recipient { address: Address, basis_points: u32 }` mirrors `RevenueSplitRecipientDto`
  - `RevenueConfig { recipients: Vec<Recipient>, admin: Address }` mirrors `RevenueSplitConfig`
  - `TOTAL_BASIS_POINTS = 10_000` constant matches the off-chain validation rule
- Register the new crate in the workspace `Cargo.toml`

## Contracts checklist

- [x] Not applicable — this PR does not touch existing contract logic, only scaffolds new types.

## Test plan

Crate compiles as part of the workspace. Logic implementation follows in CT-57 and CT-58.

Closes #1671
Closes #1672
Closes #1673
Closes #1674 
Closes #1667
