### PR TITLE
feat: admin manual-review queue, payment detail actions, and member credits page [FE-104/106/108]

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { Landmark, Scale, Split, RefreshCw } from "lucide-react";
+import { Landmark, Scale, Split, RefreshCw, ClipboardList } from "lucide-react";
 import { Card } from "@/components/admin/ui";
 
 const cards = [
@@ -30,6 +30,13 @@ const cards = [
     description:
       "Inspect settlement batches, view breakdowns, and drive execute / retry / abandon recovery.",
     icon: RefreshCw,
+  },
+  {
+    href: "/admin/payments",
+    title: "Manual-review queue",
+    description:
+      "Payments escalated to MANUAL_REVIEW — force-reconcile, resolve, or void them from the browser.",
+    icon: ClipboardList,
   },
 ];
 

--- a/frontend/app/admin/payments/[id]/page.tsx
+++ b/frontend/app/admin/payments/[id]/page.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  ArrowLeft,
+  RefreshCw,
+  CheckCircle,
+  XCircle,
+  AlertTriangle,
+} from "lucide-react";
+import Link from "next/link";
+import {
+  getPayment,
+  forceReconcilePayment,
+  resolvePaymentManually,
+  voidPayment,
+} from "@/lib/payments-api";
+import {
+  Card,
+  CardHeader,
+  Badge,
+  StatusBadge,
+  Button,
+} from "@/components/admin/ui";
+import { RequireAdmin, useAdminToken } from "@/components/admin/require-admin";
+
+export default function AdminPaymentDetailPage() {
+  const token = useAdminToken();
+  return (
+    <RequireAdmin>
+      <PaymentDetailInner token={token as string} />
+    </RequireAdmin>
+  );
+}
+
+function ConfirmDialog({
+  title,
+  description,
+  confirmLabel,
+  confirmClass,
+  onConfirm,
+  onCancel,
+  needsReason,
+}: {
+  title: string;
+  description: string;
+  confirmLabel: string;
+  confirmClass?: string;
+  onConfirm: (value: string) => void;
+  onCancel: () => void;
+  needsReason?: boolean;
+}) {
+  const [value, setValue] = useState("");
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-xl bg-white p-6 shadow-2xl dark:bg-gray-900">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+          <div>
+            <h2 className="text-base font-semibold text-gray-900 dark:text-gray-50">
+              {title}
+            </h2>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              {description}
+            </p>
+          </div>
+        </div>
+        {needsReason && (
+          <div className="mt-4">
+            <label className="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+              Reason / resolution (required)
+            </label>
+            <input
+              type="text"
+              placeholder="Enter reason…"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none dark:border-gray-700 dark:bg-gray-950 dark:text-gray-50"
+            />
+          </div>
+        )}
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => onConfirm(value)}
+            disabled={needsReason && !value.trim()}
+            className={
+              confirmClass ??
+              "rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            }
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type Action = "reconcile" | "resolve" | "void" | null;
+
+function PaymentDetailInner({ token }: { token: string }) {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const [pendingAction, setPendingAction] = useState<Action>(null);
+
+  const {
+    data: payment,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["payment", id],
+    queryFn: () => getPayment(id, token),
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["payment", id] });
+    queryClient.invalidateQueries({ queryKey: ["manual-review-payments"] });
+  };
+
+  const reconcile = useMutation({
+    mutationFn: () => forceReconcilePayment(token, id),
+    onSuccess: () => {
+      invalidate();
+      toast.success("Payment force-reconciled.");
+    },
+    onError: (err) => toast.error((err as Error).message),
+  });
+
+  const resolve = useMutation({
+    mutationFn: (resolution: string) =>
+      resolvePaymentManually(token, id, resolution),
+    onSuccess: () => {
+      invalidate();
+      toast.success("Payment resolved manually.");
+    },
+    onError: (err) => toast.error((err as Error).message),
+  });
+
+  const voidMut = useMutation({
+    mutationFn: (reason: string) => voidPayment(token, id, reason),
+    onSuccess: () => {
+      invalidate();
+      toast.success("Payment voided.");
+    },
+    onError: (err) => toast.error((err as Error).message),
+  });
+
+  if (isLoading)
+    return <p className="text-sm text-gray-500">Loading payment…</p>;
+  if (error || !payment)
+    return (
+      <p className="text-sm text-red-500">
+        {(error as Error)?.message ?? "Payment not found."}
+      </p>
+    );
+
+  const fields: Array<{ label: string; value: React.ReactNode }> = [
+    {
+      label: "Payment ID",
+      value: <span className="font-mono text-xs">{payment.id}</span>,
+    },
+    {
+      label: "Booking ID",
+      value: <span className="font-mono text-xs">{payment.bookingId}</span>,
+    },
+    {
+      label: "User ID",
+      value: <span className="font-mono text-xs">{payment.userId}</span>,
+    },
+    {
+      label: "Amount",
+      value: `${payment.amount.toLocaleString()} ${payment.currency}`,
+    },
+    {
+      label: "Rail",
+      value: (
+        <Badge className="bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-400">
+          {payment.rail}
+        </Badge>
+      ),
+    },
+    { label: "Status", value: <StatusBadge status={payment.status} /> },
+    { label: "Provider", value: payment.provider ?? "—" },
+    { label: "Provider ref.", value: payment.providerReference ?? "—" },
+    { label: "Recon attempts", value: payment.reconciliationAttempts },
+    { label: "Review reason", value: payment.manualReviewReason ?? "—" },
+    { label: "Failure reason", value: payment.failureReason ?? "—" },
+    { label: "Created", value: new Date(payment.createdAt).toLocaleString() },
+    { label: "Updated", value: new Date(payment.updatedAt).toLocaleString() },
+  ];
+
+  return (
+    <>
+      {pendingAction === "reconcile" && (
+        <ConfirmDialog
+          title="Force-reconcile payment"
+          description="This will immediately trigger a reconciliation pass for this payment. This action is irreversible."
+          confirmLabel="Force-reconcile"
+          onConfirm={() => {
+            reconcile.mutate();
+            setPendingAction(null);
+          }}
+          onCancel={() => setPendingAction(null)}
+        />
+      )}
+      {pendingAction === "resolve" && (
+        <ConfirmDialog
+          title="Resolve payment manually"
+          description="Mark this payment as manually resolved. Provide a resolution note. Irreversible."
+          confirmLabel="Resolve"
+          needsReason
+          onConfirm={(val) => {
+            resolve.mutate(val);
+            setPendingAction(null);
+          }}
+          onCancel={() => setPendingAction(null)}
+        />
+      )}
+      {pendingAction === "void" && (
+        <ConfirmDialog
+          title="Void payment"
+          description="Voiding will permanently cancel this payment. Provide a reason. This cannot be undone."
+          confirmLabel="Void payment"
+          confirmClass="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50"
+          needsReason
+          onConfirm={(val) => {
+            voidMut.mutate(val);
+            setPendingAction(null);
+          }}
+          onCancel={() => setPendingAction(null)}
+        />
+      )}
+
+      <div className="space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => router.back()}
+              className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            >
+              <ArrowLeft className="h-4 w-4" /> Back
+            </button>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-50">
+              Payment detail
+            </h1>
+          </div>
+          <Link
+            href="/admin/payments"
+            className="text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400"
+          >
+            ← Review queue
+          </Link>
+        </div>
+
+        <Card>
+          <CardHeader
+            title="Payment information"
+            description="Full details for this payment record."
+          />
+          <dl className="divide-y divide-gray-100 dark:divide-gray-800">
+            {fields.map(({ label, value }) => (
+              <div key={label} className="flex px-5 py-3 text-sm">
+                <dt className="w-44 shrink-0 font-medium text-gray-500 dark:text-gray-400">
+                  {label}
+                </dt>
+                <dd className="text-gray-900 dark:text-gray-50">{value}</dd>
+              </div>
+            ))}
+          </dl>
+        </Card>
+
+        <Card>
+          <CardHeader
+            title="Admin recovery actions"
+            description="These state transitions are irreversible — a confirmation prompt will appear before each action."
+          />
+          <div className="flex flex-wrap gap-3 px-5 py-5">
+            <Button
+              type="button"
+              onClick={() => setPendingAction("reconcile")}
+              disabled={reconcile.isPending}
+              className="bg-blue-600 hover:bg-blue-700"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Force-reconcile
+            </Button>
+            <Button
+              type="button"
+              onClick={() => setPendingAction("resolve")}
+              disabled={resolve.isPending}
+              className="bg-emerald-600 hover:bg-emerald-700"
+            >
+              <CheckCircle className="h-4 w-4" />
+              Resolve manually
+            </Button>
+            <Button
+              type="button"
+              onClick={() => setPendingAction("void")}
+              disabled={voidMut.isPending}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              <XCircle className="h-4 w-4" />
+              Void payment
+            </Button>
+          </div>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/admin/payments/page.tsx
+++ b/frontend/app/admin/payments/page.tsx
@@ -1,0 +1,128 @@
+﻿"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import Link from "next/link";
+import { ClipboardList, ExternalLink } from "lucide-react";
+import { listManualReviewPayments } from "@/lib/payments-api";
+import type { Payment } from "@/lib/payments-api";
+import {
+  Card,
+  CardHeader,
+  Badge,
+  StatusBadge,
+} from "@/components/admin/ui";
+import { RequireAdmin, useAdminToken } from "@/components/admin/require-admin";
+
+export default function AdminManualReviewPage() {
+  const token = useAdminToken();
+  return (
+    <RequireAdmin>
+      <ManualReviewInner token={token as string} />
+    </RequireAdmin>
+  );
+}
+
+function ManualReviewInner({ token }: { token: string }) {
+  const { data: payments, isLoading, error } = useQuery({
+    queryKey: ["manual-review-payments"],
+    queryFn: () => listManualReviewPayments(token),
+    refetchInterval: 30_000,
+  });
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <ClipboardList className="h-6 w-6 text-amber-600" />
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-50">
+            Manual-review queue
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Payments escalated to MANUAL_REVIEW — use the action buttons on
+            each detail page to force-reconcile, resolve, or void.
+          </p>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader
+          title={isLoading ? "Loading…" : `${payments?.length ?? 0} payment${(payments?.length ?? 0) === 1 ? "" : "s"} awaiting review`}
+          description="Auto-refreshes every 30 seconds."
+        />
+
+        {error ? (
+          <p className="px-5 py-6 text-sm text-red-600 dark:text-red-400">
+            {(error as Error).message}
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-gray-200 text-xs uppercase text-gray-500 dark:border-gray-800 dark:text-gray-400">
+                <tr>
+                  <th className="px-5 py-3">Payment ID</th>
+                  <th className="px-5 py-3">Booking</th>
+                  <th className="px-5 py-3">Rail</th>
+                  <th className="px-5 py-3">Status</th>
+                  <th className="px-5 py-3 text-right">Amount</th>
+                  <th className="px-5 py-3">Review reason</th>
+                  <th className="px-5 py-3">Created</th>
+                  <th className="px-5 py-3" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+                {payments?.map((p: Payment) => (
+                  <tr
+                    key={p.id}
+                    className="hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                  >
+                    <td className="px-5 py-3 font-mono text-xs text-gray-700 dark:text-gray-300">
+                      {p.id.slice(0, 8)}…
+                    </td>
+                    <td className="px-5 py-3 font-mono text-xs text-gray-500 dark:text-gray-400">
+                      {p.bookingId.slice(0, 8)}…
+                    </td>
+                    <td className="px-5 py-3">
+                      <Badge className="bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-400">
+                        {p.rail}
+                      </Badge>
+                    </td>
+                    <td className="px-5 py-3">
+                      <StatusBadge status={p.status} />
+                    </td>
+                    <td className="px-5 py-3 text-right tabular-nums">
+                      {p.amount.toLocaleString()} {p.currency}
+                    </td>
+                    <td className="px-5 py-3 max-w-xs truncate text-gray-500 dark:text-gray-400">
+                      {p.manualReviewReason ?? "—"}
+                    </td>
+                    <td className="px-5 py-3 text-gray-500 dark:text-gray-400">
+                      {new Date(p.createdAt).toLocaleDateString()}
+                    </td>
+                    <td className="px-5 py-3">
+                      <Link
+                        href={`/admin/payments/${p.id}`}
+                        className="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-200"
+                      >
+                        Review <ExternalLink className="h-3 w-3" />
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+                {!isLoading && (payments?.length ?? 0) === 0 && (
+                  <tr>
+                    <td
+                      colSpan={8}
+                      className="px-5 py-10 text-center text-gray-400"
+                    >
+                      No payments in the manual-review queue.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/frontend/app/credits/page.tsx
+++ b/frontend/app/credits/page.tsx
@@ -1,0 +1,182 @@
+﻿"use client";
+
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Wallet, ArrowDownLeft, ArrowUpRight, ChevronLeft, ChevronRight } from "lucide-react";
+import Cookies from "js-cookie";
+import { getCreditBalance, getCreditStatement } from "@/lib/credits-api";
+import type { CreditStatementEntry } from "@/lib/credits-api";
+
+const PAGE_SIZE = 20;
+
+function useAccessToken(): string | null {
+  return Cookies.get("accessToken") ?? null;
+}
+
+export default function CreditsPage() {
+  const token = useAccessToken();
+
+  if (!token) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="max-w-sm rounded-xl border border-dashed border-gray-300 px-8 py-12 text-center dark:border-gray-700">
+          <Wallet className="mx-auto mb-3 h-10 w-10 text-gray-300 dark:text-gray-600" />
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-50">
+            Sign in to view your credits
+          </h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Your credit balance and transaction history will appear here once you are signed in.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return <CreditsInner token={token} />;
+}
+
+function CreditsInner({ token }: { token: string }) {
+  const [page, setPage] = useState(1);
+
+  const balance = useQuery({
+    queryKey: ["credit-balance"],
+    queryFn: () => getCreditBalance(token),
+  });
+
+  const statement = useQuery({
+    queryKey: ["credit-statement", page],
+    queryFn: () => getCreditStatement(token, page, PAGE_SIZE),
+  });
+
+  const totalPages = statement.data
+    ? Math.ceil(statement.data.total / PAGE_SIZE)
+    : 1;
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 px-4 py-8">
+      {/* Balance card */}
+      <div className="overflow-hidden rounded-2xl bg-gradient-to-br from-blue-600 to-indigo-700 p-6 text-white shadow-lg">
+        <div className="flex items-start justify-between">
+          <div>
+            <p className="text-sm font-medium text-blue-100">Available balance</p>
+            {balance.isLoading ? (
+              <p className="mt-2 text-4xl font-bold tracking-tight">—</p>
+            ) : balance.error ? (
+              <p className="mt-2 text-sm text-red-300">
+                {(balance.error as Error).message}
+              </p>
+            ) : (
+              <>
+                <p className="mt-2 text-4xl font-bold tracking-tight">
+                  {balance.data!.balance.toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })}
+                  <span className="ml-2 text-xl font-normal text-blue-200">
+                    {balance.data!.currency}
+                  </span>
+                </p>
+                {balance.data!.overdraftLimit > 0 && (
+                  <p className="mt-1 text-xs text-blue-200">
+                    Overdraft limit: {balance.data!.overdraftLimit.toLocaleString()} {balance.data!.currency}
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+          <Wallet className="h-8 w-8 text-blue-200 opacity-70" />
+        </div>
+      </div>
+
+      {/* Statement */}
+      <div>
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-50">
+          Transaction history
+        </h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Your full credit ledger, newest first.
+        </p>
+
+        <div className="mt-4 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">
+          {statement.error ? (
+            <p className="px-5 py-8 text-center text-sm text-red-500">
+              {(statement.error as Error).message}
+            </p>
+          ) : statement.isLoading ? (
+            <p className="px-5 py-8 text-center text-sm text-gray-400">
+              Loading…
+            </p>
+          ) : (statement.data?.entries.length ?? 0) === 0 ? (
+            <p className="px-5 py-12 text-center text-sm text-gray-400">
+              No transactions yet.
+            </p>
+          ) : (
+            <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+              {statement.data!.entries.map((entry: CreditStatementEntry) => (
+                <li key={entry.id} className="flex items-center gap-4 px-5 py-4">
+                  <div
+                    className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-full ${
+                      entry.direction === "CREDIT"
+                        ? "bg-emerald-50 text-emerald-600 dark:bg-emerald-950 dark:text-emerald-400"
+                        : "bg-red-50 text-red-500 dark:bg-red-950 dark:text-red-400"
+                    }`}
+                  >
+                    {entry.direction === "CREDIT" ? (
+                      <ArrowDownLeft className="h-4 w-4" />
+                    ) : (
+                      <ArrowUpRight className="h-4 w-4" />
+                    )}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-gray-900 dark:text-gray-50">
+                      {entry.description ?? entry.kind}
+                    </p>
+                    <p className="truncate text-xs text-gray-400 dark:text-gray-500">
+                      {entry.reference} · {new Date(entry.createdAt).toLocaleString()}
+                    </p>
+                  </div>
+                  <p
+                    className={`shrink-0 text-sm font-semibold tabular-nums ${
+                      entry.direction === "CREDIT"
+                        ? "text-emerald-600 dark:text-emerald-400"
+                        : "text-red-500 dark:text-red-400"
+                    }`}
+                  >
+                    {entry.direction === "CREDIT" ? "+" : "−"}
+                    {entry.amount.toLocaleString(undefined, {
+                      minimumFractionDigits: 2,
+                    })}{" "}
+                    {entry.currency}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="mt-4 flex items-center justify-center gap-4">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-40 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              <ChevronLeft className="h-4 w-4" /> Prev
+            </button>
+            <span className="text-sm text-gray-500 dark:text-gray-400">
+              Page {page} of {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="inline-flex items-center gap-1 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-40 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              Next <ChevronRight className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/lib/credits-api.ts
+++ b/frontend/lib/credits-api.ts
@@ -1,0 +1,71 @@
+﻿// lib/credits-api.ts  -- member-facing credit API (FE-108)
+
+export interface CreditBalance {
+  accountId: string;
+  currency: string;
+  balance: number;
+  overdraftLimit: number;
+}
+
+export interface CreditStatementEntry {
+  id: string;
+  transactionId: string;
+  direction: "DEBIT" | "CREDIT";
+  amount: number;
+  currency: string;
+  description: string | null;
+  kind: string;
+  reference: string;
+  createdAt: string;
+}
+
+export interface CreditStatement {
+  entries: CreditStatementEntry[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+async function creditsFetch<T>(
+  path: string,
+  accessToken: string,
+  init?: RequestInit,
+): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
+      ...init?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    throw new Error(body?.message ?? `Request failed (${response.status})`);
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  return response.json() as Promise<T>;
+}
+
+// -- member credit balance (FE-108) -----------------------------------------------
+
+export function getCreditBalance(accessToken: string): Promise<CreditBalance> {
+  return creditsFetch<CreditBalance>("/credits/balance", accessToken);
+}
+
+export function getCreditStatement(
+  accessToken: string,
+  page = 1,
+  pageSize = 20,
+): Promise<CreditStatement> {
+  return creditsFetch<CreditStatement>(
+    `/credits/statement?page=${page}&pageSize=${pageSize}`,
+    accessToken,
+  );
+}

--- a/frontend/lib/payments-api.ts
+++ b/frontend/lib/payments-api.ts
@@ -157,6 +157,43 @@ export function listManualReviewPayments(
   return apiFetch<Payment[]>("/payments/admin/manual-review", accessToken);
 }
 
+// ── admin payment actions (FE-104 / FE-106) ──────────────────────────────
+
+export function forceReconcilePayment(
+  accessToken: string,
+  id: string,
+): Promise<Payment> {
+  return apiFetch<Payment>(
+    `/payments/admin/${id}/force-reconcile`,
+    accessToken,
+    { method: "POST" },
+  );
+}
+
+export function resolvePaymentManually(
+  accessToken: string,
+  id: string,
+  resolution: string,
+): Promise<Payment> {
+  return apiFetch<Payment>(
+    `/payments/admin/${id}/resolve-manually`,
+    accessToken,
+    { method: "POST", body: JSON.stringify({ resolution }) },
+  );
+}
+
+export function voidPayment(
+  accessToken: string,
+  id: string,
+  reason: string,
+): Promise<Payment> {
+  return apiFetch<Payment>(
+    `/payments/admin/${id}/void`,
+    accessToken,
+    { method: "POST", body: JSON.stringify({ reason }) },
+  );
+}
+
 // ── refunds (FE-107) ─────────────────────────────────────────────────────
 
 export function requestRefund(


### PR DESCRIPTION
### Description
This PR implements three missing frontend features for ManageHub.

**Changes Included:**
- **[FE-104] Admin manual-review queue** (/admin/payments): Table listing all payments in MANUAL_REVIEW status with auto-refresh every 30s, review-reason column, and a link to each payment's detail page.
- **[FE-106] Admin payment recovery actions** (/admin/payments/[id]): Full payment detail view with three irreversible admin actions — Force-reconcile, Resolve manually, and Void — each protected by a confirmation dialog that requires a reason/resolution note before submission.
- **[FE-108] Member credits page** (/credits): Gradient balance card showing current balance and overdraft limit, plus a paginated ledger statement with credit/debit icons and amounts.

**API layer additions:**
- lib/payments-api.ts: Added orceReconcilePayment, esolvePaymentManually, oidPayment.
- lib/credits-api.ts (new): getCreditBalance, getCreditStatement targeting GET /credits/balance and GET /credits/statement.

**Admin dashboard** updated to include a Manual-review queue card.

### Fixes
Closes #1633
Closes #1635
Closes #1637