### PR TITLE
test: WalletStatusCard state coverage, wallet-api tests, e2e, escrow contract tests

### DIFF
--- a/contracts/payment_escrow/src/lib.rs
+++ b/contracts/payment_escrow/src/lib.rs
@@ -183,3 +183,56 @@ mod test {
         assert_eq!(result, Ok(300));
     }
 }
+
+// ---------------------------------------------------------------------------
+// CT-51: happy-path tests for create/release/refund/get_status
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod escrow_test {
+    use super::*;
+    use soroban_sdk::testutils::Address as _;
+
+    fn setup() -> (Env, PaymentEscrowContractClient<'static>, Address, Address) {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(PaymentEscrowContract, ());
+        let client = PaymentEscrowContractClient::new(&env, &contract_id);
+
+        let payer = Address::generate(&env);
+        let beneficiary = Address::generate(&env);
+
+        (env, client, payer, beneficiary)
+    }
+
+    fn escrow_id(env: &Env, seed: u8) -> BytesN<32> {
+        BytesN::from_array(env, &[seed; 32])
+    }
+
+    /// create -> get_status=Locked -> release -> get_status=Released.
+    #[test]
+    fn test_create_release_happy_path() {
+        let (env, client, payer, beneficiary) = setup();
+        let id = escrow_id(&env, 1);
+
+        client.create(&id, &payer, &beneficiary, &1_000);
+        assert_eq!(client.get_status(&id), 1); // Locked
+
+        client.release(&id);
+        assert_eq!(client.get_status(&id), 2); // Released
+    }
+
+    /// create -> get_status=Locked -> refund -> get_status=Refunded.
+    #[test]
+    fn test_create_refund_happy_path() {
+        let (env, client, payer, beneficiary) = setup();
+        let id = escrow_id(&env, 2);
+
+        client.create(&id, &payer, &beneficiary, &500);
+        assert_eq!(client.get_status(&id), 1); // Locked
+
+        client.refund(&id);
+        assert_eq!(client.get_status(&id), 3); // Refunded
+    }
+}

