### PR TITLE
Feat/1700 1701 1702 1703 test coverage

### DIFF
--- a/backend/src/auth/guards/roles.guard.spec.ts
+++ b/backend/src/auth/guards/roles.guard.spec.ts
@@ -68,6 +68,40 @@ describe('RolesGuard', () => {
     ).toBe(true);
   });
 
+  /**
+   * Issue #1703: distinguishes "none of several" from "one of several".
+   * `UserRole` currently defines exactly two values (USER, ADMIN), so a
+   * requiredRoles list naming *every* real role is always satisfied by any
+   * authenticated user — there is no legitimate role value a real user can
+   * hold that misses a two-or-more-role allowlist covering the whole enum.
+   * The only way to exercise "held none of several" is a role value outside
+   * the enum entirely (stale JWT from before a role was renamed/removed,
+   * bad seed data, a migration artifact) — which is exactly the case this
+   * guard must not silently let through.
+   */
+  it('denies access when the user holds none of several accepted roles', () => {
+    reflector.getAllAndOverride.mockReturnValue([
+      UserRole.ADMIN,
+      UserRole.USER,
+    ]);
+
+    expect(
+      guard.canActivate(
+        createContext({ id: 'u1', role: 'legacy-moderator' as UserRole }),
+      ),
+    ).toBe(false);
+  });
+
+  /**
+   * "A user holding more than one required role at once" is not
+   * representable today: `RequestUser.role` (authenticated-request.interface.ts)
+   * is a single `UserRole`, not `UserRole[]`, and this guard's check
+   * (`requiredRoles.includes(request.user?.role)`) only ever tests that one
+   * value. Multi-role-per-user is explicitly unsupported rather than
+   * ambiguous — introducing it would require widening `RequestUser.role`
+   * itself, not a change to this guard.
+   */
+
   it('denies access to a user that lacks the required role', () => {
     reflector.getAllAndOverride.mockReturnValue([UserRole.ADMIN]);
 

--- a/backend/src/credits/credits.service.spec.ts
+++ b/backend/src/credits/credits.service.spec.ts
@@ -42,24 +42,6 @@ async function fund(
   });
 }
 
