### PR TITLE
Added unit tests for JwtAuthGuard and RolesGuard

### DIFF
--- a/backend/src/auth/guards/jwt-auth.guard.spec.ts
+++ b/backend/src/auth/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,134 @@
+import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { JwtAuthGuard } from './jwt-auth.guard';
+import { UserRole } from '../enums/user-role.enum';
+
+class TokenExpiredError extends Error {
+  constructor() {
+    super('jwt expired');
+    this.name = 'TokenExpiredError';
+  }
+}
+
+class JsonWebTokenError extends Error {
+  constructor(message = 'invalid signature') {
+    super(message);
+    this.name = 'JsonWebTokenError';
+  }
+}
+
+describe('JwtAuthGuard', () => {
+  const verifier = {
+    verify: jest.fn(),
+  };
+  const guard = new JwtAuthGuard(verifier as any);
+
+  const createContext = (request: Record<string, any>): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects a request with no authorization header or cookie', async () => {
+    const context = createContext({ headers: {}, cookies: {} });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      new UnauthorizedException('Missing bearer token'),
+    );
+    expect(verifier.verify).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed authorization header without the Bearer scheme', async () => {
+    const context = createContext({
+      headers: { authorization: 'Token abc.def.ghi' },
+      cookies: {},
+    });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      new UnauthorizedException('Missing bearer token'),
+    );
+    expect(verifier.verify).not.toHaveBeenCalled();
+  });
+
+  it('rejects a Bearer header that carries no token value', async () => {
+    const context = createContext({
+      headers: { authorization: 'Bearer' },
+      cookies: {},
+    });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      new UnauthorizedException('Missing bearer token'),
+    );
+    expect(verifier.verify).not.toHaveBeenCalled();
+  });
+
+  it('rejects an expired token', async () => {
+    verifier.verify.mockRejectedValueOnce(new TokenExpiredError());
+    const context = createContext({
+      headers: { authorization: 'Bearer expired.token' },
+      cookies: {},
+    });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      new UnauthorizedException('Invalid or expired token'),
+    );
+    expect(verifier.verify).toHaveBeenCalledWith('expired.token');
+  });
+
+  it('rejects a token with an invalid signature', async () => {
+    verifier.verify.mockRejectedValueOnce(new JsonWebTokenError());
+    const context = createContext({
+      headers: { authorization: 'Bearer tampered.token' },
+      cookies: {},
+    });
+
+    await expect(guard.canActivate(context)).rejects.toThrow(
+      new UnauthorizedException('Invalid or expired token'),
+    );
+    expect(verifier.verify).toHaveBeenCalledWith('tampered.token');
+  });
+
+  it('accepts a valid token and attaches the user to the request', async () => {
+    const user = { id: 'user-1', role: UserRole.ADMIN };
+    verifier.verify.mockResolvedValueOnce(user);
+    const request: Record<string, any> = {
+      headers: { authorization: 'Bearer valid.token' },
+      cookies: {},
+    };
+
+    await expect(guard.canActivate(createContext(request))).resolves.toBe(true);
+    expect(verifier.verify).toHaveBeenCalledWith('valid.token');
+    expect(request.user).toBe(user);
+  });
+
+  it('reads the token from the accessToken cookie when present', async () => {
+    const user = { id: 'user-2', role: UserRole.USER };
+    verifier.verify.mockResolvedValueOnce(user);
+    const request: Record<string, any> = {
+      headers: {},
+      cookies: { accessToken: 'cookie.token' },
+    };
+
+    await expect(guard.canActivate(createContext(request))).resolves.toBe(true);
+    expect(verifier.verify).toHaveBeenCalledWith('cookie.token');
+    expect(request.user).toBe(user);
+  });
+
+  it('prefers the cookie token over the authorization header', async () => {
+    verifier.verify.mockResolvedValueOnce({
+      id: 'user-3',
+      role: UserRole.USER,
+    });
+    const request: Record<string, any> = {
+      headers: { authorization: 'Bearer header.token' },
+      cookies: { accessToken: 'cookie.token' },
+    };
+
+    await guard.canActivate(createContext(request));
+    expect(verifier.verify).toHaveBeenCalledWith('cookie.token');
+  });
+});