--- a/frontend/components/wallet/__tests__/wallet-status-card.a11y.test.tsx
+++ b/frontend/components/wallet/__tests__/wallet-status-card.a11y.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { axe, toHaveNoViolations } from "jest-axe";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WalletStatusCard } from "../wallet-status-card";
@@ -10,13 +11,29 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+/**
+ * WalletStatusCard calls useQuery/useMutation, which throw ("No QueryClient
+ * set") without a QueryClientProvider ancestor — pre-existing gap in this
+ * file (it doesn't take an `accessToken` prop; auth comes from
+ * useSessionStore), fixed alongside adding the state-coverage suite in
+ * wallet-status-card.test.tsx.
+ */
+function renderCard() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <WalletStatusCard />
+    </QueryClientProvider>,
+  );
+}
+
 describe("WalletStatusCard accessibility", () => {
   it("has no axe violations while loading", async () => {
     vi.spyOn(walletApi, "getWalletStatus").mockReturnValue(new Promise(() => {}));
 
-    const { container } = render(
-      <WalletStatusCard accessToken="test-token" />,
-    );
+    const { container } = renderCard();
 
     expect(screen.getByRole("status")).toHaveTextContent(
       "Loading your wallet",
@@ -34,9 +51,7 @@ describe("WalletStatusCard accessibility", () => {
       currency: "USD",
     });
 
-    const { container } = render(
-      <WalletStatusCard accessToken="test-token" />,
-    );
+    const { container } = renderCard();
 
     await waitFor(() =>
       expect(screen.getByText(/USD credit/)).toBeInTheDocument(),
@@ -49,9 +64,7 @@ describe("WalletStatusCard accessibility", () => {
       new Error("Wallet request failed (500)"),
     );
 
-    const { container } = render(
-      <WalletStatusCard accessToken="test-token" />,
-    );
+    const { container } = renderCard();
 
     await waitFor(() =>
       expect(

--- a/frontend/components/wallet/__tests__/wallet-status-card.test.tsx
+++ b/frontend/components/wallet/__tests__/wallet-status-card.test.tsx
@@ -1,0 +1,279 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WalletStatusCard } from "../wallet-status-card";
+import * as walletApi from "@/lib/wallet-api";
+import type { WalletStatusResponse } from "@/lib/wallet-api";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * WalletStatusCard renders <Card>/<CardContent> unconditionally and calls
+ * useQuery/useMutation, which throw ("No QueryClient set") without a
+ * QueryClientProvider ancestor — a fresh client per test keeps React Query's
+ * cache from leaking state between tests.
+ */
+function renderCard() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <WalletStatusCard />
+    </QueryClientProvider>,
+  );
+}
+
+const UNPROVISIONED: WalletStatusResponse = {
+  provisioned: false,
+  walletAddress: null,
+  custodyType: null,
+  status: null,
+  balance: 0,
+  currency: "USD",
+};
+
+const PROVISIONED_CUSTODIAL: WalletStatusResponse = {
+  provisioned: true,
+  walletAddress: "GCUSTODIALADDRESS",
+  custodyType: "CUSTODIAL",
+  status: "ACTIVE",
+  balance: 500,
+  currency: "USD",
+};
+
+const VALID_STELLAR_ADDRESS = `G${"A".repeat(55)}`;
+
+describe("WalletStatusCard", () => {
+  describe("initial load", () => {
+    it("shows a loading state while the status request is in flight", () => {
+      vi.spyOn(walletApi, "getWalletStatus").mockReturnValue(
+        new Promise(() => {}),
+      );
+
+      renderCard();
+
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Loading your wallet",
+      );
+    });
+
+    it("shows the unprovisioned prompt once loaded with no wallet", async () => {
+      vi.spyOn(walletApi, "getWalletStatus").mockResolvedValue(UNPROVISIONED);
+
+      renderCard();
+
+      await waitFor(() =>
+        expect(
+          screen.getByText(/don't have a payment balance set up yet/),
+        ).toBeInTheDocument(),
+      );
+      expect(
+        screen.getByRole("button", { name: "Get started" }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the formatted balance once loaded with a provisioned wallet", async () => {
+      vi.spyOn(walletApi, "getWalletStatus").mockResolvedValue(
+        PROVISIONED_CUSTODIAL,
+      );
+
+      renderCard();
+
+      await waitFor(() =>
+        expect(screen.getByText("5.00 USD credit")).toBeInTheDocument(),
+      );
+    });
+  });
+
+  describe("load error", () => {
+    it("displays the error message and announces it via the live region", async () => {
+      vi.spyOn(walletApi, "getWalletStatus").mockRejectedValue(
+        new Error("Wallet request failed (500)"),
+      );
+
+      renderCard();
+
+      await waitFor(() =>
+        expect(
+          screen.getAllByText("Wallet request failed (500)").length,
+        ).toBeGreaterThan(0),
+      );
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Wallet request failed (500)",
+      );
+    });
+  });
+
+  describe("provision flow", () => {
+    it("provisions a wallet and shows the balance on success", async () => {
+      const user = userEvent.setup();
+      vi.spyOn(walletApi, "getWalletStatus").mockResolvedValue(UNPROVISIONED);
+      const provisionSpy = vi
+        .spyOn(walletApi, "provisionCustodialWallet")
+        .mockResolvedValue(PROVISIONED_CUSTODIAL);
+
+      renderCard();
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: "Get started" }),
+        ).toBeInTheDocument(),
+      );
+
+      await user.click(screen.getByRole("button", { name: "Get started" }));
+
+      expect(provisionSpy).toHaveBeenCalledTimes(1);
+      await waitFor(() =>
+        expect(screen.getByText("5.00 USD credit")).toBeInTheDocument(),
+      );
+    });
+
+    it("shows the error message when provisioning fails", async () => {
+      const user = userEvent.setup();
+      vi.spyOn(walletApi, "getWalletStatus").mockResolvedValue(UNPROVISIONED);
+      vi.spyOn(walletApi, "provisionCustodialWallet").mockRejectedValue(
+        new Error("Wallet request failed (503)"),
+      );
+
+      renderCard();
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: "Get started" }),
+        ).toBeInTheDocument(),
+      );
+      await user.click(screen.getByRole("button", { name: "Get started" }));
+
+      await waitFor(() =>
+        expect(
+          screen.getAllByText("Wallet request failed (503)").length,
+        ).toBeGreaterThan(0),
+      );
+    });
+  });
+
+  describe("link-challenge flow", () => {
+    it("requests a challenge and shows the link form on success", async () => {
+      const user = userEvent.setup();
+      vi.spyOn(walletApi, "getWalletStatus").mockResolvedValue(
+        PROVISIONED_CUSTODIAL,
+      );
+      const challengeSpy = vi
+        .spyOn(walletApi, "requestLinkChallenge")
+        .mockResolvedValue({ nonce: "test-nonce", expiresAt: "2099-01-01T00:00:00Z" });
+
+      renderCard();
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", {
+            name: "Connect a wallet you already own instead",
+          }),
+        ).toBeInTheDocument(),
+      );
+
+      await user.click(
+        screen.getByRole("button", {
+          name: "Connect a wallet you already own instead",
+        }),
+      );
+
+      expect(challengeSpy).toHaveBeenCalledTimes(1);
+      await waitFor(() =>
+        expect(screen.getByText("test-nonce")).toBeInTheDocument(),
+      );
+      expect(
+        screen.getByRole("button", { name: "Connect wallet" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("link-verify flow", () => {
+    async function openLinkForm(user: ReturnType<typeof userEvent.setup>) {
+      vi.spyOn(walletApi, "getWalletStatus").mockResolvedValue(
+        PROVISIONED_CUSTODIAL,
+      );
+      vi.spyOn(walletApi, "requestLinkChallenge").mockResolvedValue({
+        nonce: "test-nonce",
+        expiresAt: "2099-01-01T00:00:00Z",
+      });
+
+      renderCard();
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", {
+            name: "Connect a wallet you already own instead",
+          }),
+        ).toBeInTheDocument(),
+      );
+      await user.click(
+        screen.getByRole("button", {
+          name: "Connect a wallet you already own instead",
+        }),
+      );
+      await waitFor(() =>
+        expect(screen.getByText("test-nonce")).toBeInTheDocument(),
+      );
+    }
+
+    it("verifies successfully and returns to the balance view", async () => {
+      const user = userEvent.setup();
+      await openLinkForm(user);
+
+      const verifySpy = vi.spyOn(walletApi, "verifyLinkChallenge").mockResolvedValue({
+        ...PROVISIONED_CUSTODIAL,
+        custodyType: "EXTERNAL",
+        walletAddress: VALID_STELLAR_ADDRESS,
+      });
+
+      await user.type(
+        screen.getByLabelText("Wallet address"),
+        VALID_STELLAR_ADDRESS,
+      );
+      await user.type(screen.getByLabelText("Signature"), "a-valid-signature");
+      await user.click(screen.getByRole("button", { name: "Connect wallet" }));
+
+      await waitFor(() =>
+        expect(verifySpy).toHaveBeenCalledWith({
+          nonce: "test-nonce",
+          address: VALID_STELLAR_ADDRESS,
+          signature: "a-valid-signature",
+        }),
+      );
+      // The form closes and the balance view returns on success.
+      await waitFor(() =>
+        expect(
+          screen.queryByRole("button", { name: "Connect wallet" }),
+        ).not.toBeInTheDocument(),
+      );
+    });
+
+    it("shows the error message and keeps the form open when verification fails", async () => {
+      const user = userEvent.setup();
+      await openLinkForm(user);
+
+      vi.spyOn(walletApi, "verifyLinkChallenge").mockRejectedValue(
+        new Error("Signature verification failed"),
+      );
+
+      await user.type(
+        screen.getByLabelText("Wallet address"),
+        VALID_STELLAR_ADDRESS,
+      );
+      await user.type(screen.getByLabelText("Signature"), "a-valid-signature");
+      await user.click(screen.getByRole("button", { name: "Connect wallet" }));
+
+      await waitFor(() =>
+        expect(
+          screen.getAllByText("Signature verification failed").length,
+        ).toBeGreaterThan(0),
+      );
+      // The form stays open — verification failing shouldn't discard the
+      // user's in-progress link attempt.
+      expect(
+        screen.getByRole("button", { name: "Connect wallet" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/e2e/wallet.spec.ts
+++ b/frontend/e2e/wallet.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * End-to-end coverage of the one flow that currently works end to end in
+ * this app: loading and provisioning a wallet (issue FE-125).
+ *
+ * `/wallet` is a protected route (see middleware.ts) — a JWT is required,
+ * but middleware.ts only verifies its signature when `JWT_SECRET` is set,
+ * which it isn't in this test run, so any non-empty cookie value passes.
+ * The backend itself is mocked via page.route() rather than started for
+ * real, keeping this test self-contained and fast in CI.
+ */
+async function signIn(page: import("@playwright/test").Page) {
+  await page.context().addCookies([
+    {
+      name: "accessToken",
+      value: "e2e-test-token",
+      url: "http://localhost:3000",
+    },
+  ]);
+}
+
+test.describe("wallet status and provisioning", () => {
+  test("loads an unprovisioned wallet and provisions it", async ({ page }) => {
+    await signIn(page);
+
+    let provisioned = false;
+
+    await page.route("**/wallets/me", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(
+          provisioned
+            ? {
+                provisioned: true,
+                walletAddress: "GE2ETESTADDRESS",
+                custodyType: "CUSTODIAL",
+                status: "ACTIVE",
+                balance: 500,
+                currency: "USD",
+              }
+            : {
+                provisioned: false,
+                walletAddress: null,
+                custodyType: null,
+                status: null,
+                balance: 0,
+                currency: "USD",
+              },
+        ),
+      });
+    });
+
+    await page.route("**/wallets/provision", async (route) => {
+      provisioned = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          provisioned: true,
+          walletAddress: "GE2ETESTADDRESS",
+          custodyType: "CUSTODIAL",
+          status: "ACTIVE",
+          balance: 500,
+          currency: "USD",
+        }),
+      });
+    });
+
+    await page.goto("/wallet");
+
+    await expect(page.getByRole("heading", { name: "Your balance" })).toBeVisible();
+    await expect(
+      page.getByText(/don't have a payment balance set up yet/),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Get started" }).click();
+
+    await expect(page.getByText("5.00 USD credit")).toBeVisible();
+  });
+
+  test("shows an error state when the wallet status request fails", async ({ page }) => {
+    await signIn(page);
+
+    await page.route("**/wallets/me", async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ message: "Internal error" }),
+      });
+    });
+
+    await page.goto("/wallet");
+
+    await expect(page.getByText("Internal error")).toBeVisible();
+  });
+});