- const harness = createLedgerHarness();
-  const ledger = new LedgerService(
-    harness.accounts as any,
-    harness.transactions as any,
-    harness.entries as any,
-  );
-  const credits = new CreditsService(
-    ledger,
-    fakeConfigService({
-      CREDITS_DEFAULT_CURRENCY: 'USD',
-      CREDITS_DEFAULT_OVERDRAFT_LIMIT: 0,
-      ...config,
-    }),
-  );
-  return { harness, ledger, credits };
-}
-
-
 function assertLedgerBalances(harness: LedgerHarness, accountIds: string[]) {
   for (const accountId of accountIds) {
     expect(harness.balanceOf(accountId)).toBe(

--- a/backend/src/credits/credits.service.ts
+++ b/backend/src/credits/credits.service.ts
@@ -126,24 +126,6 @@ export class CreditsService {
     );
   }
 
-   const harness = createLedgerHarness();
-    const ledger = new LedgerService(
-      harness.accounts as any,
-      harness.transactions as any,
-      harness.entries as any,
-    );
-    const credits = new CreditsService(
-      ledger,
-      fakeConfigService({
-        CREDITS_DEFAULT_CURRENCY: 'USD',
-        CREDITS_DEFAULT_OVERDRAFT_LIMIT: 0,
-        ...config,
-      }),
-    );
-    return { harness, ledger, credits };
-  }
-  
-
   /**
    * Resolves (creating on first use) an owned payable account — a hub
    * operator or a referrer. `externalPayoutAddress` is what makes its

--- a/backend/src/credits/revenue-split.service.spec.ts
+++ b/backend/src/credits/revenue-split.service.spec.ts
@@ -187,6 +187,53 @@ describe('RevenueSplitService', () => {
       ]);
       expect(updated.recipients).toHaveLength(2);
     });
+
+    /**
+     * Issue #1700: every recipient here individually passes
+     * `RevenueSplitRecipientDto`'s per-field `@Min(1) @Max(10000)` check —
+     * the only thing wrong is the *set's* total. Proves the update path
+     * (`replaceRecipients`, backing `PUT .../recipients`) rejects that atomically
+     * — before the existing recipients are ever deleted, not after.
+     */
+    it('rejects an update whose individually-valid recipients do not sum to 10000, without touching existing rows', async () => {
+      const { splits, platform, operator } = await build();
+      const config = await splits.createConfig({
+        name: 'update-sum-check',
+        recipients: [
+          { label: 'platform fee', basisPoints: 4000, accountId: platform.id },
+          { label: 'hub operator', basisPoints: 6000, accountId: operator.id },
+        ],
+      });
+
+      // 9999: one short of 10000, every individual value still 1-10000.
+      await expect(
+        splits.replaceRecipients(config.id, [
+          { label: 'platform fee', basisPoints: 4999, accountId: platform.id },
+          { label: 'hub operator', basisPoints: 5000, accountId: operator.id },
+        ]),
+      ).rejects.toThrow(/must sum to 10000/);
+
+      // 10001: one over, same individual-field validity.
+      await expect(
+        splits.replaceRecipients(config.id, [
+          { label: 'platform fee', basisPoints: 5001, accountId: platform.id },
+          { label: 'hub operator', basisPoints: 5000, accountId: operator.id },
+        ]),
+      ).rejects.toThrow(/must sum to 10000/);
+
+      // Neither rejected update was partially applied: the original
+      // recipients (and only them) are still in place.
+      const unchanged = await splits.getConfig(config.id);
+      expect(unchanged.recipients).toHaveLength(2);
+      expect(
+        unchanged.recipients.map((r) => [r.label, r.basisPoints]),
+      ).toEqual(
+        expect.arrayContaining([
+          ['platform fee', 4000],
+          ['hub operator', 6000],
+        ]),
+      );
+    });
   });
 
   describe('computation', () => {

--- a/backend/src/payments/reconciliation.service.spec.ts
+++ b/backend/src/payments/reconciliation.service.spec.ts
@@ -377,6 +377,86 @@ describe('ReconciliationService', () => {
     });
   });
 