--- a/backend/src/auth/guards/roles.guard.spec.ts
+++ b/backend/src/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,84 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { RolesGuard } from './roles.guard';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { UserRole } from '../enums/user-role.enum';
+
+describe('RolesGuard', () => {
+  const reflector = {
+    getAllAndOverride: jest.fn(),
+  };
+  const guard = new RolesGuard(reflector as unknown as Reflector);
+
+  const handler = () => undefined;
+  const controllerClass = class TestController {};
+
+  const createContext = (user?: {
+    id: string;
+    role: UserRole;
+  }): ExecutionContext =>
+    ({
+      getHandler: () => handler,
+      getClass: () => controllerClass,
+      switchToHttp: () => ({
+        getRequest: () => ({ user }),
+      }),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('allows the request through when no @Roles() metadata is present', () => {
+    reflector.getAllAndOverride.mockReturnValue(undefined);
+
+    expect(
+      guard.canActivate(createContext({ id: 'u1', role: UserRole.USER })),
+    ).toBe(true);
+    expect(reflector.getAllAndOverride).toHaveBeenCalledWith(ROLES_KEY, [
+      handler,
+      controllerClass,
+    ]);
+  });
+
+  it('allows the request through when @Roles() is present but empty', () => {
+    reflector.getAllAndOverride.mockReturnValue([]);
+
+    expect(
+      guard.canActivate(createContext({ id: 'u1', role: UserRole.USER })),
+    ).toBe(true);
+  });
+
+  it('grants access to a user that has the required role', () => {
+    reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
+
+    expect(
+      guard.canActivate(createContext({ id: 'u1', role: UserRole.ADMIN })),
+    ).toBe(true);
+  });
+
+  it('grants access when the user holds one of several accepted roles', () => {
+    reflector.getAllAndOverride.mockReturnValue([
+      UserRole.ADMIN,
+      UserRole.USER,
+    ]);
+
+    expect(
+      guard.canActivate(createContext({ id: 'u1', role: UserRole.USER })),
+    ).toBe(true);
+  });
+
+  it('denies access to a user that lacks the required role', () => {
+    reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
+
+    expect(
+      guard.canActivate(createContext({ id: 'u1', role: UserRole.USER })),
+    ).toBe(false);
+  });
+
+  it('denies access when the request has no authenticated user', () => {
+    reflector.getAllAndOverride.mockReturnValue([UserRole.USER]);
+
+    expect(guard.canActivate(createContext(undefined))).toBe(false);
+  });
+});


### PR DESCRIPTION
### Overview

`backend/src/auth/guards/jwt-auth.guard.ts` and `roles.guard.ts` are the sole
enforcement point for every protected endpoint in the app, yet neither had a
single automated test. This PR adds direct unit coverage for both guards,
exercising every branch.

No production code was modified — this change is test-only.

### What's included

**`backend/src/auth/guards/jwt-auth.guard.spec.ts`**

| Scenario | Expected behaviour |
| --- | --- |
| No `Authorization` header and no cookie | `UnauthorizedException('Missing bearer token')`, verifier never called |
| Malformed header (non-`Bearer` scheme) | `UnauthorizedException('Missing bearer token')`, verifier never called |
| `Bearer` header with no token value | `UnauthorizedException('Missing bearer token')`, verifier never called |
| Expired token (verifier rejects) | `UnauthorizedException('Invalid or expired token')` |
| Invalid signature (verifier rejects) | `UnauthorizedException('Invalid or expired token')` |
| Valid token | resolves `true` and attaches the resolved user to `request.user` |
| Token supplied via `accessToken` cookie | resolves `true`, token read from the cookie |
| Cookie + header both present | cookie token takes precedence |

**`backend/src/auth/guards/roles.guard.spec.ts`**

| Scenario | Expected behaviour |
| --- | --- |
| No `@Roles()` metadata present | allows the request through (`true`) |
| `@Roles()` present but empty | allows the request through (`true`) |
| User has the required role | `true` |
| User has one of several accepted roles | `true` |
| User lacks the required role | `false` |
| No authenticated user on the request | `false` |

Coverage for the two guards under test:

```
-------------------|---------|----------|---------|---------|
File               | % Stmts | % Branch | % Funcs | % Lines |
-------------------|---------|----------|---------|---------|
 jwt-auth.guard.ts |     100 |      100 |     100 |     100 |
 roles.guard.ts    |     100 |      100 |     100 |     100 |
-------------------|---------|----------|---------|---------|
```

ESLint and Prettier both pass on the new files.

### Acceptance criteria

- [x] `jwt-auth.guard.spec.ts` covers missing header, malformed header, expired token, invalid signature, and valid token
- [x] `roles.guard.spec.ts` covers user with the required role, user without it, and no `@Roles()` metadata (allows through)
- [x] Both guards have direct unit test coverage for every branch

Closes #1691 