--- a/frontend/lib/__tests__/wallet-api.test.ts
+++ b/frontend/lib/__tests__/wallet-api.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+import * as Sentry from "@sentry/nextjs";
+import {
+  getWalletStatus,
+  provisionCustodialWallet,
+  requestLinkChallenge,
+  verifyLinkChallenge,
+} from "../wallet-api";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function textResponse(status: number, body: string): Response {
+  return new Response(body, { status });
+}
+
+describe("wallet-api", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  describe("getWalletStatus", () => {
+    it("GETs /wallets/me and returns the parsed body on success", async () => {
+      const body = {
+        provisioned: true,
+        walletAddress: "GADDR",
+        custodyType: "CUSTODIAL" as const,
+        status: "ACTIVE" as const,
+        balance: 500,
+        currency: "USD",
+      };
+      fetchMock.mockResolvedValue(jsonResponse(200, body));
+
+      const result = await getWalletStatus();
+
+      expect(result).toEqual(body);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(String(url)).toContain("/wallets/me");
+      expect(init).toMatchObject({ credentials: "same-origin" });
+      expect(init.headers).toMatchObject({ "Content-Type": "application/json" });
+    });
+  });
+
+  describe("provisionCustodialWallet", () => {
+    it("POSTs to /wallets/provision", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, {
+          provisioned: true,
+          walletAddress: "GADDR",
+          custodyType: "CUSTODIAL",
+          status: "ACTIVE",
+          balance: 0,
+          currency: "USD",
+        }),
+      );
+
+      await provisionCustodialWallet();
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(String(url)).toContain("/wallets/provision");
+      expect(init).toMatchObject({ method: "POST" });
+    });
+  });
+
+  describe("requestLinkChallenge", () => {
+    it("POSTs to /wallets/link/challenge and returns the nonce", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, { nonce: "n-1", expiresAt: "2099-01-01T00:00:00Z" }),
+      );
+
+      const result = await requestLinkChallenge();
+
+      expect(result).toEqual({ nonce: "n-1", expiresAt: "2099-01-01T00:00:00Z" });
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(String(url)).toContain("/wallets/link/challenge");
+      expect(init).toMatchObject({ method: "POST" });
+    });
+  });
+
+  describe("verifyLinkChallenge", () => {
+    it("POSTs the nonce/address/signature as the JSON body", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(200, {
+          provisioned: true,
+          walletAddress: "GADDR",
+          custodyType: "EXTERNAL",
+          status: "ACTIVE",
+          balance: 0,
+          currency: "USD",
+        }),
+      );
+
+      await verifyLinkChallenge({
+        nonce: "n-1",
+        address: "GADDR",
+        signature: "sig",
+      });
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(String(url)).toContain("/wallets/link/verify");
+      expect(init).toMatchObject({ method: "POST" });
+      expect(JSON.parse(init.body as string)).toEqual({
+        nonce: "n-1",
+        address: "GADDR",
+        signature: "sig",
+      });
+    });
+  });
+
+  describe("error path (walletFetch's non-ok branch)", () => {
+    it("throws with the server's error message from a JSON error body", async () => {
+      fetchMock.mockResolvedValue(
+        jsonResponse(404, { message: "Wallet not found" }),
+      );
+
+      await expect(getWalletStatus()).rejects.toThrow("Wallet not found");
+    });
+
+    it("falls back to a generic message when the error body is not JSON", async () => {
+      fetchMock.mockResolvedValue(textResponse(500, "<html>Internal Server Error</html>"));
+
+      await expect(getWalletStatus()).rejects.toThrow("Wallet request failed (500)");
+    });
+
+    it("falls back to a generic message when the JSON error body has no message field", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(503, { code: "UNAVAILABLE" }));
+
+      await expect(getWalletStatus()).rejects.toThrow("Wallet request failed (503)");
+    });
+
+    it("reports the failure to Sentry with the endpoint and status code tagged", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(404, { message: "Wallet not found" }));
+
+      await expect(getWalletStatus()).rejects.toThrow();
+
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+      const [error, context] = vi.mocked(Sentry.captureException).mock.calls[0];
+      expect((error as Error).message).toBe("Wallet not found");
+      expect(context).toMatchObject({
+        tags: { api: "wallet", endpoint: "/wallets/me", statusCode: 404 },
+      });
+    });
+
+    it("does not resolve — the non-ok response never reaches the caller as data", async () => {
+      fetchMock.mockResolvedValue(jsonResponse(400, { message: "Bad request" }));
+
+      await expect(getWalletStatus()).rejects.toBeInstanceOf(Error);
+    });
+  });
+});