+  describe('handleCron — full-batch load and overlap protection (issue #1701)', () => {
+    /**
+     * A synchronous unit test can't prove a full batch beats a real 5-minute
+     * wall clock against a real provider — that belongs in a staging soak
+     * test. What it can prove: every payment in a full-size
+     * PAYMENT_RECONCILE_MAX_BATCH batch is actually processed (the `take`
+     * cap isn't silently dropping candidates), and that overlap protection
+     * exists so a pass that *does* run long can never double-process
+     * alongside the next cron tick.
+     */
+    it('processes a full PAYMENT_RECONCILE_MAX_BATCH-sized batch in one pass', async () => {
+      const now = new Date();
+      const payments = Array.from({ length: 500 }, (_, i) =>
+        makePayment({ id: `batch-${i}`, createdAt: minutesAgo(10, now) }),
+      );
+      confirmationService.apply.mockResolvedValue({
+        status: PaymentStatus.CONFIRMED,
+      });
+      railAdapter.verifyByReference.mockResolvedValue({ outcome: 'confirmed' });
+
+      const { service } = build(payments, { PAYMENT_RECONCILE_MAX_BATCH: 500 });
+      const summary = await service.reconcileDueBatch(now);
+
+      expect(summary.candidates).toBe(500);
+      expect(summary.resolved).toBe(500);
+      expect(railAdapter.verifyByReference).toHaveBeenCalledTimes(500);
+    });
+
+    it('skips a cron tick that fires while the previous pass is still running', async () => {
+      const now = new Date();
+      const payment = makePayment({ createdAt: minutesAgo(10, now) });
+      let releaseVerify!: (outcome: { outcome: 'confirmed' }) => void;
+      railAdapter.verifyByReference.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            releaseVerify = resolve;
+          }),
+      );
+      confirmationService.apply.mockResolvedValue({
+        status: PaymentStatus.CONFIRMED,
+      });
+
+      const { service } = build([payment]);
+
+      const firstPass = service.handleCron();
+      // Give the first pass's microtasks a chance to reach the pending
+      // provider call before the "overlapping" second tick fires.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      await service.handleCron();
+
+      // The second tick must not have touched the provider or recorded a
+      // pass — it should have been a no-op while the first was in flight.
+      expect(railAdapter.verifyByReference).toHaveBeenCalledTimes(1);
+      expect(metrics.recordReconciliationPass).toHaveBeenCalledTimes(0);
+
+      releaseVerify!({ outcome: 'confirmed' });
+      await firstPass;
+
+      expect(metrics.recordReconciliationPass).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows the next cron tick to run once the previous pass has finished', async () => {
+      const now = new Date();
+      const payment = makePayment({ createdAt: minutesAgo(10, now) });
+      confirmationService.apply.mockResolvedValue({
+        status: PaymentStatus.CONFIRMED,
+      });
+      railAdapter.verifyByReference.mockResolvedValue({ outcome: 'confirmed' });
+
+      const { service } = build([payment]);
+
+      await service.handleCron();
+      await service.handleCron();
+
+      expect(metrics.recordReconciliationPass).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('admin recovery actions', () => {
     it('forceReconcileNow reconciles a payment immediately, bypassing the due schedule', async () => {
       const now = new Date();

--- a/backend/src/payments/reconciliation.service.ts
+++ b/backend/src/payments/reconciliation.service.ts
@@ -51,6 +51,20 @@ type ReconcileOutcome = 'resolved' | 'pending' | 'provider_error' | 'escalated';
 export class ReconciliationService {
   private readonly logger = new Logger(ReconciliationService.name);
 
+  /**
+   * Overlap guard (issue #1701): nothing bounds how long a full
+   * PAYMENT_RECONCILE_MAX_BATCH pass can take against a slow or degraded
+   * provider — 500 payments each waiting up to PAYMENT_VERIFY_TIMEOUT_MS
+   * sequentially can exceed the 5-minute cron interval. Rather than let a
+   * second @Cron firing start reconciling the same payments concurrently
+   * (double `reconciliationAttempts` increments, duplicate provider calls),
+   * a run in progress makes the next tick a no-op. Process-local by design,
+   * matching this job's single-instance deployment; a multi-instance
+   * deployment would need SettlementService's `pg_advisory_xact_lock`
+   * pattern instead.
+   */
+  private isRunning = false;
+
   constructor(
     @InjectRepository(Payment)
     private readonly paymentRepository: Repository<Payment>,
@@ -63,20 +77,34 @@ export class ReconciliationService {
 
   @Cron(CronExpression.EVERY_5_MINUTES)
   async handleCron(): Promise<void> {
-    const started = Date.now();
-    const summary = await this.reconcileDueBatch();
-    this.metrics.recordReconciliationPass(Date.now() - started);
-    this.logger.log(withRequestId(`Reconciliation pass: ${JSON.stringify(summary)}`));
-    const metrics = await this.getMetrics();
-    this.metrics.setManualReviewDepth(metrics.manualReviewQueueDepth);
-    if (metrics.alerting) {
+    if (this.isRunning) {
       this.logger.warn(
         withRequestId(
-          `ALERT: manual-review queue depth ${metrics.manualReviewQueueDepth} ` +
-            `exceeds threshold ${metrics.alertThreshold}`,
+          'Skipping reconciliation pass: the previous pass is still running',
         ),
       );
-      await this.sendManualReviewAlert(metrics.manualReviewQueueDepth, metrics.alertThreshold);
+      return;
+    }
+
+    this.isRunning = true;
+    try {
+      const started = Date.now();
+      const summary = await this.reconcileDueBatch();
+      this.metrics.recordReconciliationPass(Date.now() - started);
+      this.logger.log(withRequestId(`Reconciliation pass: ${JSON.stringify(summary)}`));
+      const metrics = await this.getMetrics();
+      this.metrics.setManualReviewDepth(metrics.manualReviewQueueDepth);
+      if (metrics.alerting) {
+        this.logger.warn(
+          withRequestId(
+            `ALERT: manual-review queue depth ${metrics.manualReviewQueueDepth} ` +
+              `exceeds threshold ${metrics.alertThreshold}`,
+          ),
+        );
+        await this.sendManualReviewAlert(metrics.manualReviewQueueDepth, metrics.alertThreshold);
+      }
+    } finally {
+      this.isRunning = false;
     }
   }
 

--- a/backend/src/wallets/wallets.service.spec.ts
+++ b/backend/src/wallets/wallets.service.spec.ts
@@ -147,6 +147,77 @@ describe('WalletsService', () => {
       expect(result).toBe(winner);
       expect(keyCustody.provisionKeypair).not.toHaveBeenCalled();
     });
+
+    /**
+     * Issue #1702: the previous test above simulates the race by scripting
+     * a single mocked rejection. This one actually fires several concurrent
+     * `provisionCustodialWallet` calls through a small in-memory
+     * WalletAccount table with the same two guarantees
+     * `credits/testing/in-memory-ledger.ts` documents for the ledger's own
+     * overdraft-race test: `transaction` serializes callbacks (standing in
+     * for the DB's insert/row locking), and the (user_id) unique index is
+     * enforced, raising the Postgres-shaped 23505 error the service
+     * recovers from. Proves exactly one wallet is ever created, every
+     * concurrent caller converges on it, and no caller ever sees the raw
+     * database constraint exception.
+     */
+    it('lets exactly one of several concurrent provision requests for the same user create a wallet', async () => {
+      const rows: any[] = [];
+      let sequence = 0;
+      let txQueue: Promise<unknown> = Promise.resolve();
+
+      const accountRepo = {
+        create: (data: any) => ({ ...data }),
+        save: async (entity: any) => {
+          if (!entity.id) {
+            const clash = rows.find((row) => row.userId === entity.userId);
+            if (clash) {
+              const error: any = new Error(
+                'duplicate key value violates unique constraint',
+              );
+              error.code = '23505';
+              error.constraint = 'uq_wallet_accounts_user_id';
+              throw error;
+            }
+            entity.id = `wallet-${++sequence}`;
+          }
+          const saved = { ...entity };
+          const index = rows.findIndex((row) => row.id === saved.id);
+          if (index >= 0) {
+            rows[index] = saved;
+          } else {
+            rows.push(saved);
+          }
+          return { ...saved };
+        },
+      };
+      walletAccountRepository.findOne = jest.fn(async ({ where }: any) => {
+        const found = rows.find((row) => row.userId === where.userId);
+        return found ? { ...found } : null;
+      });
+      const manager = { getRepository: () => accountRepo };
+      transaction.mockImplementation(async (cb: (m: any) => unknown) => {
+        const run = txQueue.then(() => cb(manager));
+        txQueue = run.then(
+          () => undefined,
+          () => undefined,
+        );
+        return run;
+      });
+      keyCustody.provisionKeypair.mockImplementation(
+        async (walletAccountId: string) => `GADDRESS-${walletAccountId}`,
+      );
+
+      const results = await Promise.all(
+        Array.from({ length: 5 }, () =>
+          service.provisionCustodialWallet('user-1'),
+        ),
+      );
+
+      expect(new Set(results.map((account) => account.id)).size).toBe(1);
+      expect(rows).toHaveLength(1);
+      expect(keyCustody.provisionKeypair).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('fundCustodialWallet', () => {


### PR DESCRIPTION
Four test-coverage fixes across `credits`, `payments`, `wallets`, and `auth`:

**#1700 — atomic revenue-split update validation**
`RevenueSplitRecipientDto` validates each recipient's basis points at the
DTO layer, but nothing proved `RevenueSplitService.replaceRecipients`
(backing `PUT .../recipients`) rejects a *set* that individually passes
per-field validation but doesn't sum to 10000. Added a test with two such
sets (9999 and 10001 total) and confirmed neither rejected update deletes
the existing recipients first — the validation already ran before the
transaction starts; this just proves it.

**#1701 — reconciliation overlap protection + full-batch test**
`ReconciliationService` had no bound on how long a full
`PAYMENT_RECONCILE_MAX_BATCH` pass could take against a slow provider —
500 sequential awaits up to `PAYMENT_VERIFY_TIMEOUT_MS` each can exceed the
5-minute cron interval. Added a process-local in-progress flag so an
overlapping `@Cron` tick becomes a no-op instead of double-processing (and
a test proving it), plus a test running a full 500-payment batch to prove
the `PAYMENT_RECONCILE_MAX_BATCH` cap doesn't silently drop candidates.
True wall-clock timing against a real provider is a staging soak-test
concern, not a synchronous unit test — the overlap guard is the structural
fix for the case where a pass does run long.

**#1702 — concurrent custodial wallet provisioning**
`WalletsService.provisionCustodialWallet`'s doc comment already claims the
same first-write-wins `(user_id)` constraint pattern the ledger's overdraft
race gets a dedicated test for, but nothing exercised real concurrency.
Added a test firing 5 genuinely concurrent calls through a small in-memory
`WalletAccount` table (serializing transactions and enforcing the unique
index, mirroring `credits/testing/in-memory-ledger.ts`'s own approach) —
exactly one wallet is created, every caller converges on it, and
`KeyCustodyService.provisionKeypair` is only ever called once.

**#1703 — RolesGuard none-of-several case**
Only the single-role case and "holds one of several" were tested. Added
the missing "holds none of several accepted roles" case. Since `UserRole`
currently has only two values (`USER`, `ADMIN`), a `requiredRoles` list
naming both is satisfied by any real user — so this is only reachable via
a role value outside the enum (stale JWT, bad seed data), which is exactly
the case the guard must not silently let through. "Holds more than one
role at once" isn't representable today (`RequestUser.role` is a single
`UserRole`, not `UserRole[]`) — documented explicitly in a comment per the
issue's own fallback instruction, rather than left ambiguous.

**One additional out-of-scope commit:** `credits.service.ts` and
`credits.service.spec.ts` on `main` had a stray fragment of the spec's
`build()` helper spliced into the middle of `CreditsService` itself
(between `getSystemAccount` and `getPayableAccount`), with the spec file
left holding an orphaned, syntactically-invalid second copy of the same
helper. This broke TypeScript compilation for the whole package — nothing
in `credits/`, including the #1700 test above, could type-check without
it. Removed the stray fragments; no behavioral change.

## Tests / checks performed

- `src/credits/revenue-split.service.spec.ts` — all tests pass
- `src/payments/reconciliation.service.spec.ts` — all tests pass (overlap-guard tests confirmed via log output: "Skipping reconciliation pass: the previous pass is still running")
- `src/auth/guards/roles.guard.spec.ts` — all tests pass
- `npx tsc --noEmit` — zero errors in any file this PR touches (confirmed after the `credits.service.ts` fix; a handful of pre-existing, unrelated errors remain elsewhere in the repo — missing modules for `credits-admin.service`/`payments-admin.service`, mismatched controller/DTO signatures in unrelated `*.controller.spec.ts` files, an Express `cookie` overload mismatch in `auth.controller.ts` — none of them touch anything this PR changes)
- `src/wallets/wallets.service.spec.ts` — **could not get a clean local run.** This sandbox's npm registry connectivity was severely degraded for this session (confirmed via ~12 install attempts across `npm install`, `npm ci`, varied retry/timeout/concurrency settings, and detached/nohup runs — each failed a different way: `ECONNRESET`, `ENOTEMPTY`/`EPERM` on a nested `rxjs` cleanup during dedup, npm's own "Exit handler never called" bug, or a genuine multi-minute stall with zero progress). The one clean install I did briefly get **before** a later reinstall attempt wiped it showed all 3 other suites above passing 45/45, and this file's only compile blocker was a corrupted `@stellar/stellar-sdk`/`@stellar/stellar-base` install (an unrelated third-party package, not this PR's code) — reinstalling just that package fixed the compile error and the file ran, before the environment degraded further. I'm confident in the test's correctness (same in-memory-transaction-table pattern as the ledger's own passing overdraft-race test) but would appreciate CI confirming this suite specifically.

## Closes

Closes #1700
Closes #1701
Closes #1702
Closes #1703