--- a/frontend/lib/wallet-api.ts
+++ b/frontend/lib/wallet-api.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/nextjs";
+
 export type WalletCustodyType = "CUSTODIAL" | "EXTERNAL";
 export type WalletStatus = "PENDING" | "ACTIVE" | "DISABLED";
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -9,4 +9,17 @@ import { defineConfig } from "@playwright/test";
 // ./e2e keeps the two runners out of each other's way.
 export default defineConfig({
   testDir: "./e2e",
+  use: {
+    baseURL: "http://localhost:3000",
+  },
+  // Starts the app itself so `npx playwright test` (and the CI e2e job) work
+  // standalone, without a separately-started dev server. `reuseExistingServer`
+  // lets a developer keep running `npm run dev` locally instead of paying for
+  // a second server start on every local test run.
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
 });


### PR DESCRIPTION
## Summary

Four test-coverage fixes across the frontend and the escrow contract:

**#1705 — `wallet-api.ts` tests**
Added tests for every exported function's success path and `walletFetch`'s
non-ok error path (JSON error body with/without a `message` field, and a
non-JSON body). Writing the error-path test surfaced a real bug blocking
it entirely: `walletFetch`'s non-ok branch calls
`Sentry.captureException(...)`, but `Sentry` was never imported in this
file — every failed wallet request would throw a `ReferenceError` instead
of the intended error, in production as much as in a test. Fixed with the
same `import * as Sentry from "@sentry/nextjs"` already used elsewhere in
this app (`app/wallet/error.tsx`).

**#1704 — `WalletStatusCard` state coverage**
Only an accessibility test existed. Added coverage of: initial load, load
error, provision flow (success and failure), link-challenge flow, and
link-verify (success and failure). Both this new suite and the
pre-existing a11y test needed a `QueryClientProvider` wrapper —
`WalletStatusCard` calls `useQuery`/`useMutation`, which throw without one,
and the a11y test's bare `render()` call had neither a provider nor a
correct prop (it was passing `accessToken`, which the component doesn't
accept — auth comes from `useSessionStore`). Fixed both alongside adding
the real coverage.

**#1706 — Playwright e2e**
CI already runs a "Frontend E2E" job and `playwright.config.ts` already
pointed `testDir` at `./e2e`, but that directory never existed — the job
was green purely because `test:e2e` uses `--pass-with-no-tests`, silently
running zero tests on every PR. Added `e2e/wallet.spec.ts` covering wallet
load + provisioning (mocked backend via `page.route()`, a fake
`accessToken` cookie past the auth middleware) plus a load-error case, and
a `webServer` block in `playwright.config.ts` so the Next dev server
starts itself for both local runs and CI.

**#1707 — escrow contract happy-path tests**
Chains `create -> get_status=Locked -> release -> get_status=Released`,
and the equivalent refund path, using `soroban-sdk`'s testutils.

## Tests / verification

- `wallet-api.test.ts`, `wallet-status-card.test.tsx`, `wallet-status-card.a11y.test.tsx`, `e2e/wallet.spec.ts` — all new/fixed, verified by careful manual review against this repo's existing test conventions. **Could not run `vitest`/`playwright` locally** — this sandbox's npm registry connectivity was severely degraded across this whole PR set (a dozen-plus install attempts, every kind of failure from `ECONNRESET` to Windows file-lock races to genuine multi-minute stalls).
- `payment_escrow`'s new tests: **partially verified.** `cargo test -p payment_escrow` initially failed to compile `soroban-sdk`'s own `testutils.rs` at all ("cannot find crate `serde_json`/`rand`") — traced this to `contracts/.cargo/config.toml` pinning `[build] target = "wasm32-unknown-unknown"` as the default for *every* cargo invocation including `test`, and `rand`'s OS-entropy code isn't available on bare wasm32. Running `cargo test --target x86_64-pc-windows-msvc` gets past that and compiles most of the dependency graph, but then hits a genuine version conflict inside `soroban-env-host 21.2.1` itself (`ChaCha20Rng` doesn't satisfy the `CryptoRng` bound `ed25519-dalek` expects — two different major versions of `ed25519-dalek` coexist in this workspace's `Cargo.lock`). That's an upstream dependency-graph issue unrelated to this file's code, and out of scope to fix here — re-resolving/pinning versions workspace-wide isn't something four test-coverage issues should carry. I'm confident in the tests from manual review against `soroban-sdk` 21.x's documented testutils API, but flagging this for CI/reviewer attention since I couldn't get a passing local run.

## Closes

Closes #1704
Closes #1705
Closes #1706
Closes #1707
